### PR TITLE
chore: pre-commit hook auto-formats staged files (closes Prettier drift foot-gun)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+#
+# Pre-commit hook — auto-format staged files with Prettier.
+#
+# Why this exists
+# ---------------
+# CI's `format:check` step has failed multiple times on commits that landed
+# without a Prettier pass. See docs/LINT-DESIGN-GUIDE.md §14. This hook
+# removes the foot-gun: any staged file Prettier handles is auto-formatted
+# in place and re-staged before the commit completes. The commit message,
+# author, and content are otherwise untouched.
+#
+# Bypass (don't, unless you really mean it):
+#   git commit --no-verify
+#
+# Manual install (the prepare script in package.json does this automatically
+# on `pnpm install`):
+#   git config core.hooksPath .githooks
+#
+
+set -e
+
+# Collect staged files matching Prettier-handled extensions.
+# Filter mode ACMR: Added, Copied, Modified, Renamed (skip Deleted).
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml)$' || true)
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+# Resolve a working `prettier` binary. Prefer the locally-installed one
+# via `pnpm exec` so the version matches the workspace.
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pre-commit: pnpm not found in PATH; skipping format pass" >&2
+  exit 0
+fi
+
+# Format the staged files in place. `--ignore-unknown` drops anything
+# Prettier doesn't recognize. `--log-level warn` keeps the output quiet
+# unless something interesting happens.
+echo "$STAGED_FILES" | xargs pnpm exec prettier --write --ignore-unknown --log-level warn
+
+# Re-stage the (possibly reformatted) files so the commit picks them up.
+echo "$STAGED_FILES" | xargs git add
+
+exit 0

--- a/docs/LINT-DESIGN-GUIDE.md
+++ b/docs/LINT-DESIGN-GUIDE.md
@@ -401,11 +401,25 @@ Our config sets `no-non-null-assertion` to `warn` (not `error`). That means `foo
 
 ---
 
-## 14. Prettier drift
+## 14. Prettier drift — and the pre-commit hook that prevents it
 
-Every time a batch of Phase 2 commits lands, `format:check` accumulates drift. **Always run `pnpm run format` before committing any batch of changes**, even if you think you didn't touch the files Prettier wants to reformat — Prettier often has opinions about files that were edited by other commits.
+Every time a batch of commits lands, `format:check` accumulates drift. **Always run `pnpm run format` before committing any batch of changes**, even if you think you didn't touch the files Prettier wants to reformat — Prettier often has opinions about files that were edited by other commits.
 
 If you see 10+ files in `format:check` failures, run `pnpm run format` and commit the result as a separate "format pass" commit or combined into the current fix.
+
+### Pre-commit hook (active by default)
+
+The repo ships a Git pre-commit hook at `.githooks/pre-commit` that auto-formats any staged file Prettier handles, then re-stages it before the commit completes. The hook is wired in via `package.json`'s `prepare` script, which runs `git config core.hooksPath .githooks` automatically on `pnpm install`. So:
+
+- Fresh clone → `pnpm install` → hook is active. No manual setup.
+- Each `git commit` → hook formats staged `.ts/.js/.json/.md/.yml` files in place, re-stages them, and lets the commit proceed.
+- If `pnpm` isn't on `PATH`, the hook prints a warning and skips the format pass instead of failing the commit.
+
+**Bypass (don't, unless you really mean it):** `git commit --no-verify`.
+
+The hook does **not** run `lint`, `typecheck`, or `test` — those would slow commits to a crawl. The deal is: the hook handles the cheapest, most-foot-gunny check (Prettier drift), and CI handles the rest. Run `pnpm run check` locally before pushing if you want the full suite.
+
+If you're an agent committing programmatically, the hook works the same way. You don't need to do anything special — your commit will just include any auto-formatted versions of your staged files.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint:fix": "eslint packages --fix",
     "format": "prettier --write \"packages/**/*.{ts,js,json,md}\" \"docs/**/*.md\" \"*.{json,md}\"",
     "format:check": "prettier --check \"packages/**/*.{ts,js,json,md}\" \"docs/**/*.md\" \"*.{json,md}\"",
-    "check": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm test"
+    "check": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm test",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Closes the Prettier-drift foot-gun that has caused multiple CI failures (most recently murmurations-ai/murmurations-harness#74). Adds a dependency-free pre-commit hook that auto-formats staged files before the commit completes, plus a `prepare` script that wires it up automatically on `pnpm install`.

## How it works

- **`.githooks/pre-commit`** — gathers staged files matching Prettier-handled extensions (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.json/.md/.yml/.yaml`), runs `pnpm exec prettier --write --ignore-unknown` on them, re-stages, and exits 0. Skips gracefully if `pnpm` isn't on PATH (so it never breaks exotic environments). Bypassable with `git commit --no-verify` if you really need it.
- **`package.json` `prepare` script** — runs `git config core.hooksPath .githooks` automatically on `pnpm install`. Fresh clones get the hook for free; no manual setup required. The `|| true` swallows errors in non-git environments (e.g. tarball installs).
- **`docs/LINT-DESIGN-GUIDE.md` §14** — documents the hook and explains the contract: hook handles Prettier (cheap), CI handles lint/typecheck/test (slow). Run `pnpm run check` locally before pushing if you want the full suite.

## Why a hook instead of husky/lint-staged

- **Zero new dependencies.** No `husky`, no `lint-staged`, no maintenance burden.
- **Works for agents.** Claude Code and other automation committing programmatically get the same protection without any per-tool setup.
- **Single file**, ~50 lines of POSIX shell, easy to audit.
- The `prepare`-script trick auto-installs without husky's hidden git config magic.

## Trade-offs

- The hook only handles **Prettier formatting**, not lint/typecheck/test. Those steps are too slow for every commit. The deal: hook covers the most foot-gunny check; CI covers the rest.
- Hook runs `prettier --write` not `--check`, so it modifies staged files in place. If you're not expecting that, your commit will still succeed — just with the formatted content.
- Bypassable with `--no-verify`. By design — emergency commits shouldn't be blocked.

## Tested

Staged an intentionally-misformatted Markdown fixture (`test-hook-fixture.md` with mangled whitespace and a misaligned table). Committed it. Verified that:

1. ✅ Prettier rewrote it in place (whitespace collapsed, table aligned)
2. ✅ The commit picked up the formatted version (`git show HEAD` matched Prettier output)
3. ✅ `prettier --check` passed afterward on the committed file
4. ✅ The `prepare` script self-installed the hook path on a fresh `pnpm install` (verified by unsetting `core.hooksPath` and running install)

Test fixture reverted via `git reset --hard HEAD~1` before the real commit.

## Test plan

- [x] `pnpm format:check` → clean
- [x] `pnpm lint` → 0 errors (14 pre-existing warnings)
- [x] `pnpm typecheck` → all 7 packages pass
- [x] Hook auto-formats a staged unformatted file end-to-end

https://claude.ai/code/session_01C3WPBwgrkEfDaCHndkY5Vp