### PR TITLE
refactor: RegisteredAgent holds IdentityChain instead of flat strings (#53)

### DIFF
--- a/packages/cli/src/command-executor.test.ts
+++ b/packages/cli/src/command-executor.test.ts
@@ -6,6 +6,8 @@ import { randomUUID } from "node:crypto";
 import {
   AgentStateStore,
   DaemonEventBus,
+  makeAgentId,
+  makeGroupId,
   type DaemonEvent,
   type RegisteredAgent,
 } from "@murmurations-ai/core";
@@ -44,28 +46,39 @@ const makeTmpRoot = (): string => {
   return dir;
 };
 
-const makeRegisteredAgent = (id: string, groups: string[] = []): RegisteredAgent => ({
-  agentId: id,
-  displayName: id,
-  trigger: { kind: "delay-once", delayMs: 100 },
-  groupMemberships: groups,
-  modelTier: "fast" as const,
-  maxWallClockMs: 5000,
-  identityContent: {
-    murmurationSoul: "test",
-    agentSoul: "test",
-    agentRole: "test",
-    groupContexts: [],
-  },
-  githubWriteScopes: { issueComments: [], branchCommits: [], labels: [], issues: [] },
-  signalScopes: {
-    sources: ["github-issue"],
-    githubScopes: [{ owner: "test", repo: "repo", filter: { state: "open" as const } }],
-  },
-  budget: { maxCostMicros: 100000, maxGithubApiCalls: 10, onBreach: "warn" as const },
-  secrets: { required: [], optional: [] },
-  tools: { mcp: [], cli: [] },
-});
+const makeRegisteredAgent = (id: string, groups: string[] = []): RegisteredAgent => {
+  const agentId = makeAgentId(id);
+  return {
+    agentId: id,
+    displayName: id,
+    trigger: { kind: "delay-once", delayMs: 100 },
+    groupMemberships: groups,
+    modelTier: "fast" as const,
+    maxWallClockMs: 5000,
+    identity: {
+      agentId,
+      frontmatter: {
+        agentId,
+        name: id,
+        modelTier: "fast",
+        groupMemberships: groups.map((g) => makeGroupId(g)),
+      },
+      layers: [
+        { kind: "murmuration-soul", content: "test", sourcePath: "<test>" },
+        { kind: "agent-soul", agentId, content: "test", sourcePath: "<test>" },
+        { kind: "agent-role", agentId, content: "test", sourcePath: "<test>" },
+      ],
+    },
+    githubWriteScopes: { issueComments: [], branchCommits: [], labels: [], issues: [] },
+    signalScopes: {
+      sources: ["github-issue"],
+      githubScopes: [{ owner: "test", repo: "repo", filter: { state: "open" as const } }],
+    },
+    budget: { maxCostMicros: 100000, maxGithubApiCalls: 10, onBreach: "warn" as const },
+    secrets: { required: [], optional: [] },
+    tools: { mcp: [], cli: [] },
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/core/src/daemon/daemon.test.ts
+++ b/packages/core/src/daemon/daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { makeAgentId, makeGroupId } from "../execution/index.js";
 import { SubprocessExecutor } from "../execution/subprocess.js";
 import { makeSecretKey, makeSecretValue } from "../secrets/index.js";
 import type {
@@ -36,6 +37,9 @@ const makeCapturingLogger = (): { logger: DaemonLogger; logs: CapturedLog[] } =>
   return { logger, logs };
 };
 
+const helloWorldId = makeAgentId("hello-world");
+const engineeringGroupId = makeGroupId("engineering");
+
 const helloWorld: RegisteredAgent = {
   agentId: "hello-world",
   displayName: "Hello World Agent",
@@ -43,14 +47,33 @@ const helloWorld: RegisteredAgent = {
   groupMemberships: ["engineering"],
   modelTier: "fast",
   maxWallClockMs: 5000,
-  identityContent: {
-    murmurationSoul: "test soul",
-    agentSoul: "test agent soul",
-    agentRole: "test role",
-    groupContexts: [
+  identity: {
+    agentId: helloWorldId,
+    frontmatter: {
+      agentId: helloWorldId,
+      name: "Hello World Agent",
+      modelTier: "fast",
+      groupMemberships: [engineeringGroupId],
+    },
+    layers: [
+      { kind: "murmuration-soul", content: "test soul", sourcePath: "<test>" },
       {
-        groupId: "engineering",
+        kind: "agent-soul",
+        agentId: helloWorldId,
+        content: "test agent soul",
+        sourcePath: "<test>",
+      },
+      {
+        kind: "agent-role",
+        agentId: helloWorldId,
+        content: "test role",
+        sourcePath: "<test>",
+      },
+      {
+        kind: "group-context",
+        groupId: engineeringGroupId,
         content: "engineering ctx",
+        sourcePath: "<test>",
       },
     ],
   },

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -66,14 +66,11 @@ const CIRCUIT_BREAKER_THRESHOLD = 3;
  * everything the daemon needs to build an {@link AgentSpawnContext}
  * for this agent without re-reading the repo on every wake.
  *
- * Two construction paths:
- *
- * 1. Manual construction — used by the hello-world Phase 1A path
- *    where content is inline placeholder strings (see
- *    `packages/cli/src/boot.ts`).
- * 2. {@link registeredAgentFromLoadedIdentity} — construct from an
- *    `IdentityLoader.load()` result plus a wake trigger. Use this in
- *    Phase 1B+ production paths where identity is read from disk.
+ * In production, instances are built by
+ * {@link registeredAgentFromLoadedIdentity} from an
+ * `IdentityLoader.load()` result plus a wake trigger (see
+ * `packages/cli/src/boot.ts`). Tests construct instances directly with
+ * an inline `IdentityChain`.
  */
 export interface RegisteredAgent {
   readonly agentId: string;
@@ -1110,12 +1107,7 @@ const buildSpawnContext = async (
       wakeId: event.wakeId,
       agentId,
       agentDir: agent.agentId,
-      frontmatter: {
-        agentId,
-        name: agent.displayName,
-        modelTier: agent.modelTier,
-        groupMemberships: groupIds,
-      },
+      frontmatter: identity.frontmatter,
       groupMemberships: groupIds,
       wakeReason: event.wakeReason,
       now: new Date(),

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -82,19 +82,12 @@ export interface RegisteredAgent {
   readonly groupMemberships: readonly string[];
   readonly modelTier: "fast" | "balanced" | "deep";
   /**
-   * The identity content layers to thread through to the executor.
-   * Populated either inline (Phase 1A) or by
-   * {@link registeredAgentFromLoadedIdentity} (Phase 1B+).
+   * The full ordered identity chain handed to the executor on spawn.
+   * Built once by {@link registeredAgentFromLoadedIdentity} (or provided
+   * directly by tests) and passed through verbatim — subsystems read typed
+   * layers (`sourcePath`, `kind`, `groupId`) without re-parsing flat strings.
    */
-  readonly identityContent: {
-    readonly murmurationSoul: string;
-    readonly agentSoul: string;
-    readonly agentRole: string;
-    readonly groupContexts: readonly {
-      readonly groupId: string;
-      readonly content: string;
-    }[];
-  };
+  readonly identity: IdentityChain;
   /**
    * Maximum wall-clock budget per wake (ms). Phase 1A default is 15s;
    * Phase 1B reads from frontmatter.
@@ -206,16 +199,6 @@ export const registeredAgentFromLoadedIdentity = (
   options: { readonly rolePath?: string } = {},
 ): RegisteredAgent => {
   const { chain, frontmatter } = loaded;
-  const groupContexts = chain.layers
-    .filter(
-      (l): l is Extract<(typeof chain.layers)[number], { kind: "group-context" }> =>
-        l.kind === "group-context",
-    )
-    .map((l) => ({ groupId: l.groupId.value, content: l.content }));
-
-  const murmurationSoul = chain.layers.find((l) => l.kind === "murmuration-soul")?.content ?? "";
-  const agentSoul = chain.layers.find((l) => l.kind === "agent-soul")?.content ?? "";
-  const agentRole = chain.layers.find((l) => l.kind === "agent-role")?.content ?? "";
 
   // ADR-0016: map snake_case YAML fields to camelCase runtime fields.
   const llm = frontmatter.llm
@@ -284,12 +267,7 @@ export const registeredAgentFromLoadedIdentity = (
     trigger,
     groupMemberships: frontmatter.group_memberships,
     modelTier: frontmatter.model_tier,
-    identityContent: {
-      murmurationSoul,
-      agentSoul,
-      agentRole,
-      groupContexts,
-    },
+    identity: chain,
     maxWallClockMs: frontmatter.max_wall_clock_ms,
     ...(llm !== undefined ? { llm } : {}),
     signalScopes,
@@ -1124,40 +1102,7 @@ const buildSpawnContext = async (
     maxCostMicros: 0,
   };
 
-  const identity: IdentityChain = {
-    agentId,
-    frontmatter: {
-      agentId,
-      name: agent.displayName,
-      modelTier: agent.modelTier,
-      groupMemberships: groupIds,
-    },
-    layers: [
-      {
-        kind: "murmuration-soul",
-        content: agent.identityContent.murmurationSoul,
-        sourcePath: "<phase-1a-placeholder>",
-      },
-      {
-        kind: "agent-soul",
-        agentId,
-        content: agent.identityContent.agentSoul,
-        sourcePath: "<phase-1a-placeholder>",
-      },
-      {
-        kind: "agent-role",
-        agentId,
-        content: agent.identityContent.agentRole,
-        sourcePath: "<phase-1a-placeholder>",
-      },
-      ...agent.identityContent.groupContexts.map((ctx) => ({
-        kind: "group-context" as const,
-        groupId: makeGroupId(ctx.groupId),
-        content: ctx.content,
-        sourcePath: "<phase-1a-placeholder>",
-      })),
-    ],
-  };
+  const identity = agent.identity;
 
   let signals: SignalBundle;
   if (aggregator) {


### PR DESCRIPTION
## Summary

- Closes #53. `RegisteredAgent` now holds the structured `IdentityChain` directly instead of a flat `{ murmurationSoul, agentSoul, agentRole, groupContexts }` string bundle.
- Removes the double roundtrip: `registeredAgentFromLoadedIdentity` no longer flattens, and the daemon spawn path no longer re-inflates with fabricated `"<phase-1a-placeholder>"` source paths.
- Unblocks Phase 4 dashboard (typed identity available for display) and Phase 5 multi-instance (partial agent loading no longer awkward).

**Net -19 lines.** Test fixtures updated in `daemon.test.ts` and `command-executor.test.ts` to build a proper `IdentityChain`.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 486 passed, 1 skipped
- [x] `pnpm run format:check` — clean
- [x] `pnpm run lint` — no new warnings (22 pre-existing non-null-assertion warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)