### PR TITLE
refactor: route CLI commands through CollaborationProvider (#90)

### DIFF
--- a/packages/cli/src/backlog.ts
+++ b/packages/cli/src/backlog.ts
@@ -1,5 +1,6 @@
 /**
- * `murmuration backlog` — view and manage a group's GitHub work queue.
+ * `murmuration backlog` — view and manage a group's work queue via the
+ * configured {@link CollaborationProvider} (GitHub issues or local items).
  *
  * Usage:
  *   murmuration backlog --root ../my-murmuration --group content
@@ -10,14 +11,10 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { resolve, join } from "node:path";
 
-import { makeSecretKey } from "@murmurations-ai/core";
-import { createGithubClient, makeRepoCoordinate } from "@murmurations-ai/github";
-import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
-
-const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
+import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
 
 export interface BacklogItem {
-  readonly number: number;
+  readonly number: string;
   readonly title: string;
   readonly labels: readonly string[];
   readonly state: "open" | "closed";
@@ -36,73 +33,57 @@ export const runBacklog = async (args: readonly string[], rootDir: string): Prom
     process.exit(2);
   }
 
-  const repoIdx = args.indexOf("--repo");
-  const repoArg = repoIdx >= 0 ? args[repoIdx + 1] : undefined;
-
   const doRefresh = args.includes("--refresh");
   const backlogDir = join(root, ".murmuration", "backlogs");
   const backlogFile = join(backlogDir, `${groupId}.json`);
 
-  // Load group config to get backlog label + repo
+  // Load group config to get backlog label
   const groupDocPath = join(root, "governance", "groups", `${groupId}.md`);
   let backlogLabel = `group:${groupId}`;
-  let backlogRepo = repoArg ?? "";
 
   if (existsSync(groupDocPath)) {
     const content = await readFile(groupDocPath, "utf8");
     const labelMatch = /backlog_label:\s*"?([^"\n]+)"?/i.exec(content);
-    if (labelMatch) backlogLabel = labelMatch[1]!.trim();
-    const repoMatch = /backlog_repo:\s*"?([^"\n]+)"?/i.exec(content);
-    if (repoMatch) backlogRepo = repoMatch[1]!.trim();
-  }
-
-  if (doRefresh && !backlogRepo) {
-    console.error(
-      "murmuration backlog: no repo configured. Use --repo owner/repo or set backlog_repo: in the group doc.",
-    );
-    process.exit(2);
+    if (labelMatch?.[1]) backlogLabel = labelMatch[1].trim();
   }
 
   if (doRefresh) {
-    // Fetch from GitHub
-    const envPath = join(root, ".env");
-    if (!existsSync(envPath)) {
-      console.error("murmuration backlog: .env not found (need GITHUB_TOKEN for --refresh)");
-      process.exit(1);
-    }
-    const provider = new DotenvSecretsProvider({ envPath });
-    await provider.load({ required: [GITHUB_TOKEN], optional: [] });
-
-    const [owner, repo] = backlogRepo.split("/");
-    if (!owner || !repo) {
-      console.error(`murmuration backlog: invalid repo "${backlogRepo}"`);
-      process.exit(1);
+    let provider;
+    try {
+      ({ provider } = await buildCollaborationProvider(root));
+    } catch (err) {
+      if (err instanceof CollaborationBuildError) {
+        console.error(`murmuration backlog: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
     }
 
-    const gh = createGithubClient({ token: provider.get(GITHUB_TOKEN) });
-    const repoCoord = makeRepoCoordinate(owner, repo);
+    console.log(
+      `Refreshing ${groupId} backlog via ${provider.displayName} (label: "${backlogLabel}")...`,
+    );
 
-    console.log(`Refreshing ${groupId} backlog from ${backlogRepo} (label: "${backlogLabel}")...`);
-
-    const result = await gh.listIssues(repoCoord, {
+    const result = await provider.listItems({
       state: "open",
       labels: [backlogLabel],
-      perPage: 30,
+      limit: 30,
     });
 
     if (!result.ok) {
-      console.error(`GitHub error: ${result.error.code} — ${result.error.message}`);
+      console.error(
+        `${provider.displayName} error: ${result.error.code} — ${result.error.message}`,
+      );
       process.exit(1);
     }
 
-    const items: BacklogItem[] = result.value.map((issue) => ({
-      number: issue.number.value,
-      title: issue.title,
-      labels: issue.labels,
-      state: issue.state,
-      url: issue.htmlUrl,
-      createdAt: issue.createdAt.toISOString(),
-      updatedAt: issue.updatedAt.toISOString(),
+    const items: BacklogItem[] = result.value.map((item) => ({
+      number: item.ref.id,
+      title: item.title,
+      labels: item.labels,
+      state: item.state,
+      url: item.ref.url ?? "",
+      createdAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
     }));
 
     await mkdir(backlogDir, { recursive: true });
@@ -116,7 +97,7 @@ export const runBacklog = async (args: readonly string[], rootDir: string): Prom
     const content = await readFile(backlogFile, "utf8");
     items = JSON.parse(content) as BacklogItem[];
   } catch {
-    console.log(`No backlog cached for ${groupId}. Run with --refresh to fetch from GitHub.`);
+    console.log(`No backlog cached for ${groupId}. Run with --refresh to fetch.`);
     return;
   }
 
@@ -130,7 +111,7 @@ export const runBacklog = async (args: readonly string[], rootDir: string): Prom
     const labels = item.labels.filter((l) => l !== backlogLabel).join(", ");
     const labelStr = labels ? ` [${labels}]` : "";
     console.log(
-      `  ${String(idx + 1).padStart(2)}. #${String(item.number).padEnd(5)} ${item.title.slice(0, 60)}${labelStr}`,
+      `  ${String(idx + 1).padStart(2)}. ${item.number.padEnd(6)} ${item.title.slice(0, 60)}${labelStr}`,
     );
   }
 };

--- a/packages/cli/src/collaboration-factory.ts
+++ b/packages/cli/src/collaboration-factory.ts
@@ -145,12 +145,7 @@ export const buildCollaborationProvider = async (
   });
 
   const provider = new GitHubCollaborationProvider({
-    // The harness GitHub client has a narrower `state` type than the
-    // provider's structural wrapper; the cast is safe because the narrower
-    // type is a subset of the structural one.
-    client: client as unknown as ConstructorParameters<
-      typeof GitHubCollaborationProvider
-    >[0]["client"],
+    client,
     repo: makeRepoCoordinate(repo.owner, repo.repo),
   });
 

--- a/packages/cli/src/collaboration-factory.ts
+++ b/packages/cli/src/collaboration-factory.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared factory for building a {@link CollaborationProvider} from a
+ * murmuration root directory. Used by the `directive`, `backlog`, and
+ * `group-wake` CLI commands so they all honor the same
+ * `collaboration.provider` config resolution as the daemon boot path.
+ *
+ * Resolution order:
+ *   1. `harness.yaml` → `collaboration.provider` + `collaboration.repo`
+ *   2. Agent `role.md` → `signals.github_scopes[0]` (fallback repo)
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  IdentityLoader,
+  LocalCollaborationProvider,
+  GitHubCollaborationProvider,
+  makeSecretKey,
+  type CollaborationProvider,
+} from "@murmurations-ai/core";
+import { createGithubClient, makeRepoCoordinate } from "@murmurations-ai/github";
+import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
+
+import { loadHarnessConfig } from "./harness-config.js";
+
+const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
+
+export interface RepoCoord {
+  readonly owner: string;
+  readonly repo: string;
+}
+
+/** Read the target repo — first from harness.yaml, then from agent signal scopes. */
+export const findDefaultRepo = async (rootDir: string): Promise<RepoCoord | null> => {
+  try {
+    const config = await loadHarnessConfig(rootDir);
+    if (config.collaboration.repo) {
+      const parts = config.collaboration.repo.split("/");
+      if (parts.length === 2 && parts[0] && parts[1]) {
+        return { owner: parts[0], repo: parts[1] };
+      }
+    }
+  } catch {
+    /* no harness.yaml — try agent scopes */
+  }
+
+  try {
+    const loader = new IdentityLoader({ rootDir });
+    const agentIds = await loader.discover();
+    for (const agentId of agentIds) {
+      try {
+        const identity = await loader.load(agentId);
+        const scopes = identity.frontmatter.signals.github_scopes;
+        if (scopes && scopes.length > 0 && scopes[0]) {
+          return { owner: scopes[0].owner, repo: scopes[0].repo };
+        }
+      } catch {
+        /* skip agents that can't be loaded */
+      }
+    }
+  } catch {
+    /* skip */
+  }
+  return null;
+};
+
+export interface BuiltCollaboration {
+  readonly provider: CollaborationProvider;
+  /** Repo coordinate, only set when using the GitHub provider. */
+  readonly repo?: RepoCoord;
+}
+
+export class CollaborationBuildError extends Error {
+  public constructor(
+    public readonly code: "MISSING_ENV" | "MISSING_REPO" | "MISSING_TOKEN",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CollaborationBuildError";
+  }
+}
+
+/**
+ * Build a {@link CollaborationProvider} for a CLI command.
+ *
+ * - Local mode: returns a {@link LocalCollaborationProvider} scoped to
+ *   `.murmuration/items/` under the root directory. No secrets needed.
+ * - GitHub mode (default): loads `GITHUB_TOKEN` from `.env`, resolves the
+ *   target repo from `harness.yaml` (falling back to agent scopes), and
+ *   returns a {@link GitHubCollaborationProvider}.
+ *
+ * Throws {@link CollaborationBuildError} on configuration problems so
+ * callers can produce command-specific error messages.
+ */
+export const buildCollaborationProvider = async (
+  rootDir: string,
+  opts: { readonly writeScopesRepos?: readonly string[] } = {},
+): Promise<BuiltCollaboration> => {
+  const config = await loadHarnessConfig(rootDir);
+
+  if (config.collaboration.provider === "local") {
+    const provider = new LocalCollaborationProvider({
+      itemsDir: join(rootDir, ".murmuration", "items"),
+      artifactsDir: rootDir,
+    });
+    return { provider };
+  }
+
+  const repo = await findDefaultRepo(rootDir);
+  if (!repo) {
+    throw new CollaborationBuildError(
+      "MISSING_REPO",
+      "Could not determine target repo. Set collaboration.repo in harness.yaml or configure github_scopes in an agent's role.md.",
+    );
+  }
+
+  const envPath = join(rootDir, ".env");
+  if (!existsSync(envPath)) {
+    throw new CollaborationBuildError(
+      "MISSING_ENV",
+      ".env not found (need GITHUB_TOKEN for the GitHub collaboration provider).",
+    );
+  }
+
+  const secretsProvider = new DotenvSecretsProvider({ envPath });
+  await secretsProvider.load({ required: [GITHUB_TOKEN], optional: [] });
+  if (!secretsProvider.has(GITHUB_TOKEN)) {
+    throw new CollaborationBuildError(
+      "MISSING_TOKEN",
+      "GITHUB_TOKEN not present in .env for the GitHub collaboration provider.",
+    );
+  }
+
+  const repoKey = `${repo.owner}/${repo.repo}`;
+  const writeScopesRepos = opts.writeScopesRepos ?? [repoKey];
+  const client = createGithubClient({
+    token: secretsProvider.get(GITHUB_TOKEN),
+    writeScopes: {
+      issueComments: [...writeScopesRepos],
+      branchCommits: [],
+      labels: [...writeScopesRepos],
+      issues: [...writeScopesRepos],
+    },
+  });
+
+  const provider = new GitHubCollaborationProvider({
+    // The harness GitHub client has a narrower `state` type than the
+    // provider's structural wrapper; the cast is safe because the narrower
+    // type is a subset of the structural one.
+    client: client as unknown as ConstructorParameters<
+      typeof GitHubCollaborationProvider
+    >[0]["client"],
+    repo: makeRepoCoordinate(repo.owner, repo.repo),
+  });
+
+  return { provider, repo };
+};

--- a/packages/cli/src/directive.ts
+++ b/packages/cli/src/directive.ts
@@ -1,9 +1,11 @@
 /**
- * `murmuration directive` — Source → murmuration communication via GitHub issues.
+ * `murmuration directive` — Source → murmuration communication via
+ * the configured {@link CollaborationProvider} (GitHub issues or local
+ * YAML items).
  *
- * Directives are GitHub issues with the `source-directive` label + scope labels.
- * Agents see them through the existing signal aggregator (listIssues).
- * Responses are issue comments.
+ * Directives are items with the `source-directive` label + scope labels.
+ * Agents see them through the existing signal aggregator. Responses are
+ * item comments.
  *
  * Usage:
  *   murmuration directive --root ../my-murmuration --agent 01-research "Validate this topic"
@@ -12,61 +14,12 @@
  *   murmuration directive --root ../my-murmuration --list
  */
 
-import { existsSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { resolve } from "node:path";
 
-import { makeSecretKey, IdentityLoader } from "@murmurations-ai/core";
-import { createGithubClient, makeRepoCoordinate } from "@murmurations-ai/github";
-import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
-
-const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
-
-/** Read the target repo — first from harness.yaml, then from agent signal scopes. */
-const findDefaultRepo = async (
-  rootDir: string,
-): Promise<{ owner: string; repo: string } | null> => {
-  // Try harness.yaml first (ADR-0021: murmuration repo is the governance target)
-  try {
-    const { loadHarnessConfig } = await import("./harness-config.js");
-    const config = await loadHarnessConfig(rootDir);
-    if (config.collaboration.repo) {
-      const parts = config.collaboration.repo.split("/");
-      if (parts.length === 2 && parts[0] && parts[1]) {
-        return { owner: parts[0], repo: parts[1] };
-      }
-    }
-  } catch {
-    /* no harness.yaml — try agent scopes */
-  }
-
-  // Fall back to agent signal scopes
-  try {
-    const loader = new IdentityLoader({ rootDir });
-    const agentIds = await loader.discover();
-    for (const agentId of agentIds) {
-      try {
-        const identity = await loader.load(agentId);
-        const scopes = identity.frontmatter.signals.github_scopes;
-        if (scopes && scopes.length > 0) {
-          const scope = scopes[0]!;
-          return { owner: scope.owner, repo: scope.repo };
-        }
-      } catch {
-        /* skip agents that can't be loaded */
-      }
-    }
-  } catch {
-    /* skip */
-  }
-  return null;
-};
+import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
 
 export const runDirective = async (args: readonly string[], rootDir: string): Promise<void> => {
   const root = resolve(rootDir);
-
-  // Load harness config to determine collaboration provider
-  const { loadHarnessConfig } = await import("./harness-config.js");
-  const config = await loadHarnessConfig(root);
 
   // Determine scope
   const agentIdx = args.indexOf("--agent");
@@ -86,8 +39,45 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
   } else if (allFlag) {
     scopeLabel = "scope:all";
     scopeDesc = "all agents";
+  } else if (!args.includes("--list")) {
+    throw new Error("murmuration directive: specify --agent <id>, --group <id>, --all, or --list");
   } else {
-    throw new Error("murmuration directive: specify --agent <id>, --group <id>, or --all");
+    scopeLabel = "";
+    scopeDesc = "";
+  }
+
+  let provider;
+  try {
+    ({ provider } = await buildCollaborationProvider(root));
+  } catch (err) {
+    if (err instanceof CollaborationBuildError) {
+      throw new Error(`murmuration directive: ${err.message}`, { cause: err });
+    }
+    throw err;
+  }
+
+  // --list mode
+  if (args.includes("--list")) {
+    const result = await provider.listItems({
+      state: "all",
+      labels: ["source-directive"],
+      limit: 20,
+    });
+    if (!result.ok) {
+      throw new Error(`${provider.displayName} error: ${result.error.code}`);
+    }
+    if (result.value.length === 0) {
+      console.log("No directives found.");
+      return;
+    }
+    for (const item of result.value) {
+      const state = item.state === "open" ? "pending" : "responded";
+      const scope = item.labels.find((l) => l.startsWith("scope:")) ?? "scope:?";
+      console.log(
+        `  ${item.ref.id.padEnd(6)} ${state.padEnd(10)} ${scope.padEnd(20)} ${item.title.slice(0, 60)}`,
+      );
+    }
+    return;
   }
 
   // Body is the last positional argument
@@ -107,92 +97,21 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
     `_Created by \`murmuration directive\`. Agents will respond on their next wake._`,
   ].join("\n");
 
-  // Use CollaborationProvider (local or GitHub) based on harness.yaml
-  if (config.collaboration.provider === "local") {
-    // Local mode — create item in filesystem
-    const { LocalCollaborationProvider } = await import("@murmurations-ai/core");
-    const collab = new LocalCollaborationProvider({
-      itemsDir: join(root, ".murmuration", "items"),
-      artifactsDir: root,
-    });
-    const result = await collab.createItem({
-      title: `[DIRECTIVE] ${body.slice(0, 80)}`,
-      body: directiveBody,
-      labels: ["source-directive", scopeLabel],
-    });
-    if (!result.ok) {
-      throw new Error(`Local provider error: ${result.error.message}`);
-    }
-    console.log(`Directive created: ${result.value.id}`);
-    console.log(`  Scope: ${scopeDesc}`);
-    console.log(`  Labels: source-directive, ${scopeLabel}`);
-    console.log(`\nAgents will see this item as a signal on their next wake.`);
-    return;
-  }
+  const createResult = await provider.createItem({
+    title: `[DIRECTIVE] ${body.slice(0, 80)}`,
+    body: directiveBody,
+    labels: ["source-directive", scopeLabel],
+  });
 
-  // GitHub mode — create issue
-  const envPath = join(root, ".env");
-  if (!existsSync(envPath)) {
-    throw new Error("murmuration directive: .env not found (need GITHUB_TOKEN)");
-  }
-  const secretsProvider = new DotenvSecretsProvider({ envPath });
-  await secretsProvider.load({ required: [GITHUB_TOKEN], optional: [] });
-
-  const repoInfo = await findDefaultRepo(root);
-  if (!repoInfo) {
+  if (!createResult.ok) {
     throw new Error(
-      "murmuration directive: could not determine target repo. Set collaboration.repo in murmuration/harness.yaml or configure github_scopes in an agent's role.md.",
+      `${provider.displayName} error: ${createResult.error.code} — ${createResult.error.message}`,
     );
   }
-  const repoKey = `${repoInfo.owner}/${repoInfo.repo}`;
-  const repo = makeRepoCoordinate(repoInfo.owner, repoInfo.repo);
-  const gh = createGithubClient({
-    token: secretsProvider.get(GITHUB_TOKEN),
-    writeScopes: {
-      issueComments: [repoKey],
-      branchCommits: [],
-      labels: [],
-      issues: [repoKey],
-    },
-  });
 
-  // --list mode
-  if (args.includes("--list")) {
-    const result = await gh.listIssues(repo, {
-      state: "all",
-      labels: ["source-directive"],
-      perPage: 20,
-    });
-    if (!result.ok) {
-      throw new Error(`GitHub error: ${result.error.code}`);
-    }
-    if (result.value.length === 0) {
-      console.log("No directives found.");
-      return;
-    }
-    for (const issue of result.value) {
-      const state = issue.state === "open" ? "pending" : "responded";
-      const scope = issue.labels.find((l) => l.startsWith("scope:")) ?? "scope:?";
-      console.log(
-        `  #${String(issue.number.value).padEnd(5)} ${state.padEnd(10)} ${scope.padEnd(20)} ${issue.title.slice(0, 60)}`,
-      );
-    }
-    return;
-  }
-
-  const issueResult = await gh.createIssue(repo, {
-    title: `[DIRECTIVE] ${body.slice(0, 80)}`,
-    labels: ["source-directive", scopeLabel],
-    body: directiveBody,
-  });
-
-  if (!issueResult.ok) {
-    throw new Error(`GitHub error: ${issueResult.error.code} — ${issueResult.error.message}`);
-  }
-
-  console.log(`Directive created: #${String(issueResult.value.number.value)}`);
-  console.log(`  URL: ${issueResult.value.htmlUrl}`);
+  console.log(`Directive created: ${createResult.value.id}`);
+  if (createResult.value.url) console.log(`  URL: ${createResult.value.url}`);
   console.log(`  Scope: ${scopeDesc}`);
   console.log(`  Labels: source-directive, ${scopeLabel}`);
-  console.log(`\nAgents will see this issue as a signal on their next wake.`);
+  console.log(`\nAgents will see this item as a signal on their next wake.`);
 };

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -29,9 +29,11 @@ import {
 import { createLLMClient, type LLMClient } from "@murmurations-ai/llm";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 
-import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
-
-const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
+import {
+  buildCollaborationProvider,
+  CollaborationBuildError,
+  findDefaultRepo,
+} from "./collaboration-factory.js";
 
 /** Map LLM provider names to their env key names. */
 const PROVIDER_SECRET_KEY: Record<string, string | null> = {
@@ -39,31 +41,6 @@ const PROVIDER_SECRET_KEY: Record<string, string | null> = {
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
   ollama: null,
-};
-
-/** Find the GitHub repo from the first available agent's signal scopes via IdentityLoader. */
-const findRepoFromAgents = async (
-  rootDir: string,
-  memberIds: readonly string[],
-): Promise<{ owner: string; repo: string } | null> => {
-  try {
-    const loader = new IdentityLoader({ rootDir });
-    for (const memberId of memberIds) {
-      try {
-        const identity = await loader.load(memberId);
-        const scopes = identity.frontmatter.signals.github_scopes;
-        if (scopes && scopes.length > 0) {
-          const scope = scopes[0]!;
-          return { owner: scope.owner, repo: scope.repo };
-        }
-      } catch {
-        /* skip */
-      }
-    }
-  } catch {
-    /* skip */
-  }
-  return null;
 };
 
 /** Resolve LLM provider + model from the facilitator's role.md. */
@@ -341,8 +318,7 @@ export const runGroupWakeCommand = async (
   const secretKeyName = PROVIDER_SECRET_KEY[llmConfig.provider];
   if (existsSync(envPath)) {
     secretsProvider = new DotenvSecretsProvider({ envPath });
-    const optionalKeys = [GITHUB_TOKEN];
-    if (secretKeyName) optionalKeys.push(makeSecretKey(secretKeyName));
+    const optionalKeys = secretKeyName ? [makeSecretKey(secretKeyName)] : [];
     await secretsProvider.load({ required: [], optional: optionalKeys });
     const tokenKey = secretKeyName ? makeSecretKey(secretKeyName) : null;
     if (llmConfig.provider === "ollama") {
@@ -434,7 +410,7 @@ export const runGroupWakeCommand = async (
   }
   if (!repoInfo) {
     // Fall back to agent-scope lookup for display purposes only.
-    const fallback = await findRepoFromAgents(root, config.members);
+    const fallback = await findDefaultRepo(root);
     if (fallback) repoInfo = fallback;
   }
 

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -16,6 +16,7 @@ import {
   makeSecretKey,
   IdentityLoader,
   runGroupWake,
+  type CollaborationProvider,
   type GroupConfig,
   type GroupWakeContext,
   type GroupWakeKind,
@@ -25,15 +26,10 @@ import {
   type GovernanceTally,
   GovernanceStateStore,
 } from "@murmurations-ai/core";
-import {
-  createGithubClient,
-  makeRepoCoordinate,
-  makeIssueNumber,
-  type GithubClient,
-  type RepoCoordinate,
-} from "@murmurations-ai/github";
 import { createLLMClient, type LLMClient } from "@murmurations-ai/llm";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
+
+import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
 
 const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
 
@@ -103,28 +99,14 @@ const getDefaultModel = (provider: string): string => {
   }
 };
 
-/** Fetch the group's GitHub issues backlog (by label). */
-const fetchGroupBacklog = async (
-  rootDir: string,
-  _groupId: string,
-  repoInfo: { owner: string; repo: string },
-): Promise<string> => {
+/** Fetch the group's open items backlog via the collaboration provider. */
+const fetchGroupBacklog = async (provider: CollaborationProvider): Promise<string> => {
   try {
-    const envPath = join(rootDir, ".env");
-    if (!existsSync(envPath)) return "(no .env — cannot fetch backlog)";
-    const { DotenvSecretsProvider } = await import("@murmurations-ai/secrets-dotenv");
-    const provider = new DotenvSecretsProvider({ envPath });
-    await provider.load({ required: [makeSecretKey("GITHUB_TOKEN")], optional: [] });
-    const { createGithubClient, makeRepoCoordinate } = await import("@murmurations-ai/github");
-    const gh = createGithubClient({ token: provider.get(makeSecretKey("GITHUB_TOKEN")) });
-    const repo = makeRepoCoordinate(repoInfo.owner, repoInfo.repo);
-    const result = await gh.listIssues(repo, { state: "open", perPage: 30 });
+    const result = await provider.listItems({ state: "open", limit: 30 });
     if (!result.ok) return `(backlog fetch failed: ${result.error.code})`;
-    const issues = result.value;
-    if (issues.length === 0) return "(no open issues)";
-    return issues
-      .map((i) => `- #${String(i.number.value)} ${i.title} [${i.labels.join(", ")}]`)
-      .join("\n");
+    const items = result.value;
+    if (items.length === 0) return "(no open items)";
+    return items.map((i) => `- ${i.ref.id} ${i.title} [${i.labels.join(", ")}]`).join("\n");
   } catch (err) {
     return `(backlog fetch error: ${err instanceof Error ? err.message : String(err)})`;
   }
@@ -159,8 +141,7 @@ const parseGroupConfig = (groupId: string, content: string): GroupConfig => {
 
 const executeActions = async (
   actions: readonly MeetingAction[],
-  gh: GithubClient,
-  repo: RepoCoordinate,
+  provider: CollaborationProvider,
 ): Promise<ActionReceipt[]> => {
   const receipts: ActionReceipt[] = [];
 
@@ -172,13 +153,11 @@ const executeActions = async (
             receipts.push({ action, success: false, error: "missing issueNumber or label" });
             break;
           }
-          // Remove old label first if this is a label swap
+          const ref = { id: String(action.issueNumber) };
           if (action.removeLabel) {
-            await gh.removeLabel(repo, makeIssueNumber(action.issueNumber), action.removeLabel);
+            await provider.removeLabel(ref, action.removeLabel);
           }
-          const result = await gh.addLabels(repo, makeIssueNumber(action.issueNumber), [
-            action.label,
-          ]);
+          const result = await provider.addLabels(ref, [action.label]);
           if (result.ok) {
             const swap = action.removeLabel ? ` (-${action.removeLabel})` : "";
             console.log(
@@ -198,17 +177,21 @@ const executeActions = async (
             receipts.push({ action, success: false, error: "missing title" });
             break;
           }
-          const issueInput: Record<string, unknown> = { title: action.title };
-          if (action.body) issueInput.body = action.body;
-          if (action.labels && action.labels.length > 0) issueInput.labels = [...action.labels];
-          const result = await gh.createIssue(
-            repo,
-            issueInput as { title: string; body?: string; labels?: string[] },
-          );
+          const input: { title: string; body: string; labels?: readonly string[] } = {
+            title: action.title,
+            body: action.body ?? "",
+          };
+          if (action.labels && action.labels.length > 0) input.labels = action.labels;
+          const result = await provider.createItem(input);
           if (result.ok) {
-            const num = result.value.number.value;
-            console.log(`    \x1b[32m✓\x1b[0m create-issue #${String(num)}: ${action.title}`);
-            receipts.push({ action, success: true, issueNumber: num });
+            const parsed = Number(result.value.id);
+            const id = Number.isFinite(parsed) ? parsed : undefined;
+            console.log(`    \x1b[32m✓\x1b[0m create-issue ${result.value.id}: ${action.title}`);
+            receipts.push({
+              action,
+              success: true,
+              ...(id !== undefined ? { issueNumber: id } : {}),
+            });
           } else {
             console.log(`    \x1b[31m✗\x1b[0m create-issue: ${result.error.code}`);
             receipts.push({ action, success: false, error: result.error.code });
@@ -220,9 +203,8 @@ const executeActions = async (
             receipts.push({ action, success: false, error: "missing issueNumber" });
             break;
           }
-          const result = await gh.updateIssueState(
-            repo,
-            makeIssueNumber(action.issueNumber),
+          const result = await provider.updateItemState(
+            { id: String(action.issueNumber) },
             "closed",
           );
           if (result.ok) {
@@ -241,9 +223,10 @@ const executeActions = async (
             receipts.push({ action, success: false, error: "missing issueNumber or body" });
             break;
           }
-          const result = await gh.createIssueComment(repo, makeIssueNumber(action.issueNumber), {
-            body: action.body,
-          });
+          const result = await provider.postComment(
+            { id: String(action.issueNumber) },
+            action.body,
+          );
           if (result.ok) {
             console.log(`    \x1b[32m✓\x1b[0m comment-issue #${String(action.issueNumber)}`);
             receipts.push({ action, success: true });
@@ -432,18 +415,39 @@ export const runGroupWakeCommand = async (
     }
   }
 
-  // Fetch the group's GitHub issues backlog for context
-  const repoInfo = await findRepoFromAgents(root, config.members);
-  let backlogContext = "";
-  if (repoInfo) {
-    console.log(`  Fetching backlog from ${repoInfo.owner}/${repoInfo.repo}...`);
-    backlogContext = await fetchGroupBacklog(root, groupId, repoInfo);
+  // Build the collaboration provider once for this command (backlog
+  // fetch, meeting action execution, meeting minutes post).
+  let collaboration: CollaborationProvider | undefined;
+  let repoInfo: { owner: string; repo: string } | undefined;
+  try {
+    const built = await buildCollaborationProvider(root);
+    collaboration = built.provider;
+    if (built.repo) repoInfo = built.repo;
+  } catch (err) {
+    if (err instanceof CollaborationBuildError) {
+      console.log(`  (collaboration provider unavailable: ${err.message})`);
+    } else {
+      console.log(
+        `  (collaboration provider error: ${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+  }
+  if (!repoInfo) {
+    // Fall back to agent-scope lookup for display purposes only.
+    const fallback = await findRepoFromAgents(root, config.members);
+    if (fallback) repoInfo = fallback;
   }
 
-  // Backlog is now passed as separate context for agenda generation (not merged with directive)
+  let backlogContext = "";
+  if (collaboration) {
+    const source = repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : collaboration.displayName;
+    console.log(`  Fetching backlog from ${source}...`);
+    backlogContext = await fetchGroupBacklog(collaboration);
+  }
+
   const backlogForAgenda =
-    repoInfo && backlogContext
-      ? `## Open Issues (${repoInfo.owner}/${repoInfo.repo})\n\n${backlogContext}`
+    collaboration && backlogContext
+      ? `## Open Items (${repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : collaboration.displayName})\n\n${backlogContext}`
       : undefined;
 
   // Load retrospective metrics if this is a retrospective
@@ -547,25 +551,15 @@ export const runGroupWakeCommand = async (
 
   // Execute structured actions from the facilitator
   let receipts: ActionReceipt[] = [];
-  if (result.actions.length > 0 && repoInfo && secretsProvider?.has(GITHUB_TOKEN)) {
+  if (result.actions.length > 0 && collaboration) {
     console.log(`\n--- Executing ${String(result.actions.length)} action(s) ---\n`);
-    const actionGh = createGithubClient({
-      token: secretsProvider.get(GITHUB_TOKEN),
-      writeScopes: {
-        issueComments: [`${repoInfo.owner}/${repoInfo.repo}`],
-        branchCommits: [],
-        labels: [`${repoInfo.owner}/${repoInfo.repo}`],
-        issues: [`${repoInfo.owner}/${repoInfo.repo}`],
-      },
-    });
-    const actionRepo = makeRepoCoordinate(repoInfo.owner, repoInfo.repo);
-    receipts = await executeActions(result.actions, actionGh, actionRepo);
+    receipts = await executeActions(result.actions, collaboration);
     const succeeded = receipts.filter((r) => r.success).length;
     const failed = receipts.filter((r) => !r.success).length;
     console.log(`\n  ${String(succeeded)} succeeded, ${String(failed)} failed`);
   } else if (result.actions.length > 0) {
     console.log(
-      `\n--- ${String(result.actions.length)} action(s) proposed but no GitHub access — skipped ---`,
+      `\n--- ${String(result.actions.length)} action(s) proposed but no collaboration provider — skipped ---`,
     );
   }
 
@@ -647,45 +641,8 @@ export const runGroupWakeCommand = async (
   ].join("\n");
 
   const meetingLabel = kind === "governance" ? "governance-meeting" : "group-meeting";
-  const repoOwner = repoInfo?.owner ?? "unknown";
-  const repoName = repoInfo?.repo ?? "unknown";
 
-  try {
-    if (!secretsProvider?.has(GITHUB_TOKEN)) throw new Error("no GITHUB_TOKEN");
-    const { makeRepoCoordinate, createGithubClient: createGH } =
-      await import("@murmurations-ai/github");
-    const meetingGh = createGH({
-      token: secretsProvider.get(GITHUB_TOKEN),
-      writeScopes: {
-        issueComments: [`${repoOwner}/${repoName}`],
-        branchCommits: [],
-        labels: [],
-        issues: [`${repoOwner}/${repoName}`],
-      },
-    });
-    const issueResult = await meetingGh.createIssue(makeRepoCoordinate(repoOwner, repoName), {
-      title: `[${kind.toUpperCase()} MEETING] ${config.name} — ${dayUtc}`,
-      labels: [meetingLabel, `group:${groupId}`],
-      body: minutes,
-    });
-    if (issueResult.ok) {
-      meetingMinutesUrl = issueResult.value.htmlUrl;
-      console.log(`\nMeeting minutes: ${issueResult.value.htmlUrl}`);
-    } else {
-      console.log(`\nFailed to create meeting issue: ${issueResult.error.code}`);
-      // Fallback: write locally
-      const { writeFile: wf, mkdir } = await import("node:fs/promises");
-      const meetingDir = join(root, ".murmuration", "runs", `group-${groupId}`, dayUtc);
-      await mkdir(meetingDir, { recursive: true });
-      await wf(
-        join(meetingDir, `meeting-${randomUUID().slice(0, 8)}.md`),
-        `# ${config.name} — ${kind} meeting — ${dayUtc}\n\n${minutes}`,
-        "utf8",
-      );
-      console.log(`  (saved locally as fallback)`);
-    }
-  } catch {
-    // Fallback: write locally if GitHub fails
+  const writeFallback = async (): Promise<void> => {
     const { writeFile: wf, mkdir } = await import("node:fs/promises");
     const meetingDir = join(root, ".murmuration", "runs", `group-${groupId}`, dayUtc);
     await mkdir(meetingDir, { recursive: true });
@@ -694,7 +651,25 @@ export const runGroupWakeCommand = async (
       `# ${config.name} — ${kind} meeting — ${dayUtc}\n\n${minutes}`,
       "utf8",
     );
-    console.log(`\nMeeting minutes saved locally (GitHub unavailable).`);
+  };
+
+  if (collaboration) {
+    const itemResult = await collaboration.createItem({
+      title: `[${kind.toUpperCase()} MEETING] ${config.name} — ${dayUtc}`,
+      labels: [meetingLabel, `group:${groupId}`],
+      body: minutes,
+    });
+    if (itemResult.ok) {
+      meetingMinutesUrl = itemResult.value.url ?? itemResult.value.id;
+      console.log(`\nMeeting minutes: ${meetingMinutesUrl}`);
+    } else {
+      console.log(`\nFailed to create meeting item: ${itemResult.error.code}`);
+      await writeFallback();
+      console.log(`  (saved locally as fallback)`);
+    }
+  } else {
+    await writeFallback();
+    console.log(`\nMeeting minutes saved locally (no collaboration provider).`);
   }
 
   return {

--- a/packages/core/src/collaboration/github-provider.ts
+++ b/packages/core/src/collaboration/github-provider.ts
@@ -38,15 +38,20 @@ export interface GitHubClientLike {
 
   listIssues(
     repo: unknown,
-    filter?: { state?: string; labels?: string[]; since?: Date; perPage?: number },
+    filter?: {
+      state?: "open" | "closed" | "all";
+      labels?: readonly string[];
+      since?: Date;
+      perPage?: number;
+    },
   ): Promise<{
     ok: boolean;
     value?: readonly {
       number: { value: number };
       title: string;
-      body: string;
-      state: string;
-      labels: string[];
+      body: string | null;
+      state: "open" | "closed";
+      labels: readonly string[];
       htmlUrl: string;
       createdAt: Date;
       updatedAt: Date;
@@ -149,11 +154,16 @@ export class GitHubCollaborationProvider implements CollaborationProvider {
   }
 
   async listItems(filter?: ItemFilter): Promise<CollabResult<readonly CollaborationItem[]>> {
-    const listFilter: { state?: string; labels?: string[]; since?: Date; perPage?: number } = {
+    const listFilter: {
+      state?: "open" | "closed" | "all";
+      labels?: readonly string[];
+      since?: Date;
+      perPage?: number;
+    } = {
       state: filter?.state === "all" ? "all" : (filter?.state ?? "open"),
       perPage: filter?.limit ?? 30,
     };
-    if (filter?.labels) listFilter.labels = [...filter.labels];
+    if (filter?.labels) listFilter.labels = filter.labels;
     if (filter?.since) listFilter.since = filter.since;
     const result = await this.#client.listIssues(this.#repo, listFilter);
     if (!result.ok) return { ok: false, error: this.#mapError(result.error) };
@@ -162,8 +172,8 @@ export class GitHubCollaborationProvider implements CollaborationProvider {
       value: result.value!.map((issue) => ({
         ref: { id: String(issue.number.value), url: issue.htmlUrl },
         title: issue.title,
-        body: issue.body,
-        state: (issue.state === "open" ? "open" : "closed") as ItemState,
+        body: issue.body ?? "",
+        state: issue.state,
         labels: issue.labels,
         createdAt: issue.createdAt,
         updatedAt: issue.updatedAt,


### PR DESCRIPTION
## Summary

- Closes #90. Completes ADR-0021 §5 by routing the three remaining CLI commands — `directive`, `backlog`, `group-wake` — through `CollaborationProvider` instead of `createGithubClient()` directly.
- Local mode (`collaboration.provider: local` in `harness.yaml`) now works for all three commands, not just the daemon and signal aggregator.
- Adds `packages/cli/src/collaboration-factory.ts` — shared factory that reads config, resolves the target repo (harness.yaml → agent signal scopes fallback), and builds either `LocalCollaborationProvider` or `GitHubCollaborationProvider`.

## Blast radius

- `directive.ts`: `--list` and create flows use `listItems` / `createItem`. Removes inline local-mode branch (now handled by factory).
- `backlog.ts`: `--refresh` uses `listItems`. `BacklogItem.number` is now `string` (was `number`) — items can be local-mode slugs, not just GH issue numbers.
- `group-wake.ts`: replaces 3 separate `createGithubClient()` constructions (backlog fetch, action execution, meeting minutes post) with a single provider built at command start. `executeActions` takes `CollaborationProvider` instead of `(gh, repo)`.

**Net +328/-295 (net +33 lines including the new factory; −125 lines of duplicate boilerplate removed from the three commands).**

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 486 passed
- [x] `pnpm run format:check` — clean
- [x] `pnpm run lint` — 0 errors, 19 warnings (3 fewer than baseline; no new warnings)

## Follow-ups (out of scope)

- `GitHubClientLike` structural type in `@murmurations-ai/core` has looser `state: string` than the real `GithubClient.listIssues` filter. Factory casts via `as unknown as` to bridge. Worth tightening the structural type in a follow-up so callers don't need the cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)