### PR TITLE
feat: per-agent plugin declarations + runtime gating

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -828,8 +828,37 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     providers: providerRegistry.list().map((p) => p.id),
   });
 
-  // Collect all extension tools into a flat array for the runner
+  // Collect all extension tools into a flat array — used by group
+  // meetings (where any member may invoke any plugin) and as the
+  // fallback for agents whose role.md declares no `plugins:`.
   const extensionTools = loadedExtensions.flatMap((ext) => ext.tools);
+
+  /**
+   * Filter the loaded extensions by an agent's declared `plugins:`
+   * (ADR-0023). Returns a flat tool array ready to hand to the runner.
+   *
+   * Matching rule: an agent's `provider` string matches an extension
+   * id directly (e.g. `"web-search"`) OR via its last path segment
+   * (e.g. `"@murmurations-ai/web-search"` → `"web-search"`). This lets
+   * role.md declarations use either the bare plugin id or the
+   * scoped-npm-style form.
+   *
+   * Backward compat: when `agent.plugins` is empty, return all loaded
+   * extension tools (matches pre-gating behavior).
+   */
+  const selectExtensionToolsFor = (
+    agent: RegisteredAgent,
+  ): readonly (typeof extensionTools)[number][] => {
+    if (agent.plugins.length === 0) return extensionTools;
+    const declared = new Set<string>();
+    for (const p of agent.plugins) {
+      declared.add(p.provider);
+      const parts = p.provider.split("/");
+      const last = parts[parts.length - 1];
+      if (last !== undefined && parts.length > 1) declared.add(last);
+    }
+    return loadedExtensions.filter((ext) => declared.has(ext.id)).flatMap((ext) => ext.tools);
+  };
 
   // -------------------------------------------------------------------
   // Per-agent composition (Phase 2D3)
@@ -973,12 +1002,15 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               }
               return candidate as AgentRunner<InProcessRunnerClients>;
             } catch {
-              // No custom runner — use the built-in default runner
+              // No custom runner — use the built-in default runner.
+              // Per-agent plugin gating: filter extension tools by the
+              // agent's declared plugins (role.md `plugins:`).
               const { createDefaultRunner } = await import("@murmurations-ai/core");
+              const agentTools = selectExtensionToolsFor(capturedAgent);
               return createDefaultRunner(
                 capturedAgentDir,
                 [],
-                extensionTools.length > 0 ? { extensionTools } : {},
+                agentTools.length > 0 ? { extensionTools: agentTools } : {},
                 exampleRoot,
               ) as unknown as AgentRunner<InProcessRunnerClients>;
             }

--- a/packages/cli/src/command-executor.test.ts
+++ b/packages/cli/src/command-executor.test.ts
@@ -77,6 +77,7 @@ const makeRegisteredAgent = (id: string, groups: string[] = []): RegisteredAgent
     budget: { maxCostMicros: 100000, maxGithubApiCalls: 10, onBreach: "warn" as const },
     secrets: { required: [], optional: [] },
     tools: { mcp: [], cli: [] },
+    plugins: [],
   };
 };
 

--- a/packages/core/src/daemon/daemon.test.ts
+++ b/packages/core/src/daemon/daemon.test.ts
@@ -93,6 +93,7 @@ const helloWorld: RegisteredAgent = {
     optional: [],
   },
   tools: { mcp: [], cli: [] },
+  plugins: [],
 };
 
 describe("Daemon", () => {

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -179,6 +179,16 @@ export interface RegisteredAgent {
     }[];
     readonly cli: readonly string[];
   };
+
+  /**
+   * OpenClaw-compatible plugins the agent declares as dependencies
+   * (ADR-0023). Today this is declarative — plugins load daemon-wide
+   * and all agents see every plugin-contributed tool. Future per-agent
+   * gating will consult this field to filter what each agent sees.
+   */
+  readonly plugins: readonly {
+    readonly provider: string;
+  }[];
 }
 
 /**
@@ -259,6 +269,8 @@ export const registeredAgentFromLoadedIdentity = (
     cli: frontmatter.tools.cli,
   };
 
+  const plugins = frontmatter.plugins.map((p) => ({ provider: p.provider }));
+
   return {
     agentId: chain.agentId.value,
     displayName: frontmatter.name,
@@ -274,6 +286,7 @@ export const registeredAgentFromLoadedIdentity = (
     budget,
     secrets,
     tools,
+    plugins,
   };
 };
 

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -462,6 +462,50 @@ describe("roleFrontmatterSchema (ADR-0016 extensions)", () => {
     expect(loaded.frontmatter.tools.mcp[1]?.env).toEqual({ GITHUB_TOKEN: "$GITHUB_TOKEN" });
     expect(loaded.frontmatter.tools.cli).toEqual(["gh", "gcloud"]);
   });
+
+  it("plugins defaults to empty when omitted (backwards compat)", async () => {
+    await writeMinimalFixture(
+      "no-plugins",
+      ['agent_id: "no-plugins"', 'name: "No Plugins"', "model_tier: fast"].join("\n"),
+    );
+    const loader = new IdentityLoader({ rootDir });
+    const loaded = await loader.load("no-plugins");
+    expect(loaded.frontmatter.plugins).toEqual([]);
+  });
+
+  it("parses plugin declarations from role.md frontmatter (ADR-0023)", async () => {
+    await writeMinimalFixture(
+      "with-plugins",
+      [
+        'agent_id: "with-plugins"',
+        'name: "Plugin Agent"',
+        "model_tier: balanced",
+        "plugins:",
+        '  - provider: "@murmurations-ai/web-search"',
+        '  - provider: "custom-plugin"',
+      ].join("\n"),
+    );
+    const loader = new IdentityLoader({ rootDir });
+    const loaded = await loader.load("with-plugins");
+    expect(loaded.frontmatter.plugins).toHaveLength(2);
+    expect(loaded.frontmatter.plugins[0]?.provider).toBe("@murmurations-ai/web-search");
+    expect(loaded.frontmatter.plugins[1]?.provider).toBe("custom-plugin");
+  });
+
+  it("rejects malformed plugin entries (empty provider)", async () => {
+    await writeMinimalFixture(
+      "bad-plugins",
+      [
+        'agent_id: "bad-plugins"',
+        'name: "Bad"',
+        "model_tier: fast",
+        "plugins:",
+        '  - provider: ""',
+      ].join("\n"),
+    );
+    const loader = new IdentityLoader({ rootDir });
+    await expect(loader.load("bad-plugins")).rejects.toThrow(FrontmatterInvalidError);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -221,6 +221,20 @@ const toolsSchema = z
   })
   .default({ mcp: [], cli: [] });
 
+/** Plugin declarations — ADR-0023 extensions the agent wants to pull from.
+ *  Today these are loaded daemon-wide; this field is declarative so each
+ *  agent's plugin dependencies are visible in its role.md. Per-agent
+ *  plugin gating is a future enhancement. */
+const pluginsSchema = z
+  .array(
+    z
+      .object({
+        provider: z.string().min(1),
+      })
+      .strict(),
+  )
+  .default([]);
+
 /** Shape expected from `role.md` YAML frontmatter. Spec §5.3 + ADR-0016. */
 export const roleFrontmatterSchema = z.object({
   agent_id: z.string().min(1),
@@ -241,8 +255,13 @@ export const roleFrontmatterSchema = z.object({
   budget: budgetSchema,
   secrets: secretsSchema,
 
-  // ADR-0020 Phase 3: tool declarations
+  // ADR-0020 Phase 3: tool declarations (per-agent MCP + CLI)
   tools: toolsSchema,
+
+  // ADR-0023: plugin declarations — which OpenClaw-compatible plugins
+  // the agent relies on. Declarative today (plugins load daemon-wide);
+  // per-agent gating is a future enhancement.
+  plugins: pluginsSchema,
 });
 
 /** Parsed, validated shape of a `role.md` frontmatter block. */


### PR DESCRIPTION
## Summary

Agents can now declare the ADR-0023 plugins they rely on in \`role.md\`:

\`\`\`yaml
plugins:
  - provider: "@murmurations-ai/web-search"
\`\`\`

Runtime:
- Empty/omitted \`plugins\` → agent sees every loaded plugin's tools (backward compat)
- Non-empty → agent sees only tools from declared plugins

Matching rule: provider string matches extension id directly OR via last path segment (so \`@murmurations-ai/web-search\` resolves to extension id \`web-search\`).

## Tests

- 3 new identity-loader tests for the plugin schema
- 522 total (up from 519)
- \`pnpm run build\` / \`typecheck\` / \`test\` / \`format:check\` / \`lint\` all green

## Scope note

Group meetings keep the full tool set — meetings aren't single-agent wakes, and gating by union-of-members risks silent tool starvation. Can revisit if per-group plugin gating becomes a need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)