### PR TITLE
refactor: isolate governance plugin from mutable state store (#43)

### DIFF
--- a/examples/governance-command/index.mjs
+++ b/examples/governance-command/index.mjs
@@ -75,20 +75,22 @@ const ChainOfCommandPlugin = {
     return [DIRECTIVE_GRAPH, REPORT_GRAPH];
   },
 
-  async onEventsEmitted(batch, store) {
+  async onEventsEmitted(batch, _reader) {
     const decisions = [];
     for (const event of batch.events) {
       switch (event.kind) {
         case CC_DIRECTIVE:
         case CC_REPORT:
         case "agent-governance-event": {
-          store.create(
-            event.kind === CC_DIRECTIVE ? "directive" : "report",
-            batch.agentId,
-            event.payload,
-          );
           // Everything goes to Source (the authority)
-          decisions.push({ event, routes: [{ target: "source" }] });
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+            create: {
+              kind: event.kind === CC_DIRECTIVE ? "directive" : "report",
+              payload: event.payload,
+            },
+          });
           break;
         }
         case CC_ESCALATION: {
@@ -102,7 +104,7 @@ const ChainOfCommandPlugin = {
     return decisions;
   },
 
-  async evaluateAction(agentId, action, context, store) {
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
     const ctx = typeof context === "object" && context !== null ? context : {};
     const tier = /** @type {string|undefined} */ (/** @type {any} */ (ctx).tier);
 

--- a/examples/governance-consensus/index.mjs
+++ b/examples/governance-consensus/index.mjs
@@ -89,24 +89,30 @@ const ConsensusPlugin = {
     return [PROPOSAL_GRAPH, CONCERN_GRAPH];
   },
 
-  async onEventsEmitted(batch, store) {
+  async onEventsEmitted(batch, _reader) {
     const decisions = [];
     for (const event of batch.events) {
       switch (event.kind) {
         case CONS_PROPOSAL:
         case "agent-governance-event": {
-          store.create("proposal", batch.agentId, event.payload);
           // Proposals go to the full assembly
           const routes = [{ target: "source" }];
           if (event.targetAgentId) {
             routes.push({ target: "agent", agentId: event.targetAgentId });
           }
-          decisions.push({ event, routes });
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "proposal", payload: event.payload },
+          });
           break;
         }
         case CONS_CONCERN: {
-          store.create("concern", batch.agentId, event.payload);
-          decisions.push({ event, routes: [{ target: "source" }] });
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+            create: { kind: "concern", payload: event.payload },
+          });
           break;
         }
         case CONS_BLOCK: {
@@ -126,7 +132,7 @@ const ConsensusPlugin = {
     return decisions;
   },
 
-  async evaluateAction(agentId, action, context, store) {
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
     const ctx = typeof context === "object" && context !== null ? context : {};
     const tier = /** @type {string|undefined} */ (/** @type {any} */ (ctx).tier);
 

--- a/examples/governance-meritocratic/index.mjs
+++ b/examples/governance-meritocratic/index.mjs
@@ -74,24 +74,30 @@ const MeritocraticPlugin = {
     return [FLAG_GRAPH, STANDARD_GRAPH];
   },
 
-  async onEventsEmitted(batch, store) {
+  async onEventsEmitted(batch, _reader) {
     const decisions = [];
     for (const event of batch.events) {
       switch (event.kind) {
         case MERIT_FLAG:
         case "agent-governance-event": {
-          store.create("flag", batch.agentId, event.payload);
           // Flags route to the guild lead + Source
           const routes = [{ target: "source" }];
           if (event.targetAgentId) {
             routes.push({ target: "agent", agentId: event.targetAgentId });
           }
-          decisions.push({ event, routes });
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "flag", payload: event.payload },
+          });
           break;
         }
         case MERIT_STANDARD: {
-          store.create("standard", batch.agentId, event.payload);
-          decisions.push({ event, routes: [{ target: "source" }] });
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+            create: { kind: "standard", payload: event.payload },
+          });
           break;
         }
         case MERIT_ENDORSEMENT: {
@@ -110,7 +116,7 @@ const MeritocraticPlugin = {
     return decisions;
   },
 
-  async evaluateAction(agentId, action, context, store) {
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
     const ctx = typeof context === "object" && context !== null ? context : {};
     const tier = /** @type {string|undefined} */ (/** @type {any} */ (ctx).tier);
 

--- a/examples/governance-parliamentary/index.mjs
+++ b/examples/governance-parliamentary/index.mjs
@@ -101,32 +101,33 @@ const ParliamentaryGovernancePlugin = {
     return [MOTION_GRAPH, AMENDMENT_GRAPH];
   },
 
-  async onEventsEmitted(batch, store) {
+  async onEventsEmitted(batch, _reader) {
     const decisions = [];
 
     for (const event of batch.events) {
       switch (event.kind) {
         case PARL_MOTION:
         case "agent-governance-event": {
-          // Create a tracked motion in the store
-          const item = store.create("motion", batch.agentId, event.payload);
-
           // Motions go to the chair (Source) for scheduling
           /** @type {import('@murmurations-ai/core').GovernanceRouteTarget[]} */
           const routes = [{ target: "source" }];
           if (event.targetAgentId) {
             routes.push({ target: "agent", agentId: event.targetAgentId });
           }
-          decisions.push({ event, routes });
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "motion", payload: event.payload },
+          });
           break;
         }
 
         case PARL_AMENDMENT: {
           // Amendments attach to a motion
-          store.create("amendment", batch.agentId, event.payload);
           decisions.push({
             event,
             routes: [{ target: "source" }],
+            create: { kind: "amendment", payload: event.payload },
           });
           break;
         }
@@ -158,7 +159,7 @@ const ParliamentaryGovernancePlugin = {
     return decisions;
   },
 
-  async evaluateAction(agentId, action, context, store) {
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
     // Parliamentary authorization:
     //   - Actions covered by a passed motion → allow
     //   - Actions requiring a vote → deny until motion passes

--- a/examples/governance-s3/index.mjs
+++ b/examples/governance-s3/index.mjs
@@ -116,34 +116,33 @@ const S3GovernancePlugin = {
     return [TENSION_GRAPH, PROPOSAL_GRAPH];
   },
 
-  async onEventsEmitted(batch, store) {
+  async onEventsEmitted(batch, _reader) {
     const decisions = [];
 
     for (const event of batch.events) {
       switch (event.kind) {
         case "agent-governance-event":
         case S3_TENSION: {
-          // Create a tracked tension item in the store.
-          const item = store.create("tension", batch.agentId, event.payload);
-
           // Route to Source for visibility + to any targeted agent.
           /** @type {import('@murmurations-ai/core').GovernanceRouteTarget[]} */
           const routes = [{ target: "source" }];
           if (event.targetAgentId) {
             routes.push({ target: "agent", agentId: event.targetAgentId });
           }
-          decisions.push({ event, routes });
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "tension", payload: event.payload },
+          });
           break;
         }
 
         case S3_PROPOSAL: {
-          // Create a tracked proposal item.
-          store.create("proposal", batch.agentId, event.payload);
-
           // Proposals route to Source for consent round initiation.
           decisions.push({
             event,
             routes: [{ target: "source" }],
+            create: { kind: "proposal", payload: event.payload },
           });
           break;
         }
@@ -193,7 +192,7 @@ const S3GovernancePlugin = {
     return decisions;
   },
 
-  async evaluateAction(agentId, action, context, store) {
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
     // S3 authorization: check whether a ratified governance item
     // covers the requested action.
     //

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -802,6 +802,28 @@ export class Daemon {
             this.#governanceStore,
           );
           for (const decision of decisions) {
+            if (decision.create) {
+              // Plugin requested an item creation. The daemon applies
+              // it so plugins never touch the write surface — `createdBy`
+              // is derived from the triggering batch, not the plugin.
+              try {
+                this.#governanceStore.create(
+                  decision.create.kind,
+                  result.agentId,
+                  decision.create.payload,
+                  decision.create.reviewAt !== undefined
+                    ? { reviewAt: decision.create.reviewAt }
+                    : {},
+                );
+              } catch (err) {
+                this.#logger.warn("daemon.governance.create.failed", {
+                  wakeId: result.wakeId.value,
+                  agentId: result.agentId.value,
+                  kind: decision.create.kind,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+            }
             for (const route of decision.routes) {
               this.#dispatchGovernanceRoute(result, decision.event, route);
             }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -51,6 +51,7 @@ import type { SignalAggregator } from "../signals/index.js";
 import {
   GovernanceStateStore,
   NoOpGovernancePlugin,
+  makeGovernanceStateReader,
   type GovernancePlugin,
 } from "../governance/index.js";
 
@@ -799,7 +800,7 @@ export class Daemon {
               agentId: result.agentId,
               events: result.governanceEvents,
             },
-            this.#governanceStore,
+            makeGovernanceStateReader(this.#governanceStore),
           );
           for (const decision of decisions) {
             if (decision.create) {

--- a/packages/core/src/governance/governance.test.ts
+++ b/packages/core/src/governance/governance.test.ts
@@ -8,6 +8,7 @@ import { makeAgentId } from "../execution/index.js";
 import {
   GovernanceStateStore,
   NoOpGovernancePlugin,
+  makeGovernanceStateReader,
   type GovernancePlugin,
   type GovernanceStateGraph,
   type GovernanceItem,
@@ -337,6 +338,25 @@ describe("GovernancePlugin + Daemon dispatch contract", () => {
       }
     }
     expect(store.query({ kind: "tension" })).toHaveLength(1);
+  });
+
+  it("makeGovernanceStateReader withholds write methods at runtime", () => {
+    const store = new GovernanceStateStore();
+    store.registerGraph(S3_TENSION);
+    const reader = makeGovernanceStateReader(store);
+
+    // Read methods are present and functional.
+    expect(typeof reader.graphs).toBe("function");
+    expect(typeof reader.query).toBe("function");
+    expect(reader.size()).toBe(0);
+
+    // Write methods are absent — a .mjs plugin casting back cannot
+    // mutate the store through this handle.
+    const proxy = reader as unknown as Record<string, unknown>;
+    expect(proxy["create"]).toBeUndefined();
+    expect(proxy["transition"]).toBeUndefined();
+    expect(proxy["setGithubIssueUrl"]).toBeUndefined();
+    expect(proxy["registerGraph"]).toBeUndefined();
   });
 });
 

--- a/packages/core/src/governance/governance.test.ts
+++ b/packages/core/src/governance/governance.test.ts
@@ -305,31 +305,37 @@ describe("GovernancePlugin + Daemon dispatch contract", () => {
     expect(result.allow).toBe(true);
   });
 
-  it("GovernancePlugin onEventsEmitted receives batch and can create items", async () => {
-    // Simulates what a real plugin would do: receive events, create governance items
+  it("GovernancePlugin onEventsEmitted requests creates via decision.create", async () => {
+    // Plugins cannot mutate the store directly — they attach a `create`
+    // field to their routing decision and the daemon performs the write.
     const store = new GovernanceStateStore();
     store.registerGraph(S3_TENSION);
 
     const plugin = new NoOpGovernancePlugin();
-    // Override to actually create an item from an event
-    plugin.onEventsEmitted = (batch, s) => {
-      for (const event of batch.events) {
-        if (event.kind === "tension") {
-          s.create("tension", batch.agentId, event.payload as Record<string, unknown>);
-        }
-      }
-      return Promise.resolve([]);
+    plugin.onEventsEmitted = (batch, _reader) => {
+      const decisions = batch.events
+        .filter((event) => event.kind === "tension")
+        .map((event) => ({
+          event,
+          routes: [{ target: "source" as const }],
+          create: { kind: "tension", payload: event.payload },
+        }));
+      return Promise.resolve(decisions);
     };
 
-    await plugin.onEventsEmitted(
-      {
-        wakeId: { kind: "wake-id", value: "w1" },
-        agentId: makeAgentId("01-research"),
-        events: [{ kind: "tension", payload: { topic: "pricing" } }],
-      },
-      store,
-    );
+    const batch = {
+      wakeId: { kind: "wake-id" as const, value: "w1" },
+      agentId: makeAgentId("01-research"),
+      events: [{ kind: "tension", payload: { topic: "pricing" } }],
+    };
+    const decisions = await plugin.onEventsEmitted(batch, store);
 
+    // Simulate the daemon applying the plugin's create requests.
+    for (const decision of decisions) {
+      if (decision.create) {
+        store.create(decision.create.kind, batch.agentId, decision.create.payload);
+      }
+    }
     expect(store.query({ kind: "tension" })).toHaveLength(1);
   });
 });

--- a/packages/core/src/governance/governance.test.ts
+++ b/packages/core/src/governance/governance.test.ts
@@ -352,11 +352,10 @@ describe("GovernancePlugin + Daemon dispatch contract", () => {
 
     // Write methods are absent — a .mjs plugin casting back cannot
     // mutate the store through this handle.
-    const proxy = reader as unknown as Record<string, unknown>;
-    expect(proxy["create"]).toBeUndefined();
-    expect(proxy["transition"]).toBeUndefined();
-    expect(proxy["setGithubIssueUrl"]).toBeUndefined();
-    expect(proxy["registerGraph"]).toBeUndefined();
+    expect("create" in reader).toBe(false);
+    expect("transition" in reader).toBe(false);
+    expect("setGithubIssueUrl" in reader).toBe(false);
+    expect("registerGraph" in reader).toBe(false);
   });
 });
 

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -183,10 +183,28 @@ export interface GovernanceItemFilter {
  * Durable when `persistDir` is set (production daemon restarts).
  */
 
-/** Interface for governance state storage — enables GitHub-backed or SSE implementations. */
-export interface IGovernanceStateStore {
-  registerGraph(graph: GovernanceStateGraph): void;
+/**
+ * Read-only view of governance state, handed to {@link GovernancePlugin}
+ * lifecycle hooks. Plugins are decision-makers, not state mutators —
+ * they inspect current state and return {@link GovernanceRoutingDecision}s
+ * that describe what should happen. The daemon applies mutations on the
+ * plugin's behalf.
+ *
+ * Isolating reads from writes at the type level prevents a buggy or
+ * adversarial plugin from corrupting items it does not own, bypassing
+ * state-graph validation, or mutating history.
+ */
+export interface GovernanceStateReader {
   graphs(): readonly GovernanceStateGraph[];
+  get(itemId: string): GovernanceItem | undefined;
+  query(filter?: GovernanceItemFilter): readonly GovernanceItem[];
+  buildDecisionRecord(itemId: string, summary: string): GovernanceDecisionRecord;
+  size(): number;
+}
+
+/** Interface for governance state storage — enables GitHub-backed or SSE implementations. */
+export interface IGovernanceStateStore extends GovernanceStateReader {
+  registerGraph(graph: GovernanceStateGraph): void;
   create(
     kind: string,
     createdBy: AgentId,
@@ -195,10 +213,6 @@ export interface IGovernanceStateStore {
   ): GovernanceItem;
   transition(itemId: string, to: string, triggeredBy: string, reason?: string): GovernanceItem;
   setGithubIssueUrl(itemId: string, url: string): void;
-  get(itemId: string): GovernanceItem | undefined;
-  query(filter?: GovernanceItemFilter): readonly GovernanceItem[];
-  buildDecisionRecord(itemId: string, summary: string): GovernanceDecisionRecord;
-  size(): number;
   load(): Promise<number>;
   flush(): Promise<void>;
 }
@@ -488,10 +502,24 @@ export type GovernanceRouteTarget =
   | { readonly target: "external"; readonly channel: string; readonly ref: string }
   | { readonly target: "discard" };
 
+/**
+ * A plugin-requested governance item creation. Returned as part of
+ * {@link GovernanceRoutingDecision} so the daemon — not the plugin —
+ * writes to the state store. The daemon sets `createdBy` from the
+ * triggering batch; the plugin has no way to forge it.
+ */
+export interface GovernanceItemCreateRequest {
+  readonly kind: string;
+  readonly payload: unknown;
+  readonly reviewAt?: Date;
+}
+
 /** Pairs one governance event with its routing decision(s). */
 export interface GovernanceRoutingDecision {
   readonly event: EmittedGovernanceEvent;
   readonly routes: readonly GovernanceRouteTarget[];
+  /** Optional: ask the daemon to create a governance item tied to this event. */
+  readonly create?: GovernanceItemCreateRequest;
 }
 
 // ---------------------------------------------------------------------------
@@ -569,24 +597,27 @@ export interface GovernancePlugin {
 
   /**
    * Called after every wake that produces governance events. The
-   * plugin inspects the events and returns routing instructions.
-   * It may also create or advance governance items in the store.
+   * plugin inspects the events (with read-only state access) and
+   * returns routing decisions. If the plugin wants to record a new
+   * governance item, it attaches a `create` request to the decision
+   * and the daemon performs the write.
    */
   onEventsEmitted(
     batch: GovernanceEventBatch,
-    store: GovernanceStateStore,
+    reader: GovernanceStateReader,
   ): Promise<readonly GovernanceRoutingDecision[]>;
 
   /**
-   * Go/no-go ruling before a consequential action. The plugin may
-   * consult the state store (e.g. "is there an approved governance
-   * item for this action?") or apply model-specific logic.
+   * Go/no-go ruling before a consequential action. Read-only — plugins
+   * consult current state (e.g. "is there an approved governance item
+   * for this action?") but cannot mutate it. Returning `{ allow: false }`
+   * is the only way to influence execution.
    */
   evaluateAction(
     agentId: AgentId,
     action: string,
     context: unknown,
-    store: GovernanceStateStore,
+    reader: GovernanceStateReader,
   ): Promise<GovernanceDecision>;
 
   /**
@@ -624,7 +655,7 @@ export class NoOpGovernancePlugin implements GovernancePlugin {
   // eslint-disable-next-line @typescript-eslint/require-await
   public async onEventsEmitted(
     _batch: GovernanceEventBatch,
-    _store: GovernanceStateStore,
+    _reader: GovernanceStateReader,
   ): Promise<readonly GovernanceRoutingDecision[]> {
     return [];
   }
@@ -634,7 +665,7 @@ export class NoOpGovernancePlugin implements GovernancePlugin {
     _agentId: AgentId,
     _action: string,
     _context: unknown,
-    _store: GovernanceStateStore,
+    _reader: GovernanceStateReader,
   ): Promise<GovernanceDecision> {
     return { allow: true };
   }

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -202,6 +202,24 @@ export interface GovernanceStateReader {
   size(): number;
 }
 
+/**
+ * Build a runtime read-only proxy of a {@link GovernanceStateReader}.
+ *
+ * TypeScript narrows the plugin interface to the reader surface, but a
+ * JavaScript/`.mjs` plugin can runtime-cast its parameter back to the
+ * full store. This proxy closes that gap: the returned object carries
+ * *only* the reader methods, delegating each to the underlying store.
+ * Casting it back to `GovernanceStateStore` still yields `undefined`
+ * for `create`/`transition`/`setGithubIssueUrl` at runtime.
+ */
+export const makeGovernanceStateReader = (store: GovernanceStateReader): GovernanceStateReader => ({
+  graphs: () => store.graphs(),
+  get: (itemId) => store.get(itemId),
+  query: (filter) => store.query(filter),
+  buildDecisionRecord: (itemId, summary) => store.buildDecisionRecord(itemId, summary),
+  size: () => store.size(),
+});
+
 /** Interface for governance state storage — enables GitHub-backed or SSE implementations. */
 export interface IGovernanceStateStore extends GovernanceStateReader {
   registerGraph(graph: GovernanceStateGraph): void;
@@ -628,7 +646,16 @@ export interface GovernancePlugin {
    */
   onTransition?(item: GovernanceItem, transition: GovernanceStateTransition): void;
 
-  /** Optional hook called once when the daemon starts. */
+  /**
+   * Optional hook called once when the daemon starts. Unlike
+   * {@link onEventsEmitted} and {@link evaluateAction}, this receives the
+   * full mutable store so the plugin can register state graphs via
+   * {@link GovernanceStateStore.registerGraph}. Plugins **should not**
+   * create or transition items here — that belongs in `onEventsEmitted`
+   * via the {@link GovernanceRoutingDecision.create} channel. Runtime
+   * isolation is relaxed for this hook because plugin code is
+   * operator-trusted at startup.
+   */
   onDaemonStart?(store: GovernanceStateStore): Promise<void>;
 
   /** Optional hook called once when the daemon stops. */


### PR DESCRIPTION
## Summary

- Closes #43. Splits `GovernanceStateStore`'s read surface from its write surface. Plugins now receive a `GovernanceStateReader` — no `create`/`transition`/`setGithubIssueUrl` methods.
- Adds `GovernanceItemCreateRequest` and an optional `create` field on `GovernanceRoutingDecision`. Plugins *describe* what they want created; the daemon performs the write with `createdBy` derived from the triggering batch (plugins cannot forge `createdBy`).
- Transitions stay daemon-only — timeouts, meeting outcomes, internal state changes. No example plugin called `store.transition()` from `onEventsEmitted`, so no capability is lost.

## Blast radius

- `GovernanceStateReader` is a strict subtype of the existing store, so callers passing the full store are still type-compatible.
- 5 example plugins updated (s3, command, consensus, meritocratic, parliamentary) — `store.create(...)` moves into `decision.create`.
- One governance test rewritten to demonstrate the new contract.

**Net +73 lines.** Blocks Phase 3 (user-extensible plugins).

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 486 passed
- [x] `pnpm run format:check` — clean
- [x] `pnpm run lint` — no new warnings (22 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)