### PR TITLE
feat: ProviderRegistry — pluggable LLM provider registration (ADR-0025 Phase 1)

### DIFF
--- a/docs/adr/0025-pluggable-llm-providers.md
+++ b/docs/adr/0025-pluggable-llm-providers.md
@@ -1,0 +1,215 @@
+# ADR-0025 — Pluggable LLM provider registry
+
+- **Status:** Proposed
+- **Date:** 2026-04-17
+- **Decision-maker(s):** Source (design)
+- **Related:** ADR-0014 (LLM client), ADR-0020 (Vercel AI SDK migration), ADR-0023 (Extension system), ADR-0024 (Spirit of the Murmuration)
+
+## Context
+
+The harness hardcodes four LLM providers — `gemini`, `anthropic`, `openai`, `ollama` — across multiple sites:
+
+- `ProviderId = "gemini" | "anthropic" | "openai" | "ollama"` as a closed union in `packages/llm/src/types.ts`
+- `createVercelModel` with a four-case switch in `packages/llm/src/adapters/provider-registry.ts`
+- `MODEL_TIER_TABLE: Record<ProviderId, Record<ModelTier, string>>` in `packages/llm/src/tiers.ts`
+- `providerEnvKeyName` in `packages/llm/src/adapters/provider-registry.ts`
+- Duplicated maps in `packages/cli/src/init.ts`, `packages/cli/src/boot.ts`, `packages/cli/src/group-wake.ts`
+
+The underlying Vercel AI SDK supports a much wider set: `@ai-sdk/mistral`, `@ai-sdk/cohere`, `@ai-sdk/amazon-bedrock`, `@ai-sdk/fireworks`, `@ai-sdk/groq`, `@ai-sdk/xai`, `@ai-sdk/perplexity`, `@ai-sdk/google-vertex` (Google Cloud Vertex AI — hosts Anthropic, Meta, Mistral, and Google models under one API), `@ai-sdk/deepseek`, `@ai-sdk/cerebras`, and community adapters following the same shape. None of them are reachable today without forking the harness.
+
+This ADR replaces the closed union with an extensible registry. Operators can add any Vercel-AI-SDK-compatible provider without patching the harness, through the same extension system established in ADR-0023.
+
+### Related but distinct
+
+This ADR is about **provider plurality**: supporting many LLM vendors. It does not change the harness's relationship with a single provider (e.g. the prompt-caching work for Anthropic, or Gemini thinking-token accounting). Each provider still exposes its own capabilities through the same `LLMClient` facade.
+
+## Decision
+
+### §1 — Widen `ProviderId` to an open string
+
+Replace the closed union with an open type that preserves autocomplete for built-ins:
+
+```ts
+// packages/llm/src/types.ts
+export const KNOWN_PROVIDERS = ["gemini", "anthropic", "openai", "ollama"] as const;
+export type KnownProviderId = (typeof KNOWN_PROVIDERS)[number];
+// Preserves autocomplete without closing the set.
+export type ProviderId = KnownProviderId | (string & {});
+```
+
+Callers that had `switch(provider)` exhaustiveness on the union must either fall through to a registry lookup or declare a default. `LLMClientConfig` is widened correspondingly — unknown providers route through the registry rather than the existing switch.
+
+### §2 — `ProviderRegistry` in `@murmurations-ai/llm`
+
+A new class owns the provider lookup. Built-ins are registered automatically at construction; extensions register more via the hook in §3.
+
+```ts
+export interface ProviderDefinition {
+  readonly id: ProviderId;
+  /** Env-var name for the provider's API key. Null for keyless providers (e.g. Ollama). */
+  readonly envKeyName: string | null;
+  /** Instantiate a Vercel LanguageModel for this provider + model. */
+  create(opts: { readonly token: SecretValue | null; readonly model: string; readonly baseUrl?: string }): Promise<LanguageModel>;
+  /** Optional model-tier fallback table. If absent, tiers require an explicit model in config. */
+  readonly tiers?: Readonly<Record<ModelTier, string>>;
+  /** Human-readable name for logs + diagnostics. */
+  readonly displayName: string;
+}
+
+export class ProviderRegistry {
+  register(def: ProviderDefinition): void;
+  has(id: ProviderId): boolean;
+  get(id: ProviderId): ProviderDefinition | undefined;
+  list(): readonly ProviderDefinition[];
+  envKeyName(id: ProviderId): string | null | undefined;
+  resolveModelForTier(id: ProviderId, tier: ModelTier): string | undefined;
+}
+
+export const createDefaultRegistry = (): ProviderRegistry; // registers the 4 built-ins
+```
+
+The registry is the single source of truth. Code in `@murmurations-ai/cli` consumes it exclusively — no inline provider strings, no duplicated env-key maps.
+
+### §3 — Extension hook for provider registration
+
+ADR-0023 extensions gain an optional `registerProviders(api)` entry point. An extension that wants to add Mistral ships its own SDK dependency and declares a provider:
+
+```ts
+// extensions/mistral/index.mjs
+import { createMistral } from "@ai-sdk/mistral";
+
+export default {
+  id: "mistral-provider",
+  version: "1.0.0",
+  registerProviders(api) {
+    api.registerProvider({
+      id: "mistral",
+      envKeyName: "MISTRAL_API_KEY",
+      displayName: "Mistral",
+      tiers: {
+        fast: "mistral-small-latest",
+        balanced: "mistral-large-latest",
+        deep: "mistral-large-latest",
+      },
+      create: async ({ token, model }) => {
+        const client = createMistral({ apiKey: token?.reveal() ?? "" });
+        return client(model);
+      },
+    });
+  },
+};
+```
+
+Extensions are discovered at daemon boot by `packages/core/src/extensions/loader.ts` (already exists). The daemon constructs a `ProviderRegistry`, seeds it with built-ins, then invokes `registerProviders(api)` on every extension that exposes one. The registry is then passed through to anything that needs to resolve a provider (runner, Spirit, boot validation).
+
+Extensions that only register providers (no tools, no skills) are legitimate — the registration hook is orthogonal to the tool hook added in ADR-0023.
+
+### §4 — `harness.yaml` schema additions
+
+No schema changes are required for operators who stick with the four built-ins. For operators that want more, the existing `extensions/` directory is the discovery mechanism — drop in a provider extension, it registers automatically.
+
+Optional hints in `harness.yaml` for UX:
+
+```yaml
+llm:
+  provider: mistral
+  model: mistral-large-latest
+  # Optional: pin a specific version of the model if the provider supports it.
+```
+
+Agents keep their `role.md` `llm:` frontmatter exactly as today. The `provider` field becomes a free-form string validated against the live registry at boot. An unknown provider fails boot with a clear diagnostic listing registered providers.
+
+### §5 — Migration path
+
+Zero breaking changes for existing murmurations:
+
+- The four built-in providers are registered by default at construction, matching today's behavior bit-for-bit.
+- Existing `role.md` files continue to validate.
+- Existing `harness.yaml` files continue to parse.
+- The duplicated provider → env-key maps in `boot.ts`, `group-wake.ts`, and `init.ts` are replaced with `registry.envKeyName(provider)` calls — pure internal refactor, no surface change.
+- `resolveModelForTier(provider, tier)` becomes `registry.resolveModelForTier(provider, tier)` with the same behavior for built-ins.
+
+Operators who want Mistral (or any other provider) add an extension. The day-zero experience is identical; day-one adds a clear upgrade path.
+
+### §6 — CLI surface
+
+One new read-only command:
+
+```
+murmuration providers list       # Show registered providers with their env-key + tier defaults
+```
+
+`murmuration init` prompt widens:
+
+```
+Default LLM provider [gemini]:   # accepts anything; suggests built-ins in help text
+```
+
+If the operator types an unknown provider, `init` still scaffolds `harness.yaml` with that value and emits a note: _"Unknown provider 'mistral' — drop an extension at `extensions/mistral/` to register it before booting the daemon. See docs/provider-extensions.md."_
+
+## Consequences
+
+**Positive:**
+
+- Any Vercel-AI-SDK-compatible provider becomes reachable without patching the harness.
+- Single source of truth for provider identity, env-key convention, and tier tables.
+- Consistent extension model — provider registration reuses the ADR-0023 machinery.
+- Operators own their provider dependencies: extensions bundle the `@ai-sdk/*` SDK and any auth conventions.
+- Vertex AI (via `@ai-sdk/google-vertex`) becomes a first-class option for operators who want to host Claude on GCP.
+
+**Negative:**
+
+- Adding a provider now requires either using the built-in four or authoring a small extension. (Today: no option beyond the four.) Mitigate with shipped example extensions.
+- Boot becomes slightly heavier — one pass over extensions to collect provider registrations. O(n) in extension count; not meaningful at realistic scale.
+- Open type `string & {}` loses exhaustiveness checking on `provider` switches. Code that previously relied on exhaustiveness must route through the registry instead. This is the right shape but it's a refactor.
+
+**Neutral:**
+
+- Model tier tables for unknown providers require the operator to specify a concrete model in config. This is a conscious tradeoff — we cannot anticipate tier mappings for every SDK.
+- Extensions that register providers are plain JavaScript, not declarative YAML. This is intentional: factory signatures and auth conventions vary too much between providers for pure config to work.
+
+## Open questions
+
+1. **Vertex AI auth** — `@ai-sdk/google-vertex` uses Application Default Credentials (ADC) rather than a simple API key. The `envKeyName` contract doesn't fit. Provider definitions may need an optional `authCheck(context)` hook for providers with non-key auth. Decide in Phase 2.
+
+2. **Model tier coverage** — extensions that don't declare `tiers` require operators to always specify `llm.model` in config. Should the registry reject `tier-based` resolution for those providers at boot, or fall back to some harness-wide default? Proposal: reject explicitly — better an error than a wrong model.
+
+3. **Provider versioning** — extensions declare a version, but the `ProviderRegistry` currently ignores it. If two extensions register the same provider id with different versions, last-write-wins. Acceptable for MVP; revisit if it becomes a real problem.
+
+4. **Live model catalogs** — some providers expose a models API (e.g. OpenAI `/v1/models`). A future enhancement: `providers list --models` queries live catalogs via the provider's factory. Out of scope here.
+
+5. **Registration order vs. extension order** — if two extensions register the same provider id, which wins? Proposal: explicit error at registration time; force the operator to resolve the conflict. Alternative: first-write-wins (built-ins never lose, since they register first). Decide in Phase 1 implementation.
+
+## Implementation plan
+
+Three phases, each independently shippable.
+
+### Phase 1 — Core registry
+
+- `ProviderRegistry` class in `@murmurations-ai/llm`
+- `createDefaultRegistry()` pre-registers the four built-ins with existing behavior
+- `ProviderId` widened to `KnownProviderId | (string & {})`
+- `MODEL_TIER_TABLE` moved behind `registry.resolveModelForTier`
+- `providerEnvKeyName` becomes `registry.envKeyName` (deprecate the free function over one release)
+- Dedupe the four hardcoded maps in `boot.ts`, `group-wake.ts`, `init.ts` through the registry
+- Registry construction happens once in `boot.ts` and is passed explicitly through to the runner, Spirit, and any other consumer — no module-level singleton
+
+### Phase 2 — Extension integration
+
+- Extend the ADR-0023 `Extension` interface with optional `registerProviders(api)`
+- `packages/core/src/extensions/loader.ts` collects provider registrations at boot
+- Daemon boot validates `harness.yaml llm.provider` against the registry; unknown provider → boot fails with registered-providers listing
+- Spirit reads its provider through the same registry (ADR-0024 integration point)
+- Example extension for one non-built-in provider (e.g. `extensions/mistral/`) as the canonical reference
+- `murmuration providers list` CLI command
+- Docs: `docs/provider-extensions.md` — authoring guide with the Mistral example worked through end-to-end
+
+### Phase 3 — Polish + ecosystem
+
+- Example extensions for 3-5 more providers (Vertex AI, Groq, Bedrock, xAI, Perplexity)
+- `murmuration providers list --models` that queries live catalogs where available
+- Address open question 1 (non-key auth) for Vertex
+- Address open question 3 (version conflicts) if it's actually hurting
+- Consider promoting popular community extensions into `@murmurations-ai/provider-*` packages bundled with the harness binary
+
+Each phase is a separate release. Phase 1 alone is a meaningful internal improvement (single source of truth, no duplicated maps). Phase 2 is the operator-visible win. Phase 3 is ecosystem-facing.

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -61,25 +61,26 @@ import {
   type GithubWriteScopes,
   type RepoCoordinate,
 } from "@murmurations-ai/github";
-import { createLLMClient, type LLMClient, type LLMCostHook } from "@murmurations-ai/llm";
+import {
+  createLLMClient,
+  providerEnvKeyName,
+  type LLMClient,
+  type LLMCostHook,
+} from "@murmurations-ai/llm";
 import { resolveLLMCost } from "@murmurations-ai/llm/pricing";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 import { DefaultSignalAggregator } from "@murmurations-ai/signals";
 
 const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
 
-/**
- * Map each LLM provider to the dotenv key expected for its API token.
- * Ollama needs no key (`null`). These are used by the boot path to
- * union the correct optional keys into the daemon's SecretDeclaration
- * based on the registered agents' `llm` pins per ADR-0016.
- */
-const PROVIDER_SECRET_KEY: Record<"gemini" | "anthropic" | "openai" | "ollama", string | null> = {
-  gemini: "GEMINI_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
-  openai: "OPENAI_API_KEY",
-  ollama: null,
-};
+// Per ADR-0025, the provider → env-key mapping lives on the
+// ProviderRegistry. `providerEnvKeyName` is a back-compat shim over
+// the default (built-in) registry. Returns `undefined` both for
+// keyless providers (e.g. Ollama) and for providers not registered
+// under the default set — boot treats both the same: no secret to
+// declare. Extension-registered providers land in Phase 2 when the
+// boot path constructs its own registry and lets extensions
+// contribute before sealing.
 
 /**
  * Per-wake adapter: turn the LLM client's token-count-only cost hook
@@ -214,8 +215,8 @@ const buildSecretDeclaration = (agents: readonly RegisteredAgent[]): SecretDecla
       if (!required.has(name)) optional.set(name, makeSecretKey(name));
     }
     if (agent.llm) {
-      const keyName = PROVIDER_SECRET_KEY[agent.llm.provider];
-      if (keyName !== null && !required.has(keyName)) {
+      const keyName = providerEnvKeyName(agent.llm.provider);
+      if (keyName !== undefined && !required.has(keyName)) {
         optional.set(keyName, makeSecretKey(keyName));
       }
     }
@@ -304,7 +305,7 @@ const buildAgentClients = ({
   } = {};
 
   if (agent.llm) {
-    const keyName = PROVIDER_SECRET_KEY[agent.llm.provider];
+    const keyName = providerEnvKeyName(agent.llm.provider);
     const costHook = costBuilder ? makeDaemonHook(costBuilder) : undefined;
     if (agent.llm.provider === "ollama") {
       result.llm = createLLMClient({
@@ -314,7 +315,7 @@ const buildAgentClients = ({
         ...(ollamaBaseUrl !== undefined ? { baseUrl: ollamaBaseUrl } : {}),
         ...(costHook !== undefined ? { defaultCostHook: costHook } : {}),
       });
-    } else if (keyName !== null && provider?.has(makeSecretKey(keyName)) === true) {
+    } else if (keyName !== undefined && provider?.has(makeSecretKey(keyName)) === true) {
       const token = provider.get(makeSecretKey(keyName));
       result.llm = createLLMClient({
         provider: agent.llm.provider,

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -26,7 +26,7 @@ import {
   type GovernanceTally,
   GovernanceStateStore,
 } from "@murmurations-ai/core";
-import { createLLMClient, type LLMClient } from "@murmurations-ai/llm";
+import { createLLMClient, providerEnvKeyName, type LLMClient } from "@murmurations-ai/llm";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 
 import {
@@ -35,13 +35,8 @@ import {
   findDefaultRepo,
 } from "./collaboration-factory.js";
 
-/** Map LLM provider names to their env key names. */
-const PROVIDER_SECRET_KEY: Record<string, string | null> = {
-  gemini: "GEMINI_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
-  openai: "OPENAI_API_KEY",
-  ollama: null,
-};
+// Per ADR-0025: provider → env-key mapping lives on the LLM package's
+// ProviderRegistry. `providerEnvKeyName` consults the default registry.
 
 /** Resolve LLM provider + model from the facilitator's role.md. */
 const resolveLLMConfig = async (
@@ -315,7 +310,7 @@ export const runGroupWakeCommand = async (
   const envPath = join(root, ".env");
   let llmClient: LLMClient | undefined;
   let secretsProvider: DotenvSecretsProvider | undefined;
-  const secretKeyName = PROVIDER_SECRET_KEY[llmConfig.provider];
+  const secretKeyName = providerEnvKeyName(llmConfig.provider);
   if (existsSync(envPath)) {
     secretsProvider = new DotenvSecretsProvider({ envPath });
     const optionalKeys = secretKeyName ? [makeSecretKey(secretKeyName)] : [];
@@ -328,7 +323,7 @@ export const runGroupWakeCommand = async (
         model: llmConfig.model,
       });
     } else if (tokenKey && secretsProvider.has(tokenKey)) {
-      const provider = llmConfig.provider as "gemini" | "anthropic" | "openai";
+      const provider = llmConfig.provider;
       llmClient = createLLMClient({
         provider,
         token: secretsProvider.get(tokenKey),

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -26,6 +26,8 @@ import { mkdir, writeFile, chmod } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { createInterface, type Interface } from "node:readline";
 
+import { providerEnvKeyName } from "@murmurations-ai/llm";
+
 // DO NOT create readline at module scope — it grabs stdin and corrupts
 // terminal mode for other commands (e.g., attach REPL double echo).
 let rl: Interface | null = null;
@@ -240,7 +242,7 @@ _Define the agent-specific bright lines beyond the murmuration soul._
     );
 
     // role.md
-    const secretName = agent.provider === "ollama" ? "" : `${agent.provider.toUpperCase()}_API_KEY`;
+    const secretName = providerEnvKeyName(agent.provider) ?? "";
     if (secretName) secretNames.add(secretName);
     const groupLine = agent.group ? `\n  - "${agent.group}"` : "";
     const ghScopes = githubOwner

--- a/packages/llm/src/adapters/provider-registry.ts
+++ b/packages/llm/src/adapters/provider-registry.ts
@@ -1,33 +1,21 @@
 /**
- * Vercel AI SDK provider registry — creates provider model instances
- * from harness config. Each provider's API key is revealed exactly
- * once here (grep-checkable per ADR-0014).
+ * Back-compat shims over the new {@link ProviderRegistry} (ADR-0025).
+ *
+ * Historically this file held the provider-factory switch and the
+ * provider → env-var map. Both have moved to `providers.ts` where each
+ * `ProviderDefinition` owns its own factory and env-key convention.
+ * The exports below remain for callers that pre-date the registry;
+ * they consult the process-wide default registry under the hood.
+ *
+ * New code should take a `ProviderRegistry` instance explicitly and
+ * call `.get(id)?.create({ token, model })` directly.
  */
 
 import type { LanguageModel } from "ai";
 import type { SecretValue } from "@murmurations-ai/core";
-import type { ProviderId } from "../types.js";
 
-/**
- * The environment variable name each provider expects its API key
- * under. Callers that need to resolve a secret for a given provider
- * should use this map rather than inlining the string — it keeps
- * provider-specific conventions (and any future additions) in one
- * place. Returns `undefined` for providers that don't require a key
- * (e.g. Ollama, which runs locally).
- */
-export const providerEnvKeyName = (provider: ProviderId): string | undefined => {
-  switch (provider) {
-    case "gemini":
-      return "GEMINI_API_KEY";
-    case "anthropic":
-      return "ANTHROPIC_API_KEY";
-    case "openai":
-      return "OPENAI_API_KEY";
-    case "ollama":
-      return undefined;
-  }
-};
+import { defaultRegistry } from "../providers.js";
+import type { ProviderId } from "../types.js";
 
 export interface ProviderRegistryConfig {
   readonly provider: ProviderId;
@@ -37,43 +25,34 @@ export interface ProviderRegistryConfig {
 }
 
 /**
- * Create a Vercel AI SDK LanguageModel from harness config.
- * reveal() is called exactly once per provider construction.
+ * Create a Vercel AI SDK `LanguageModel` for the given provider.
+ * Deprecated in favor of {@link ProviderRegistry.get}`(id).create(...)`.
  */
 export const createVercelModel = async (config: ProviderRegistryConfig): Promise<LanguageModel> => {
-  switch (config.provider) {
-    case "gemini": {
-      const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
-      const google = createGoogleGenerativeAI({
-        apiKey: config.token?.reveal() ?? "",
-        ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
-      });
-      return google(config.model);
-    }
-    case "anthropic": {
-      const { createAnthropic } = await import("@ai-sdk/anthropic");
-      const anthropic = createAnthropic({
-        apiKey: config.token?.reveal() ?? "",
-        ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
-      });
-      return anthropic(config.model);
-    }
-    case "openai": {
-      const { createOpenAI } = await import("@ai-sdk/openai");
-      const openai = createOpenAI({
-        apiKey: config.token?.reveal() ?? "",
-        ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
-      });
-      return openai(config.model);
-    }
-    case "ollama": {
-      // Ollama exposes an OpenAI-compatible API at /v1
-      const { createOpenAI } = await import("@ai-sdk/openai");
-      const ollama = createOpenAI({
-        baseURL: config.baseUrl ?? "http://localhost:11434/v1",
-        apiKey: "ollama", // required by SDK but not validated by Ollama
-      });
-      return ollama(config.model);
-    }
+  const def = defaultRegistry().get(config.provider);
+  if (!def) {
+    throw new Error(
+      `createVercelModel: provider "${config.provider}" is not registered (register it on a ProviderRegistry or drop an extension that registers it)`,
+    );
   }
+  return def.create({
+    token: config.token,
+    model: config.model,
+    ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl } : {}),
+  });
+};
+
+/**
+ * Env-var name each provider expects its API key under.
+ *
+ * Deprecated free-function form. Prefer `registry.envKeyName(id)` on
+ * a `ProviderRegistry` you own — that way extension-registered
+ * providers are reachable. This shim consults the default registry,
+ * which only contains the four built-ins.
+ */
+export const providerEnvKeyName = (provider: ProviderId): string | undefined => {
+  const name = defaultRegistry().envKeyName(provider);
+  // `null` (keyless providers like Ollama) and `undefined` (unknown) both
+  // collapse to `undefined` here for parity with the pre-registry signature.
+  return name ?? undefined;
 };

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -12,7 +12,14 @@ import type { LLMCostHook } from "./cost-hook.js";
 import type { LLMClientError } from "./errors.js";
 import type { RetryPolicy } from "./retry.js";
 import { resolveModelForTier } from "./tiers.js";
-import type { LLMClientCapabilities, LLMRequest, LLMResponse, ModelTier, Result } from "./types.js";
+import type {
+  LLMClientCapabilities,
+  LLMRequest,
+  LLMResponse,
+  ModelTier,
+  ProviderId,
+  Result,
+} from "./types.js";
 import type { LLMAdapter } from "./adapters/adapter.js";
 import { VercelAdapter } from "./adapters/vercel-adapter.js";
 import { createVercelModel } from "./adapters/provider-registry.js";
@@ -56,11 +63,16 @@ interface BaseClientConfig {
   readonly now?: () => Date;
 }
 
-export type LLMClientConfig =
-  | (BaseClientConfig & { readonly provider: "gemini"; readonly token: SecretValue })
-  | (BaseClientConfig & { readonly provider: "anthropic"; readonly token: SecretValue })
-  | (BaseClientConfig & { readonly provider: "openai"; readonly token: SecretValue })
-  | (BaseClientConfig & { readonly provider: "ollama"; readonly token: null });
+/**
+ * Client configuration. Built-in providers have specific token
+ * contracts (Ollama: `null`; rest: `SecretValue`). Extension-registered
+ * providers (ADR-0025) may declare their own — the registry is
+ * the source of truth at runtime.
+ */
+export type LLMClientConfig = BaseClientConfig & {
+  readonly provider: ProviderId;
+  readonly token: SecretValue | null;
+};
 
 // ---------------------------------------------------------------------------
 // Factory (unchanged signature — lazy Vercel model creation)

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,8 +1,9 @@
 /**
  * @murmurations-ai/llm
  *
- * Four-provider LLM client for the Murmuration Harness. See
- * `docs/adr/0014-llm-client.md` for the full rationale.
+ * LLM client for the Murmuration Harness. See `docs/adr/0014-llm-client.md`
+ * for the core design and `docs/adr/0025-pluggable-llm-providers.md` for
+ * the extensible provider registry.
  */
 
 // Public factory + client interface
@@ -11,6 +12,7 @@ export type { CallOptions, LLMClient, LLMClientConfig } from "./client.js";
 
 // Domain types
 export type {
+  KnownProviderId,
   LLMClientCapabilities,
   LLMMessage,
   LLMRequest,
@@ -22,6 +24,7 @@ export type {
   ToolDefinition,
   ToolCallResult,
 } from "./types.js";
+export { KNOWN_PROVIDERS } from "./types.js";
 
 // Cost hook
 export type { LLMCostHook } from "./cost-hook.js";
@@ -30,10 +33,19 @@ export type { LLMCostHook } from "./cost-hook.js";
 export type { RetryPolicy } from "./retry.js";
 export { DEFAULT_RETRY_POLICY } from "./retry.js";
 
-// Model tier resolution
+// Provider registry (ADR-0025)
+export {
+  BUILT_IN_PROVIDERS,
+  ProviderRegistry,
+  createDefaultRegistry,
+  defaultRegistry,
+} from "./providers.js";
+export type { ProviderCreateOptions, ProviderDefinition } from "./providers.js";
+
+// Model tier resolution (back-compat shims over the default registry)
 export { MODEL_TIER_TABLE, resolveModelForTier } from "./tiers.js";
 
-// Provider env-key convention (single source of truth)
+// Provider env-key convention (back-compat shim; prefer ProviderRegistry.envKeyName)
 export { providerEnvKeyName } from "./adapters/provider-registry.js";
 
 // Observability (ADR-0020 Phase 4)

--- a/packages/llm/src/providers.test.ts
+++ b/packages/llm/src/providers.test.ts
@@ -1,0 +1,162 @@
+/**
+ * ProviderRegistry — unit tests (ADR-0025).
+ *
+ * Covers the pure-JS surface: registration, duplicate detection,
+ * env-key lookup, tier resolution, back-compat shims, and the built-in
+ * default registry. The Vercel SDK `create` factories are not
+ * exercised here (they're thin wrappers around third-party SDKs).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILT_IN_PROVIDERS,
+  ProviderRegistry,
+  createDefaultRegistry,
+  defaultRegistry,
+} from "./providers.js";
+import { KNOWN_PROVIDERS } from "./types.js";
+import { providerEnvKeyName } from "./adapters/provider-registry.js";
+import { MODEL_TIER_TABLE, resolveModelForTier } from "./tiers.js";
+
+describe("ProviderRegistry", () => {
+  it("starts empty", () => {
+    const r = new ProviderRegistry();
+    expect(r.list()).toHaveLength(0);
+    expect(r.has("gemini")).toBe(false);
+    expect(r.get("gemini")).toBeUndefined();
+  });
+
+  it("registers and retrieves providers", () => {
+    const r = new ProviderRegistry();
+    r.register({
+      id: "mistral",
+      displayName: "Mistral",
+      envKeyName: "MISTRAL_API_KEY",
+      tiers: { fast: "mistral-small", balanced: "mistral-large", deep: "mistral-large" },
+      create: () => Promise.resolve({} as never),
+    });
+    expect(r.has("mistral")).toBe(true);
+    expect(r.get("mistral")?.displayName).toBe("Mistral");
+    expect(r.list()).toHaveLength(1);
+  });
+
+  it("throws on duplicate registration", () => {
+    const r = new ProviderRegistry();
+    const def = {
+      id: "x",
+      displayName: "X",
+      envKeyName: null,
+      create: () => Promise.resolve({} as never),
+    };
+    r.register(def);
+    expect(() => r.register(def)).toThrow(/already registered/);
+  });
+
+  it("envKeyName returns the registered key, null for keyless, undefined for unknown", () => {
+    const r = new ProviderRegistry();
+    r.register({
+      id: "with-key",
+      displayName: "With Key",
+      envKeyName: "WITH_KEY_API_KEY",
+      create: () => Promise.resolve({} as never),
+    });
+    r.register({
+      id: "keyless",
+      displayName: "Keyless",
+      envKeyName: null,
+      create: () => Promise.resolve({} as never),
+    });
+    expect(r.envKeyName("with-key")).toBe("WITH_KEY_API_KEY");
+    expect(r.envKeyName("keyless")).toBeNull();
+    expect(r.envKeyName("unknown")).toBeUndefined();
+  });
+
+  it("resolveModelForTier returns tier mapping or undefined", () => {
+    const r = new ProviderRegistry();
+    r.register({
+      id: "tiered",
+      displayName: "Tiered",
+      envKeyName: null,
+      tiers: { fast: "f", balanced: "b", deep: "d" },
+      create: () => Promise.resolve({} as never),
+    });
+    r.register({
+      id: "untiered",
+      displayName: "Untiered",
+      envKeyName: null,
+      create: () => Promise.resolve({} as never),
+    });
+    expect(r.resolveModelForTier("tiered", "balanced")).toBe("b");
+    expect(r.resolveModelForTier("untiered", "balanced")).toBeUndefined();
+    expect(r.resolveModelForTier("unknown", "balanced")).toBeUndefined();
+  });
+});
+
+describe("Built-in providers", () => {
+  it("BUILT_IN_PROVIDERS covers all KNOWN_PROVIDERS", () => {
+    const ids = BUILT_IN_PROVIDERS.map((p) => p.id);
+    expect(ids.sort()).toEqual([...KNOWN_PROVIDERS].sort());
+  });
+
+  it("createDefaultRegistry registers all four built-ins", () => {
+    const r = createDefaultRegistry();
+    for (const id of KNOWN_PROVIDERS) {
+      expect(r.has(id)).toBe(true);
+      expect(r.get(id)?.displayName).toBeTruthy();
+    }
+  });
+
+  it("each built-in has the expected env-key convention", () => {
+    const r = createDefaultRegistry();
+    expect(r.envKeyName("gemini")).toBe("GEMINI_API_KEY");
+    expect(r.envKeyName("anthropic")).toBe("ANTHROPIC_API_KEY");
+    expect(r.envKeyName("openai")).toBe("OPENAI_API_KEY");
+    expect(r.envKeyName("ollama")).toBeNull();
+  });
+
+  it("each built-in exposes fast/balanced/deep tiers", () => {
+    const r = createDefaultRegistry();
+    for (const id of KNOWN_PROVIDERS) {
+      expect(r.resolveModelForTier(id, "fast")).toBeTruthy();
+      expect(r.resolveModelForTier(id, "balanced")).toBeTruthy();
+      expect(r.resolveModelForTier(id, "deep")).toBeTruthy();
+    }
+  });
+});
+
+describe("Default (singleton) registry", () => {
+  it("returns the same instance on repeated calls", () => {
+    const a = defaultRegistry();
+    const b = defaultRegistry();
+    expect(a).toBe(b);
+  });
+
+  it("is pre-populated with built-ins", () => {
+    expect(defaultRegistry().has("anthropic")).toBe(true);
+  });
+});
+
+describe("Back-compat shims", () => {
+  it("providerEnvKeyName returns the same value as the registry", () => {
+    expect(providerEnvKeyName("gemini")).toBe("GEMINI_API_KEY");
+    expect(providerEnvKeyName("anthropic")).toBe("ANTHROPIC_API_KEY");
+    // Ollama is keyless — shim collapses null → undefined for legacy parity.
+    expect(providerEnvKeyName("ollama")).toBeUndefined();
+    expect(providerEnvKeyName("unknown-provider")).toBeUndefined();
+  });
+
+  it("resolveModelForTier returns the same model as the registry", () => {
+    expect(resolveModelForTier("gemini", "balanced")).toBe("gemini-2.5-pro");
+    expect(resolveModelForTier("anthropic", "fast")).toBe("claude-sonnet-4-5-20250929");
+  });
+
+  it("resolveModelForTier throws loudly for unknown providers", () => {
+    expect(() => resolveModelForTier("unknown", "balanced")).toThrow(/no tier/);
+  });
+
+  it("MODEL_TIER_TABLE mirrors the built-in tier tables", () => {
+    expect(MODEL_TIER_TABLE.gemini.balanced).toBe("gemini-2.5-pro");
+    expect(MODEL_TIER_TABLE.anthropic.fast).toBe("claude-sonnet-4-5-20250929");
+  });
+});

--- a/packages/llm/src/providers.ts
+++ b/packages/llm/src/providers.ts
@@ -1,0 +1,210 @@
+/**
+ * ProviderRegistry — pluggable registry of LLM providers (ADR-0025).
+ *
+ * The harness ships with four built-in providers (Gemini, Anthropic,
+ * OpenAI, Ollama) that match the Vercel AI SDK's first-party adapters.
+ * Extensions (ADR-0023) can register additional providers at daemon
+ * boot by calling `api.registerProvider(definition)` in their
+ * `registerProviders(api)` hook (wired in Phase 2).
+ *
+ * This file is the single source of truth for:
+ *   - provider identity + display name
+ *   - env-var convention for each provider's API key
+ *   - model-tier mappings for each provider
+ *   - how to construct a Vercel AI SDK `LanguageModel` for a provider
+ *
+ * Callers that previously consulted hardcoded switches, inline maps,
+ * or the deprecated free functions (`providerEnvKeyName`,
+ * `resolveModelForTier`) should obtain a `ProviderRegistry` instance
+ * and ask it instead.
+ */
+
+import type { LanguageModel } from "ai";
+
+import type { SecretValue } from "@murmurations-ai/core";
+
+import type { ModelTier, ProviderId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Arguments passed to a provider's `create` factory. */
+export interface ProviderCreateOptions {
+  readonly token: SecretValue | null;
+  readonly model: string;
+  /** Optional override for the provider's API base URL (proxies, self-hosted, etc). */
+  readonly baseUrl?: string;
+}
+
+/** A registered provider — everything the harness needs to use it. */
+export interface ProviderDefinition {
+  readonly id: ProviderId;
+  readonly displayName: string;
+  /** Env-var name for this provider's API key. `null` means keyless
+   *  (e.g. Ollama runs locally and needs no key). */
+  readonly envKeyName: string | null;
+  /** Optional model-tier fallback table. When absent, tier-based
+   *  resolution fails loudly — the operator must pin an explicit model
+   *  in `harness.yaml` or `role.md`. */
+  readonly tiers?: Readonly<Record<ModelTier, string>>;
+  /** Construct a Vercel AI SDK `LanguageModel` for this provider + model. */
+  create(opts: ProviderCreateOptions): Promise<LanguageModel>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export class ProviderRegistry {
+  readonly #byId = new Map<string, ProviderDefinition>();
+
+  /** Register a provider. Throws if the id is already taken. */
+  public register(def: ProviderDefinition): void {
+    if (this.#byId.has(def.id)) {
+      throw new Error(`ProviderRegistry: provider id "${def.id}" is already registered`);
+    }
+    this.#byId.set(def.id, def);
+  }
+
+  public has(id: ProviderId): boolean {
+    return this.#byId.has(id);
+  }
+
+  public get(id: ProviderId): ProviderDefinition | undefined {
+    return this.#byId.get(id);
+  }
+
+  public list(): readonly ProviderDefinition[] {
+    return [...this.#byId.values()];
+  }
+
+  /** Env-var name for `id`'s API key, or `null` if keyless.
+   *  Returns `undefined` when the provider is not registered. */
+  public envKeyName(id: ProviderId): string | null | undefined {
+    const def = this.#byId.get(id);
+    if (!def) return undefined;
+    return def.envKeyName;
+  }
+
+  /** Resolve a tier to a concrete model for the given provider.
+   *  Returns `undefined` when the provider is not registered or has
+   *  no tier table. */
+  public resolveModelForTier(id: ProviderId, tier: ModelTier): string | undefined {
+    return this.#byId.get(id)?.tiers?.[tier];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in providers
+// ---------------------------------------------------------------------------
+
+const GEMINI_PROVIDER: ProviderDefinition = {
+  id: "gemini",
+  displayName: "Google Gemini",
+  envKeyName: "GEMINI_API_KEY",
+  tiers: {
+    fast: "gemini-2.5-flash",
+    balanced: "gemini-2.5-pro",
+    deep: "gemini-2.5-pro",
+  },
+  create: async ({ token, model, baseUrl }) => {
+    const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
+    const google = createGoogleGenerativeAI({
+      apiKey: token?.reveal() ?? "",
+      ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+    });
+    return google(model);
+  },
+};
+
+const ANTHROPIC_PROVIDER: ProviderDefinition = {
+  id: "anthropic",
+  displayName: "Anthropic",
+  envKeyName: "ANTHROPIC_API_KEY",
+  tiers: {
+    fast: "claude-sonnet-4-5-20250929",
+    balanced: "claude-sonnet-4-5-20250929",
+    deep: "claude-opus-4-6-20251030",
+  },
+  create: async ({ token, model, baseUrl }) => {
+    const { createAnthropic } = await import("@ai-sdk/anthropic");
+    const anthropic = createAnthropic({
+      apiKey: token?.reveal() ?? "",
+      ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+    });
+    return anthropic(model);
+  },
+};
+
+const OPENAI_PROVIDER: ProviderDefinition = {
+  id: "openai",
+  displayName: "OpenAI",
+  envKeyName: "OPENAI_API_KEY",
+  tiers: {
+    fast: "gpt-4o-mini",
+    balanced: "gpt-4o",
+    deep: "gpt-4-turbo",
+  },
+  create: async ({ token, model, baseUrl }) => {
+    const { createOpenAI } = await import("@ai-sdk/openai");
+    const openai = createOpenAI({
+      apiKey: token?.reveal() ?? "",
+      ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+    });
+    return openai(model);
+  },
+};
+
+const OLLAMA_PROVIDER: ProviderDefinition = {
+  id: "ollama",
+  displayName: "Ollama",
+  envKeyName: null,
+  tiers: {
+    fast: "llama3.2:3b",
+    balanced: "llama3.2",
+    deep: "llama3.1:70b",
+  },
+  create: async ({ model, baseUrl }) => {
+    const { createOpenAI } = await import("@ai-sdk/openai");
+    const ollama = createOpenAI({
+      baseURL: baseUrl ?? "http://localhost:11434/v1",
+      apiKey: "ollama",
+    });
+    return ollama(model);
+  },
+};
+
+export const BUILT_IN_PROVIDERS: readonly ProviderDefinition[] = [
+  GEMINI_PROVIDER,
+  ANTHROPIC_PROVIDER,
+  OPENAI_PROVIDER,
+  OLLAMA_PROVIDER,
+];
+
+// ---------------------------------------------------------------------------
+// Default registry + singleton for back-compat shims
+// ---------------------------------------------------------------------------
+
+/** Build a fresh `ProviderRegistry` with the four built-in providers
+ *  pre-registered. Callers that accept extension contributions
+ *  (daemon boot, Spirit init) should use this and then allow
+ *  additional registrations before sealing. */
+export const createDefaultRegistry = (): ProviderRegistry => {
+  const registry = new ProviderRegistry();
+  for (const def of BUILT_IN_PROVIDERS) {
+    registry.register(def);
+  }
+  return registry;
+};
+
+/** Process-wide default registry. Used by the back-compat free
+ *  functions (`providerEnvKeyName`, `resolveModelForTier`,
+ *  `createVercelModel`) that pre-date the registry. Phase 2 will
+ *  discourage implicit-singleton use and favor explicit injection. */
+let DEFAULT_REGISTRY: ProviderRegistry | null = null;
+
+export const defaultRegistry = (): ProviderRegistry => {
+  DEFAULT_REGISTRY ??= createDefaultRegistry();
+  return DEFAULT_REGISTRY;
+};

--- a/packages/llm/src/tiers.ts
+++ b/packages/llm/src/tiers.ts
@@ -1,35 +1,42 @@
 /**
- * Static model-tier resolution table. The single place in the package
- * where model strings live; updated via PR when providers release new
- * models.
+ * Tier-based model resolution.
  *
- * `ModelTier` is imported from `@murmurations-ai/core/execution`.
+ * Historically this file held a static `MODEL_TIER_TABLE`. After
+ * ADR-0025 the tier tables live on each `ProviderDefinition` and are
+ * consulted via `ProviderRegistry.resolveModelForTier`. The exports
+ * below are back-compat shims that use the default (built-in) registry
+ * — callers that want extension-registered providers should take a
+ * `ProviderRegistry` parameter instead.
  */
 
-import type { ModelTier, ProviderId } from "./types.js";
+import { defaultRegistry } from "./providers.js";
+import type { KnownProviderId, ModelTier, ProviderId } from "./types.js";
 
-export const MODEL_TIER_TABLE: Record<ProviderId, Record<ModelTier, string>> = {
-  gemini: {
-    fast: "gemini-2.5-flash",
-    balanced: "gemini-2.5-pro",
-    deep: "gemini-2.5-pro", // Pro is the top Google tier
-  },
-  anthropic: {
-    fast: "claude-sonnet-4-5-20250929",
-    balanced: "claude-sonnet-4-5-20250929",
-    deep: "claude-opus-4-6-20251030", // verify model id against live API at impl time
-  },
-  openai: {
-    fast: "gpt-4o-mini",
-    balanced: "gpt-4o",
-    deep: "gpt-4-turbo", // verify against current API at impl time
-  },
-  ollama: {
-    fast: "llama3.2:3b",
-    balanced: "llama3.2",
-    deep: "llama3.1:70b",
-  },
+/** Deprecated. Kept for back-compat. Prefer
+ *  {@link ProviderRegistry.resolveModelForTier} on a registry you
+ *  construct with {@link createDefaultRegistry}. */
+export const resolveModelForTier = (provider: ProviderId, tier: ModelTier): string => {
+  const model = defaultRegistry().resolveModelForTier(provider, tier);
+  if (!model) {
+    throw new Error(
+      `resolveModelForTier: no tier "${tier}" for provider "${provider}" (register the provider or pin an explicit model)`,
+    );
+  }
+  return model;
 };
 
-export const resolveModelForTier = (provider: ProviderId, tier: ModelTier): string =>
-  MODEL_TIER_TABLE[provider][tier];
+/** Deprecated. The tier table for built-in providers, materialized from
+ *  the default registry for legacy callers. Reads go through the
+ *  registry — don't mutate. */
+export const MODEL_TIER_TABLE: Readonly<Record<KnownProviderId, Record<ModelTier, string>>> =
+  (() => {
+    const r = defaultRegistry();
+    const table = {} as Record<KnownProviderId, Record<ModelTier, string>>;
+    for (const id of ["gemini", "anthropic", "openai", "ollama"] as const) {
+      const def = r.get(id);
+      if (def?.tiers) {
+        table[id] = { ...def.tiers };
+      }
+    }
+    return table;
+  })();

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -6,8 +6,22 @@
 
 import type { ModelTier } from "@murmurations-ai/core";
 
-/** Discriminant for the four providers. */
-export type ProviderId = "gemini" | "anthropic" | "openai" | "ollama";
+/**
+ * Built-in provider identifiers. Extensions (ADR-0025) register
+ * additional providers at daemon boot; those get arbitrary string ids.
+ */
+export const KNOWN_PROVIDERS = ["gemini", "anthropic", "openai", "ollama"] as const;
+
+export type KnownProviderId = (typeof KNOWN_PROVIDERS)[number];
+
+/**
+ * Provider identifier. Kept as an open string to support
+ * extension-registered providers (Mistral, Groq, Bedrock, Vertex, …).
+ * Built-in ids stay auto-completable via the `KnownProviderId` union.
+ * The `& {}` trick widens the type without collapsing the known-set
+ * literal-ness for autocomplete.
+ */
+export type ProviderId = KnownProviderId | (string & {});
 
 /** Terminal state of a completion. Normalized across providers. */
 export type StopReason =


### PR DESCRIPTION
## Summary

Implements Phase 1 of [ADR-0025](docs/adr/0025-pluggable-llm-providers.md). Replaces the closed 4-provider union with an extensible `ProviderRegistry`. Each provider is a `ProviderDefinition` that owns its identity, display name, env-key convention, tier mapping, and Vercel SDK construction.

The four built-ins (Gemini, Anthropic, OpenAI, Ollama) are registered by default. Extensions will register more in Phase 2.

## Changes

### \`@murmurations-ai/llm\` — new pluggable surface

- \`providers.ts\` (new) — \`ProviderRegistry\` class, \`ProviderDefinition\` interface, \`createDefaultRegistry()\` + \`defaultRegistry()\` singleton, declarations for the four built-ins
- \`types.ts\` — \`ProviderId\` widened from closed union to \`KnownProviderId | (string & {})\`. \`KNOWN_PROVIDERS\` exported as a const array
- \`client.ts\` — \`LLMClientConfig\` widened so extension-registered providers flow through the same client
- \`tiers.ts\` — \`resolveModelForTier\` / \`MODEL_TIER_TABLE\` become back-compat shims over the default registry; \`resolveModelForTier\` now throws loudly for unknown providers
- \`adapters/provider-registry.ts\` — \`createVercelModel\` and \`providerEnvKeyName\` become back-compat shims. Removed the 4-case switch.

### \`@murmurations-ai/cli\` — consolidate duplicated inline maps

- \`boot.ts\` — \`PROVIDER_SECRET_KEY\` inline map replaced with \`providerEnvKeyName(...)\`
- \`group-wake.ts\` — same
- \`init.ts\` — \`\${agent.provider.toUpperCase()}_API_KEY\` replaced with \`providerEnvKeyName(agent.provider)\`

### Tests

- 15 new unit tests (\`providers.test.ts\`) covering registration, duplicate detection, env-key lookup, tier resolution, built-in coverage, singleton identity, back-compat shims
- 515 tests total (up from 500)

## Migration

**Zero breaking changes for existing murmurations.** The four built-in providers behave exactly as before — same env-key conventions, same tier tables, same construction. Existing \`harness.yaml\` + \`role.md\` files continue to validate unchanged.

## Not in this PR (Phase 2 + 3)

- Extension hook for provider registration (\`extension.registerProviders(api)\`)
- Example provider extension (e.g. \`extensions/mistral/\`)
- \`murmuration providers list\` CLI command
- Provider-extension authoring docs
- Boot-time validation of \`llm.provider\` against the live registry

## Test plan

- [x] \`pnpm run build\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test\` — 515 passed (15 new)
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm run lint\` — 0 errors, 18 warnings (all pre-existing)

## Review focus

- Is the \`ProviderId = KnownProviderId | (string & {})\` shape the right tradeoff? (Preserves autocomplete without closing the set.)
- Is the singleton \`defaultRegistry()\` pattern acceptable for Phase 1 back-compat, given Phase 2 moves to explicit injection?
- Does the \`resolveModelForTier\` throw-on-unknown behavior feel right, or should it return \`undefined\` (old silent-fail pattern)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)