### PR TITLE
feat: extension-registered LLM providers (ADR-0025 Phase 2)

### DIFF
--- a/examples/extensions/mistral/index.mjs
+++ b/examples/extensions/mistral/index.mjs
@@ -1,0 +1,55 @@
+/**
+ * Example provider extension — registers Mistral as an LLM provider
+ * via the ProviderRegistry hook added in ADR-0025 Phase 2.
+ *
+ * To use this extension in a murmuration:
+ *   1. Copy this directory to `<root>/extensions/mistral/`
+ *   2. Install `@ai-sdk/mistral` (e.g. `pnpm add @ai-sdk/mistral`
+ *      at the murmuration root, or ship it as a dep of your own
+ *      distribution extension)
+ *   3. Add `MISTRAL_API_KEY=...` to your `.env`
+ *   4. Set `llm.provider: mistral` in `murmuration/harness.yaml` (or
+ *      per-agent in `role.md` frontmatter)
+ *
+ * The extension reuses the same `registerProvider` API any other
+ * provider does — Groq, Bedrock, xAI, Perplexity, Vertex AI, etc.
+ * all follow the same pattern.
+ */
+
+/** @type {import('@murmurations-ai/core').ExtensionEntry} */
+export default {
+  id: "mistral-provider",
+  name: "Mistral (via Vercel AI SDK)",
+  description: "Registers Mistral models as an LLM provider.",
+
+  register(api) {
+    if (!api.registerProvider) {
+      console.warn(
+        "[mistral-provider] api.registerProvider unavailable — loader was not built with provider registration support",
+      );
+      return;
+    }
+
+    /** @type {import('@murmurations-ai/llm').ProviderDefinition} */
+    const mistralDefinition = {
+      id: "mistral",
+      displayName: "Mistral",
+      envKeyName: "MISTRAL_API_KEY",
+      tiers: {
+        fast: "mistral-small-latest",
+        balanced: "mistral-large-latest",
+        deep: "mistral-large-latest",
+      },
+      create: async ({ token, model, baseUrl }) => {
+        const { createMistral } = await import("@ai-sdk/mistral");
+        const mistral = createMistral({
+          apiKey: token?.reveal() ?? "",
+          ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+        });
+        return mistral(model);
+      },
+    };
+
+    api.registerProvider(mistralDefinition);
+  },
+};

--- a/examples/extensions/mistral/openclaw.plugin.json
+++ b/examples/extensions/mistral/openclaw.plugin.json
@@ -1,0 +1,7 @@
+{
+  "id": "mistral-provider",
+  "providerAuthEnvVars": {
+    "mistral": ["MISTRAL_API_KEY"]
+  },
+  "contracts": {}
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -266,6 +266,7 @@ Usage:
   murmuration directive --list          Show all directives and responses
   murmuration group-wake [options]     Convene a group meeting (on demand)
   murmuration backlog [options]         View/refresh a group's GitHub work queue
+  murmuration providers list [--json]   List registered LLM providers
   murmuration status [--root|--name]     Show daemon status and agent summary
   murmuration stop [--root|--name]      Stop the running daemon gracefully
   murmuration restart [--root|--name]   Stop and restart (picks up new code)
@@ -467,6 +468,11 @@ const main = async (): Promise<void> => {
     }
     case "directive": {
       await runDirective(argv.slice(1), resolveRoot(argv.slice(1)));
+      break;
+    }
+    case "providers": {
+      const { runProviders } = await import("./providers-cmd.js");
+      await runProviders(argv.slice(1));
       break;
     }
     case "register": {

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -760,12 +760,38 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   }
 
   // -------------------------------------------------------------------
-  // Extension loading (ADR-0023)
+  // Provider registry (ADR-0025) — built-ins pre-registered; extensions
+  // contribute more via their `registerProviders(api)` hook below.
+  // -------------------------------------------------------------------
+
+  const { createDefaultRegistry, validateProviderDefinition } =
+    await import("@murmurations-ai/llm");
+  const providerRegistry = createDefaultRegistry();
+
+  // -------------------------------------------------------------------
+  // Extension loading (ADR-0023 + ADR-0025 Phase 2)
   // -------------------------------------------------------------------
 
   const { loadExtensions } = await import("@murmurations-ai/core");
   const extensionsDir = join(exampleRoot, "extensions");
-  const loadedExtensions = await loadExtensions(extensionsDir, exampleRoot);
+  const loadedExtensions = await loadExtensions(extensionsDir, exampleRoot, {
+    onRegisterProvider: (definition, extensionId) => {
+      try {
+        const def = validateProviderDefinition(definition, extensionId);
+        providerRegistry.register(def);
+        logger.info("daemon.providers.registered", {
+          extensionId,
+          providerId: def.id,
+          displayName: def.displayName,
+        });
+      } catch (err) {
+        logger.warn("daemon.providers.invalid", {
+          extensionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  });
   if (loadedExtensions.length > 0) {
     const toolCount = loadedExtensions.reduce((n, ext) => n + ext.tools.length, 0);
     logger.info("daemon.extensions.loaded", {
@@ -774,6 +800,12 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       ids: loadedExtensions.map((e) => e.id),
     });
   }
+
+  // Log the resolved provider roster — operator can see at a glance
+  // which providers are available for `llm.provider` config fields.
+  logger.info("daemon.providers.roster", {
+    providers: providerRegistry.list().map((p) => p.id),
+  });
 
   // Collect all extension tools into a flat array for the runner
   const extensionTools = loadedExtensions.flatMap((ext) => ext.tools);

--- a/packages/cli/src/providers-cmd.ts
+++ b/packages/cli/src/providers-cmd.ts
@@ -1,0 +1,54 @@
+/**
+ * `murmuration providers list` — show the LLM providers registered on
+ * the default registry (built-in providers only). Extension-registered
+ * providers only appear at daemon boot time; to see those, check the
+ * daemon log for the `daemon.providers.roster` event, or run against
+ * a live daemon (Phase 3 adds a `providers.list` socket RPC).
+ */
+
+import { createDefaultRegistry } from "@murmurations-ai/llm";
+
+export const runProviders = async (args: readonly string[]): Promise<void> => {
+  const verb = args[0] ?? "list";
+
+  if (verb !== "list") {
+    console.error(`murmuration providers: unknown subcommand "${verb}" (expected: list)`);
+    process.exit(2);
+  }
+
+  const registry = createDefaultRegistry();
+  const providers = registry.list();
+  const jsonFlag = args.includes("--json");
+
+  if (jsonFlag) {
+    process.stdout.write(
+      JSON.stringify(
+        providers.map((p) => ({
+          id: p.id,
+          displayName: p.displayName,
+          envKeyName: p.envKeyName,
+          tiers: p.tiers ?? null,
+        })),
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  const header = `${"ID".padEnd(12)} ${"NAME".padEnd(20)} ${"ENV KEY".padEnd(20)} TIERS`;
+  console.log(header);
+  console.log("─".repeat(header.length + 20));
+  for (const p of providers) {
+    const env = p.envKeyName ?? "(keyless)";
+    const tiers = p.tiers
+      ? `fast=${p.tiers.fast} · balanced=${p.tiers.balanced} · deep=${p.tiers.deep}`
+      : "(none)";
+    console.log(`${p.id.padEnd(12)} ${p.displayName.padEnd(20)} ${env.padEnd(20)} ${tiers}`);
+  }
+  console.log(
+    "\n(Built-in providers only. Extension-registered providers load at daemon boot;\n see the `daemon.providers.roster` event in the daemon log.)",
+  );
+
+  return Promise.resolve();
+};

--- a/packages/core/src/extensions/extensions.test.ts
+++ b/packages/core/src/extensions/extensions.test.ts
@@ -168,4 +168,52 @@ describe("loadExtensions", () => {
     const result = await loadExtensions(extDir, rootDir);
     expect(result).toEqual([]);
   });
+
+  it("forwards api.registerProvider to onRegisterProvider option (ADR-0025)", async () => {
+    await writeExtension(
+      "provider-ext",
+      { id: "provider-ext" },
+      `export default {
+        id: "provider-ext",
+        name: "Provider Ext",
+        description: "registers a provider",
+        register(api) {
+          api.registerProvider?.({
+            id: "fake",
+            displayName: "Fake",
+            envKeyName: "FAKE_KEY",
+            create: () => Promise.resolve({}),
+          });
+        },
+      };`,
+    );
+
+    const captured: { def: unknown; extensionId: string }[] = [];
+    await loadExtensions(extDir, rootDir, {
+      onRegisterProvider: (def, extensionId) => captured.push({ def, extensionId }),
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.extensionId).toBe("provider-ext");
+    expect((captured[0]?.def as { id: string }).id).toBe("fake");
+  });
+
+  it("omits api.registerProvider when no onRegisterProvider is given", async () => {
+    await writeExtension(
+      "no-hook-ext",
+      { id: "no-hook-ext" },
+      `export default {
+        id: "no-hook-ext",
+        name: "No Hook Ext",
+        description: "",
+        register(api) {
+          globalThis.__registerProviderAvailable = typeof api.registerProvider === "function";
+        },
+      };`,
+    );
+
+    await loadExtensions(extDir, rootDir);
+    // @ts-expect-error — global test value
+    expect(globalThis.__registerProviderAvailable).toBe(false);
+  });
 });

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -3,9 +3,11 @@
  */
 
 export { loadExtensions } from "./loader.js";
+export type { LoadExtensionsOptions } from "./loader.js";
 export type {
   ExtensionEntry,
   ExtensionManifest,
+  ExtensionProviderDefinition,
   LoadedExtension,
   MurmurationPluginApi,
 } from "./types.js";

--- a/packages/core/src/extensions/loader.ts
+++ b/packages/core/src/extensions/loader.ts
@@ -11,6 +11,7 @@ import type {
   ToolDefinition,
   ExtensionEntry,
   ExtensionManifest,
+  ExtensionProviderDefinition,
   LoadedExtension,
   MurmurationPluginApi,
 } from "./types.js";
@@ -18,6 +19,21 @@ import type {
 // ---------------------------------------------------------------------------
 // Loader
 // ---------------------------------------------------------------------------
+
+export interface LoadExtensionsOptions {
+  /**
+   * Invoked when an extension calls `api.registerProvider(def)`
+   * (ADR-0025). The daemon boot path wires this to
+   * `ProviderRegistry.register` in `@murmurations-ai/llm`, which
+   * validates the shape at registration time. When this option is
+   * omitted, extensions that try to register providers see a missing
+   * `api.registerProvider` and should log or skip gracefully.
+   */
+  readonly onRegisterProvider?: (
+    definition: ExtensionProviderDefinition,
+    extensionId: string,
+  ) => void;
+}
 
 /**
  * Scan an extensions directory, load manifests, check env vars,
@@ -28,6 +44,7 @@ import type {
 export async function loadExtensions(
   extensionsDir: string,
   rootDir: string,
+  options: LoadExtensionsOptions = {},
 ): Promise<readonly LoadedExtension[]> {
   const loaded: LoadedExtension[] = [];
 
@@ -91,10 +108,17 @@ export async function loadExtensions(
       const extensionEntry = mod.default;
       if (!extensionEntry?.register) continue;
 
-      // Register tools via the plugin API
+      // Register tools and (optionally) providers via the plugin API
       const tools: ToolDefinition[] = [];
       const api: MurmurationPluginApi = {
         registerTool: (tool) => tools.push(tool),
+        ...(options.onRegisterProvider !== undefined
+          ? {
+              registerProvider: (def: ExtensionProviderDefinition): void => {
+                options.onRegisterProvider!(def, manifest.id);
+              },
+            }
+          : {}),
         getSecret: (key) => process.env[key],
         rootDir,
       };

--- a/packages/core/src/extensions/types.ts
+++ b/packages/core/src/extensions/types.ts
@@ -33,10 +33,34 @@ export interface ExtensionManifest {
 // Plugin API (subset of OpenClaw's OpenClawPluginApi)
 // ---------------------------------------------------------------------------
 
+/**
+ * Structural shape of a provider definition that extensions contribute
+ * via `api.registerProvider(...)`. The concrete type lives in
+ * `@murmurations-ai/llm` (`ProviderDefinition`); this core-level
+ * declaration is intentionally opaque to avoid a circular dependency
+ * between `core` and `llm`. The caller of `loadExtensions` (daemon
+ * boot) validates the shape against the live `ProviderRegistry`.
+ *
+ * Extensions should import the real `ProviderDefinition` type from
+ * `@murmurations-ai/llm` and pass an instance to `registerProvider`.
+ */
+export type ExtensionProviderDefinition = unknown;
+
 /** API provided to extensions during registration. */
 export interface MurmurationPluginApi {
   /** Register a tool that agents can use during wakes. */
   registerTool(tool: ToolDefinition): void;
+
+  /**
+   * Register an LLM provider (ADR-0025). The definition is validated
+   * against the caller's `ProviderRegistry` at registration time;
+   * extensions should import `ProviderDefinition` from
+   * `@murmurations-ai/llm` to author it.
+   *
+   * Only present when the extension loader was constructed with an
+   * `onRegisterProvider` callback (typically the daemon boot path).
+   */
+  registerProvider?(definition: ExtensionProviderDefinition): void;
 
   /** Access a secret (env var) by name. */
   getSecret(key: string): string | undefined;

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -36,9 +36,11 @@ export { DEFAULT_RETRY_POLICY } from "./retry.js";
 // Provider registry (ADR-0025)
 export {
   BUILT_IN_PROVIDERS,
+  InvalidProviderDefinitionError,
   ProviderRegistry,
   createDefaultRegistry,
   defaultRegistry,
+  validateProviderDefinition,
 } from "./providers.js";
 export type { ProviderCreateOptions, ProviderDefinition } from "./providers.js";
 

--- a/packages/llm/src/providers.test.ts
+++ b/packages/llm/src/providers.test.ts
@@ -11,9 +11,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   BUILT_IN_PROVIDERS,
+  InvalidProviderDefinitionError,
   ProviderRegistry,
   createDefaultRegistry,
   defaultRegistry,
+  validateProviderDefinition,
 } from "./providers.js";
 import { KNOWN_PROVIDERS } from "./types.js";
 import { providerEnvKeyName } from "./adapters/provider-registry.js";
@@ -134,6 +136,69 @@ describe("Default (singleton) registry", () => {
 
   it("is pre-populated with built-ins", () => {
     expect(defaultRegistry().has("anthropic")).toBe(true);
+  });
+});
+
+describe("validateProviderDefinition", () => {
+  const validDef = {
+    id: "mistral",
+    displayName: "Mistral",
+    envKeyName: "MISTRAL_API_KEY",
+    tiers: { fast: "mistral-small", balanced: "mistral-large", deep: "mistral-large" },
+    create: () => Promise.resolve({} as never),
+  };
+
+  it("accepts a well-formed definition", () => {
+    expect(() => validateProviderDefinition(validDef, "ext")).not.toThrow();
+  });
+
+  it("accepts null envKeyName (keyless)", () => {
+    const keyless = { ...validDef, id: "local", envKeyName: null };
+    expect(() => validateProviderDefinition(keyless, "ext")).not.toThrow();
+  });
+
+  it("accepts omitted tiers", () => {
+    const { tiers: _tiers, ...noTiers } = validDef;
+    expect(() => validateProviderDefinition(noTiers, "ext")).not.toThrow();
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => validateProviderDefinition("string", "ext")).toThrow(
+      InvalidProviderDefinitionError,
+    );
+    expect(() => validateProviderDefinition(null, "ext")).toThrow(InvalidProviderDefinitionError);
+  });
+
+  it("rejects empty id", () => {
+    expect(() => validateProviderDefinition({ ...validDef, id: "" }, "ext")).toThrow(/id/);
+  });
+
+  it("rejects non-function create", () => {
+    expect(() => validateProviderDefinition({ ...validDef, create: "nope" }, "ext")).toThrow(
+      /create/,
+    );
+  });
+
+  it("rejects wrong-typed envKeyName", () => {
+    expect(() => validateProviderDefinition({ ...validDef, envKeyName: 42 }, "ext")).toThrow(
+      /envKeyName/,
+    );
+  });
+
+  it("rejects malformed tiers (missing tier)", () => {
+    expect(() =>
+      validateProviderDefinition({ ...validDef, tiers: { fast: "a", balanced: "b" } }, "ext"),
+    ).toThrow(/deep/);
+  });
+
+  it("reports the extensionId in the error message", () => {
+    try {
+      validateProviderDefinition({}, "mistral-ext");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidProviderDefinitionError);
+      expect((err as Error).message).toMatch(/\[mistral-ext\]/);
+    }
   });
 });
 

--- a/packages/llm/src/providers.ts
+++ b/packages/llm/src/providers.ts
@@ -208,3 +208,95 @@ export const defaultRegistry = (): ProviderRegistry => {
   DEFAULT_REGISTRY ??= createDefaultRegistry();
   return DEFAULT_REGISTRY;
 };
+
+// ---------------------------------------------------------------------------
+// Validation — used by the daemon boot path when accepting
+// extension-contributed provider definitions (ADR-0025 §3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when an extension's provider registration fails validation.
+ * Fields are populated from the offending definition where possible.
+ */
+export class InvalidProviderDefinitionError extends Error {
+  public constructor(
+    message: string,
+    public readonly extensionId: string,
+    public readonly offending: unknown,
+  ) {
+    super(`[${extensionId}] ${message}`);
+    this.name = "InvalidProviderDefinitionError";
+  }
+}
+
+/**
+ * Runtime validation for an `unknown` payload contributed by an
+ * extension. Returns a typed `ProviderDefinition` or throws
+ * {@link InvalidProviderDefinitionError} with a precise reason.
+ *
+ * The contract is enforced at the boundary so extensions written in
+ * plain JavaScript can't corrupt the registry with malformed entries.
+ */
+export const validateProviderDefinition = (
+  def: unknown,
+  extensionId: string,
+): ProviderDefinition => {
+  if (!def || typeof def !== "object") {
+    throw new InvalidProviderDefinitionError(
+      "provider definition must be an object",
+      extensionId,
+      def,
+    );
+  }
+  const rec = def as {
+    id?: unknown;
+    displayName?: unknown;
+    envKeyName?: unknown;
+    create?: unknown;
+    tiers?: unknown;
+  };
+
+  if (typeof rec.id !== "string" || rec.id.length === 0) {
+    throw new InvalidProviderDefinitionError("`id` must be a non-empty string", extensionId, def);
+  }
+  if (typeof rec.displayName !== "string" || rec.displayName.length === 0) {
+    throw new InvalidProviderDefinitionError(
+      "`displayName` must be a non-empty string",
+      extensionId,
+      def,
+    );
+  }
+  if (rec.envKeyName !== null && typeof rec.envKeyName !== "string") {
+    throw new InvalidProviderDefinitionError(
+      "`envKeyName` must be a string or null",
+      extensionId,
+      def,
+    );
+  }
+  if (typeof rec.create !== "function") {
+    throw new InvalidProviderDefinitionError("`create` must be a function", extensionId, def);
+  }
+  if (rec.tiers !== undefined) {
+    const tiers = rec.tiers;
+    if (!tiers || typeof tiers !== "object") {
+      throw new InvalidProviderDefinitionError(
+        "`tiers` must be an object when present",
+        extensionId,
+        def,
+      );
+    }
+    const tierRec = tiers as { fast?: unknown; balanced?: unknown; deep?: unknown };
+    for (const key of ["fast", "balanced", "deep"] as const) {
+      const v = tierRec[key];
+      if (typeof v !== "string" || v.length === 0) {
+        throw new InvalidProviderDefinitionError(
+          `\`tiers.${key}\` must be a non-empty string when tiers are declared`,
+          extensionId,
+          def,
+        );
+      }
+    }
+  }
+
+  return def as ProviderDefinition;
+};


### PR DESCRIPTION
## Summary

Phase 2 of ADR-0025. Wires the ProviderRegistry from Phase 1 into the extension system (ADR-0023). Operators can drop a provider extension into \`<root>/extensions/\` and it becomes a first-class \`llm.provider\` option without any harness patching.

## What shipped

- **Extension API hook** — \`MurmurationPluginApi.registerProvider(def)\`. Extensions pass a \`ProviderDefinition\` (from \`@murmurations-ai/llm\`); the daemon boot path validates and registers it.
- **Runtime validator** — \`validateProviderDefinition(def, extensionId)\` in \`@murmurations-ai/llm\`. Throws \`InvalidProviderDefinitionError\` with a precise reason for any malformed field. Enforced at the boot boundary so extensions written in plain JS can't corrupt the registry.
- **Boot integration** — \`packages/cli/src/boot.ts\` constructs a ProviderRegistry, seeds built-ins, loads extensions with \`onRegisterProvider\`, logs each registration, and emits a \`daemon.providers.roster\` event with the final provider list.
- **\`murmuration providers list\`** — new CLI command. Shows id / display name / env key / tier defaults. JSON mode via \`--json\`. Static view (built-ins only) for now; a daemon RPC for the live view is Phase 3.
- **Worked example** — \`examples/extensions/mistral/\` with manifest + \`index.mjs\`. Copy-paste reference for Groq, Bedrock, xAI, Perplexity, Vertex AI, DeepSeek, Cerebras, etc.

## Test plan

- [x] \`pnpm run build\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test\` — 526 passed (11 new)
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm run lint\` — 0 errors, 19 warnings (all pre-existing)

## Review focus

- Is the \`ExtensionProviderDefinition = unknown\` + runtime validator the right boundary? Alternative: import \`ProviderDefinition\` into core with a type-only import (that may also work given \`LanguageModel\` is only referenced in \`create\`).
- Is \`murmuration providers list\` showing built-ins only acceptable for Phase 2, or should it error out until a live-daemon RPC lands?
- Does the Mistral example strike the right balance between minimal and educational?

## Not in this PR

- Live-daemon \`providers list\` (needs a \`providers.list\` socket RPC)
- Boot-time validation of \`harness.yaml llm.provider\` against the registered roster
- More shipped example extensions (Groq, Bedrock, Vertex, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)