### PR TITLE
fix: resolve CI lint failures (missing tsconfig ref + 3 strict-lint violations)

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
   "references": [
     { "path": "../core" },
     { "path": "../github" },
+    { "path": "../llm" },
     { "path": "../secrets-dotenv" },
     { "path": "../signals" }
   ]

--- a/packages/core/src/directives/index.ts
+++ b/packages/core/src/directives/index.ts
@@ -117,8 +117,7 @@ export class DirectiveStore {
       if (d.status !== "pending") return false;
       if (d.scope.kind === "all") return true;
       if (d.scope.kind === "agent") return d.scope.agentId === agentId;
-      if (d.scope.kind === "circle") return circleIds.includes(d.scope.circleId);
-      return false;
+      return circleIds.includes(d.scope.circleId);
     });
   }
 

--- a/packages/dashboard-tui/src/dashboard.ts
+++ b/packages/dashboard-tui/src/dashboard.ts
@@ -103,12 +103,17 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
     const agentCost = costMap.get(a.agentId);
     const totalCost = agentCost ? formatUsd(agentCost.totalMicros) : dim("$0.0000");
     const wakes = agentCost ? String(agentCost.wakes) : "0";
-    const barLen = agentCost ? Math.max(0, Math.round((agentCost.totalMicros / maxCost) * BAR_WIDTH)) : 0;
-    const bar = barLen > 0
-      ? cyan("█".repeat(barLen)) + dim("░".repeat(BAR_WIDTH - barLen))
-      : dim("░".repeat(BAR_WIDTH));
+    const barLen = agentCost
+      ? Math.max(0, Math.round((agentCost.totalMicros / maxCost) * BAR_WIDTH))
+      : 0;
+    const bar =
+      barLen > 0
+        ? cyan("█".repeat(barLen)) + dim("░".repeat(BAR_WIDTH - barLen))
+        : dim("░".repeat(BAR_WIDTH));
 
-    lines.push(`  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w`);
+    lines.push(
+      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w`,
+    );
   }
 
   // Collapse inactive agents into a summary
@@ -117,7 +122,7 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
       .filter((a) => a.nextWakeCountdown !== "--")
       .map((a) => a.nextWakeCountdown)
       .sort();
-    const soonest = nextWakes.length > 0 ? `  soonest: ${nextWakes[0]}` : "";
+    const soonest = nextWakes.length > 0 ? `  soonest: ${nextWakes[0] ?? ""}` : "";
     lines.push(`  ${dim(`[--]  ${String(inactive.length)} agents awaiting first wake${soonest}`)}`);
   }
 
@@ -287,5 +292,7 @@ export const startDashboard = async (rootDir: string): Promise<void> => {
 
   tui.start();
 
-  await new Promise<void>(() => {});
+  await new Promise<void>((_resolve) => {
+    /* keep process alive */
+  });
 };


### PR DESCRIPTION
## Summary

Resolves 62 ESLint errors that were blocking CI on `main`. See #28 for the full post-mortem.

- **Add `../llm` project reference to `packages/cli/tsconfig.json`** — the missing reference caused TypeScript to fail resolving `@murmuration/llm` types, which in turn caused 55+ cascading `no-unsafe-*` errors in `boot.ts` and `circle-wake.ts`
- **Remove unnecessary conditional in `packages/core/src/directives/index.ts`** — the exhaustive discriminated union made the final `if (d.scope.kind === "circle")` always true
- **Guard template literal in `packages/dashboard-tui/src/dashboard.ts`** — `nextWakes[0]` is `string | undefined` under `noUncheckedIndexedAccess`
- **Name the no-op executor in `dashboard.ts`** — fixes `no-empty-function` on the keep-alive promise

## Test plan

- [x] `pnpm lint` → 0 errors (11 pre-existing `no-non-null-assertion` warnings remain)
- [x] `pnpm typecheck` → passes after build artifacts exist
- [x] `pnpm build` → all packages build
- [ ] CI green on this PR

Closes #28

https://claude.ai/code/session_01C3WPBwgrkEfDaCHndkY5Vp