### PR TITLE
fix: restore directive close/delete/edit CLI subcommands (#111)

### DIFF
--- a/docs/proposals/01-execution-sandboxing.md
+++ b/docs/proposals/01-execution-sandboxing.md
@@ -1,0 +1,61 @@
+# Architectural Proposal 01: Execution Sandboxing (ContainerExecutor)
+
+## Context
+
+Currently, the Murmuration Harness relies on `SubprocessExecutor` and `InProcessExecutor` to run agent tasks. While human oversight (the "Source") sets boundaries, agents executing arbitrary code or shell commands directly on the host machine presents a severe security and stability risk. A hallucinated command like `rm -rf` or a compromised prompt via a GitHub issue could result in catastrophic data loss or system compromise.
+
+## Proposal
+
+Implement a `ContainerExecutor` (utilizing Docker, Podman, or a lightweight VM/microVM like Firecracker) to enforce strict execution sandboxing for all agent tasks. Alternatively or additionally, support a `WasmExecutor` for purely computational tasks compiled to WebAssembly.
+
+## Specifications
+
+### 1. The `ContainerExecutor` Interface
+
+Extend the existing `AgentExecutor` interface to support containerized execution.
+
+```typescript
+export interface ContainerExecutorConfig {
+  image: string; // e.g., 'murmuration/agent-base:latest'
+  memoryLimitMB: number;
+  cpuLimit: number;
+  networkMode: "none" | "host" | "bridge"; // default to 'none' unless explicitly required
+  volumeMounts: ReadonlyArray<{
+    hostPath: string;
+    containerPath: string;
+    readOnly: boolean;
+  }>;
+}
+
+export class ContainerExecutor implements AgentExecutor {
+  // Implements the spawn and execution logic by shelling out to docker/podman
+  // or using the Docker Engine API.
+}
+```
+
+### 2. Ephemeral Workspaces
+
+- Every agent wake creates a completely isolated, ephemeral directory on the host.
+- This directory is mounted into the container at a standard location (e.g., `/workspace`).
+- Once the execution finishes, artifacts are extracted to a safe location, and the ephemeral directory is purged.
+
+### 3. Network Restrictions
+
+- By default, the container should have NO network access (`--network none`).
+- If an agent needs to fetch data or push code, network access must be explicitly granted via configuration or temporarily proxied through the host via a tightly controlled allowlist proxy.
+
+### 4. Tool Execution Proxy
+
+- Tools invoked by the LLM (e.g., `bash`, `read`, `write`) are not executed by the daemon directly.
+- Instead, the daemon serializes the tool call, sends it to a lightweight agent-runner inside the container, and awaits the stdout/stderr response.
+
+## Trade-offs
+
+- **Pros:** Massive security improvement; protects the human Source's machine; reproducible environments; prevents dependency collisions between agents.
+- **Cons:** Slower startup time for agent wakes (mitigated by keeping hot containers or using microVMs); requires Docker/Podman to be installed on the host machine; more complex logging and debugging.
+
+## Next Steps
+
+1. Create a proof-of-concept `ContainerExecutor` using the Docker CLI.
+2. Define a base Docker image (`murmuration-agent-base`) containing essential tools (git, node, python).
+3. Update `Daemon` to route tasks to `ContainerExecutor` based on harness configuration.

--- a/docs/proposals/02-system-of-record-abstraction.md
+++ b/docs/proposals/02-system-of-record-abstraction.md
@@ -1,0 +1,63 @@
+# Architectural Proposal 02: Abstraction of System of Record
+
+## Context
+
+The Murmuration Harness currently hardcodes GitHub as the System of Record. Action items are translated into GitHub issues, labels are used for assignment (`assigned:<agentId>`), and the `@murmurations-ai/github` package is deeply intertwined with the core logic. While GitHub is an excellent default, this tight coupling limits the framework's enterprise viability where tools like Linear, Jira, GitLab, or Notion are the centers of gravity.
+
+## Proposal
+
+Introduce a generic `CollaborationProvider` (Adapter/Port) interface in `@murmurations-ai/core`. Move all GitHub-specific logic into an implementation of this interface (e.g., `GitHubCollaborationProvider`).
+
+## Specifications
+
+### 1. The `CollaborationProvider` Interface
+
+Define a standardized set of asynchronous capabilities that any System of Record must provide.
+
+```typescript
+// Core abstractions
+export type TaskId = string & { readonly __brand: unique symbol };
+export type AgentId = string & { readonly __brand: unique symbol };
+
+export interface TaskItem {
+  id: TaskId;
+  title: string;
+  description: string;
+  status: "open" | "in_progress" | "done" | "blocked";
+  assignedTo?: AgentId;
+  metadata: Record<string, unknown>; // For provider-specific data (e.g., GH issue #)
+}
+
+export interface CollaborationProvider {
+  // Task Management
+  createTask(task: Omit<TaskItem, "id">): Promise<TaskItem>;
+  updateTask(id: TaskId, updates: Partial<TaskItem>): Promise<TaskItem>;
+  getAssignedTasks(agentId: AgentId): Promise<ReadonlyArray<TaskItem>>;
+
+  // Signaling / Communication
+  addComment(id: TaskId, content: string): Promise<void>;
+
+  // Governance / Meeting outputs
+  publishMeetingNotes(groupId: string, content: string): Promise<string>;
+}
+```
+
+### 2. Signal Aggregator Decoupling
+
+The `SignalAggregator` must be updated to consume arrays of `CollaborationProvider`. It will query all configured providers for pending signals/tasks and normalize them into a standard `SignalBundle` for the agents.
+
+### 3. Action Translation
+
+When an agent or group meeting outputs JSON actions, the `ActionTranslator` will route the action to the appropriate provider based on the context or explicit configuration (e.g., "Create a Jira ticket").
+
+## Trade-offs
+
+- **Pros:** Enables enterprise adoption; avoids vendor lock-in; allows "polyglot" murmuration operations (e.g., engineering tasks in Linear, HR tasks in Notion); aligns with Clean Architecture principles.
+- **Cons:** The lowest common denominator problem (the interface might omit powerful provider-specific features); requires writing mapping layers for every new integration; refactoring the current GitHub-centric code will touch many files.
+
+## Next Steps
+
+1. Extract the `CollaborationProvider` interface in `@murmurations-ai/core`.
+2. Wrap the existing `@murmurations-ai/github` functionality into a `GitHubCollaborationProvider`.
+3. Swap direct GitHub client calls in the `Daemon` and `SignalAggregator` with calls to the interface.
+4. Implement a lightweight `LocalDiskCollaborationProvider` for testing without network calls.

--- a/docs/proposals/03-observability-tracing.md
+++ b/docs/proposals/03-observability-tracing.md
@@ -1,0 +1,51 @@
+# Architectural Proposal 03: Deep Observability and Tracing
+
+## Context
+
+Debugging a multi-agent system is inherently difficult. When a murmuration gets stuck in an infinite loop, hallucinates a strange response, or makes a flawed governance decision, identifying the root cause is challenging. While the TUI dashboard provides a point-in-time view, understanding the historical flow requires distributed tracing.
+
+## Proposal
+
+Instrument the entire `@murmurations-ai/core` and related packages with **OpenTelemetry (OTel)**. Every group meeting, agent wake, LLM prompt, and tool execution should generate linked distributed traces, allowing export to standard observability backends (e.g., Datadog, Honeycomb, LangSmith).
+
+## Specifications
+
+### 1. Span Hierarchy
+
+Define a standardized trace hierarchy:
+
+- **Trace:** An entire "Wake Cycle" or "Group Meeting".
+- **Parent Spans:** `Daemon.handleWake`, `GroupMeeting.facilitate`.
+- **Child Spans:** `SignalAggregator.fetch`, `AgentExecutor.spawn`, `LLMClient.generateText`, `Tool.execute`.
+
+### 2. Semantic Conventions
+
+Adhere to standard OpenTelemetry semantic conventions and define Murmuration-specific attributes:
+
+- `murmuration.agent.id`: The ID of the agent executing.
+- `murmuration.group.id`: The ID of the group meeting.
+- `murmuration.governance.state`: The current state of the governance machine.
+- `llm.prompt.tokens`: Input token count.
+- `llm.completion.tokens`: Output token count.
+
+### 3. Log Exporter Integration
+
+- Modify the existing `logger` utility to attach the active `trace_id` and `span_id` to all structured logs.
+- Ensure sensitive data (like `SecretValue`) remains scrubbed before being attached to span attributes, reusing the existing `scrubLogRecord()` logic.
+
+### 4. Visualization & Tooling
+
+- Provide a default OTLP (OpenTelemetry Protocol) exporter configuration targeting a local Jaeger or Prometheus instance for local development.
+- Provide easy bridges to LLM-specific observability platforms like Braintrust or Langfuse for prompt/eval tracking.
+
+## Trade-offs
+
+- **Pros:** Unprecedented visibility into agent decision-making; easier debugging of cascading failures; capability to run performance and cost analytics over time.
+- **Cons:** Adds dependency bloat (OTel SDKs can be heavy); potential performance overhead if tracing everything; requires discipline to instrument new modules correctly.
+
+## Next Steps
+
+1. Install `@opentelemetry/api` and `@opentelemetry/sdk-node` into `@murmurations-ai/core`.
+2. Wrap the `Daemon.#handleWake` and `runGroupWake()` in root spans.
+3. Propagate context down to the `@murmurations-ai/llm` client to capture prompt generation spans.
+4. Document how to run a local Jaeger instance alongside the daemon.

--- a/docs/proposals/04-durable-execution.md
+++ b/docs/proposals/04-durable-execution.md
@@ -1,0 +1,42 @@
+# Architectural Proposal 04: Durable Execution State
+
+## Context
+
+The `Daemon` currently relies on an in-memory `TimerScheduler` and local `AgentStateStore` files to manage execution state. If the daemon process crashes or the host machine restarts during a long-running agent task (e.g., compiling a large codebase or scraping multiple web pages), the progress is lost. The agent must start over on the next wake, which wastes compute, tokens, and time.
+
+## Proposal
+
+Adopt a **Durable Execution** paradigm for the `AgentExecutor`. Using concepts similar to Temporal.io or AWS Step Functions, ensure that execution state (including intermediate LLM steps and tool outputs) is durably checkpointed so that an agent can resume exactly where it left off after an interruption.
+
+## Specifications
+
+### 1. The Execution Log
+
+Instead of just executing commands, the `AgentExecutor` should maintain an append-only "Execution History" log for each wake.
+
+- Every input (prompt), output (completion), and tool result is written to this log _before_ proceeding to the next step.
+- If the process crashes, the `Daemon` reads the log upon restart and "replays" the deterministic steps to reconstruct the agent's memory state without re-calling the LLM or re-running completed tools.
+
+### 2. Checkpointing
+
+- Introduce a `yield` or `checkpoint` primitive in the `Executor` interface.
+- Long-running loops inside the agent should periodically checkpoint their state.
+
+### 3. Idempotent Tool Execution
+
+- Tools must be categorized. "Safe" tools (like `read_file`) can be re-run if needed. "Mutating" tools (like `github_commit` or `send_email`) must check the execution log to ensure they are not executed twice during a replay scenario.
+
+### 4. Storage Backend
+
+- Use a lightweight embedded database (like SQLite) or a structured JSONL append-only file per task to store the Execution History. The single-writer principle defined in the architecture standards must apply here.
+
+## Trade-offs
+
+- **Pros:** Massive reliability boost; eliminates wasted tokens on aborted runs; essential for long-running autonomous tasks; gracefully handles rate-limits by sleeping and resuming.
+- **Cons:** Major architectural shift for the execution engine; requires rigorous handling of non-deterministic tool outputs; higher disk I/O due to constant checkpointing.
+
+## Next Steps
+
+1. Design the schema for the Execution History log.
+2. Implement an append-only JSONL logger for the `AgentExecutor`.
+3. Create a prototype where an agent process is killed halfway through a task, and the Daemon successfully resumes it from the exact LLM turn by reading the log.

--- a/docs/proposals/05-multi-tiered-memory.md
+++ b/docs/proposals/05-multi-tiered-memory.md
@@ -1,0 +1,51 @@
+# Architectural Proposal 05: Multi-tiered Memory Architecture
+
+## Context
+
+Currently, the Murmuration Harness relies on the System of Record (e.g., GitHub Issues and Action Items) as its sole form of memory. This functions as "Working Memory" or "Episodic Memory" for the current task. However, as a project grows, agents lose the broader context of why past decisions were made, how similar bugs were solved, or the specific conventions of the codebase that aren't explicitly written in a prompt.
+
+## Proposal
+
+Formalize a multi-tiered memory architecture within the harness. Maintain the current Working Memory (GitHub issues/signals) but introduce a **Semantic/Vector Memory** tier. This tier will automatically index historical decisions, completed tasks, meeting notes, and documentation, allowing agents to query past experiences.
+
+## Specifications
+
+### 1. Memory Tier Definitions
+
+- **Working Memory (Tier 1):** The current `SignalBundle` containing active issues, PRs, and immediate action items. Loaded directly into the system prompt context.
+- **Semantic Memory (Tier 2):** A Vector Store holding embeddings of all completed tasks, merged PR descriptions, and past governance decisions.
+
+### 2. The `MemoryStore` Interface
+
+Introduce an interface in `@murmurations-ai/core`:
+
+```typescript
+export interface MemoryStore {
+  // Indexing new knowledge
+  indexDocument(id: string, content: string, metadata: Record<string, unknown>): Promise<void>;
+
+  // Retrieval
+  searchSimilar(query: string, limit?: number): Promise<Array<{ content: string; score: number }>>;
+}
+```
+
+### 3. Automated Knowledge Capture
+
+- When an action item is marked `closed` or `done`, the `Daemon` automatically extracts the summary and solution, generates an embedding via `@murmurations-ai/llm`, and indexes it in the `MemoryStore`.
+- When a group meeting concludes, the resulting `content` (meeting minutes) is also indexed.
+
+### 4. Agent Retrieval Tool
+
+- Provide agents with a `search_memory` tool. If an agent is stuck, it can explicitly query the vector store (e.g., `search_memory("How did we fix the auth token bug last month?")`).
+
+## Trade-offs
+
+- **Pros:** Prevents agents from repeating mistakes; allows new agents to "onboard" to a murmuration by searching history; reduces token usage by not cramming all history into the prompt.
+- **Cons:** Introduces complexity of managing a vector database (e.g., ChromaDB, SQLite-vss, or pgvector); cost of generating embeddings for all historical data.
+
+## Next Steps
+
+1. Define the `MemoryStore` interface.
+2. Implement an adapter for a local, file-based vector store (e.g., SQLite with vector extension or a simple local JSON+cosine similarity approach for the MVP).
+3. Update the `ActionTranslator` or `Daemon` to hook into task completion events to trigger indexing.
+4. Add the `search_memory` tool to the default agent prompt.

--- a/docs/proposals/06-mcp-integration.md
+++ b/docs/proposals/06-mcp-integration.md
@@ -1,0 +1,51 @@
+# Architectural Proposal 06: Model Context Protocol (MCP) Integration
+
+## Context
+
+The README mentions that the harness is "OpenClaw-compatible" for extensions. While having an extension system is crucial for adding new tools, building custom integrations for every API (Slack, Postgres, Figma, Linear) is a massive maintenance burden. The industry is rapidly coalescing around the **Model Context Protocol (MCP)** as the standard way to expose local files, external APIs, and tools to LLM-powered agents.
+
+## Proposal
+
+Adopt the Model Context Protocol (MCP) natively within `@murmurations-ai/core`. Allow the harness to connect to any standard MCP server. This instantly grants Murmuration agents access to a vast, growing ecosystem of pre-built tools without writing any bespoke extension code.
+
+## Specifications
+
+### 1. MCP Client Integration
+
+- Implement an MCP Client within the `Daemon` or `AgentExecutor` initialization.
+- The `harness.yaml` config should allow users to define a list of MCP servers (either via stdio or SSE/HTTP).
+
+```yaml
+# harness.yaml snippet
+mcpServers:
+  - name: "postgres"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+  - name: "slack"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-slack"]
+```
+
+### 2. Tool Translation
+
+- The core must translate the tools exposed by the MCP servers into the format required by the underlying LLM providers in `@murmurations-ai/llm` (e.g., Anthropic tool use format, OpenAI function calling format).
+
+### 3. Resource and Prompt Access
+
+- In addition to Tools, MCP provides Resources (e.g., database schemas) and Prompts. The `SignalAggregator` or the `AgentContext` builder should be able to fetch relevant Resources from the MCP servers to inject into the agent's context window on wake.
+
+### 4. Deprecation Path
+
+- Once MCP is fully supported, evaluate deprecating the bespoke "OpenClaw" extension format in favor of recommending developers build standard MCP servers.
+
+## Trade-offs
+
+- **Pros:** Instant access to hundreds of community-built tools; aligns the harness with the broader AI engineering ecosystem; simplifies the internal extension architecture.
+- **Cons:** MCP is a relatively new protocol and still evolving; managing the lifecycles of multiple external MCP server processes adds complexity to the `Daemon`.
+
+## Next Steps
+
+1. Add the official `@modelcontextprotocol/sdk` to `@murmurations-ai/core`.
+2. Update the `Daemon` to parse `mcpServers` from the config and spin up the stdio processes.
+3. Bridge the MCP `ListToolsRequest` to the LLM client's tool configuration payload.
+4. Test with a standard community MCP server (e.g., the local filesystem server or SQLite server).

--- a/packages/cli/src/directive.test.ts
+++ b/packages/cli/src/directive.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `murmuration directive` — CLI-verb tests.
+ *
+ * Covers the close / delete / edit manage subcommands that were
+ * silently dropped in PR #104 and restored in PR #111. These tests
+ * lock the dispatch shape so a future refactor can't lose them again.
+ *
+ * The tests exercise the full `runDirective` entry point against a
+ * fresh tmp murmuration — no daemon, no network. Local collaboration
+ * provider only.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runDirective } from "./directive.js";
+
+let root = "";
+
+const writeLocalItem = (id: string, state: "open" | "closed" = "open"): void => {
+  writeFileSync(
+    join(root, ".murmuration", "items", `${id}.json`),
+    JSON.stringify(
+      {
+        id,
+        title: `[DIRECTIVE] test ${id}`,
+        state,
+        labels: ["source-directive", "scope:all"],
+        createdAt: "2026-04-19T00:00:00.000Z",
+        updatedAt: "2026-04-19T00:00:00.000Z",
+        comments: [],
+        body: "test body",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+};
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), `directive-test-${randomUUID().slice(0, 8)}-`));
+  mkdirSync(join(root, "murmuration"), { recursive: true });
+  mkdirSync(join(root, ".murmuration", "items"), { recursive: true });
+  // Minimal harness.yaml — local provider so no GitHub setup needed
+  writeFileSync(
+    join(root, "murmuration", "harness.yaml"),
+    `collaboration:\n  provider: "local"\n`,
+    "utf8",
+  );
+});
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("runDirective — manage subcommands (restoration of regression fixed by #111)", () => {
+  it("close flips the item state to closed via the local provider", async () => {
+    writeLocalItem("abc12345");
+    await runDirective(["close", "abc12345"], root);
+
+    const raw = JSON.parse(
+      readFileSync(join(root, ".murmuration", "items", "abc12345.json"), "utf8"),
+    ) as { state: string };
+    expect(raw.state).toBe("closed");
+  });
+
+  it("close finds the subcommand even when --root/--name flags precede it", async () => {
+    writeLocalItem("def67890");
+    // args: --root <path> close <id>  — the verb is not at position 0
+    await runDirective(["--root", root, "close", "def67890"], root);
+
+    const raw = JSON.parse(
+      readFileSync(join(root, ".murmuration", "items", "def67890.json"), "utf8"),
+    ) as { state: string };
+    expect(raw.state).toBe("closed");
+  });
+
+  it("delete removes the local item file", async () => {
+    writeLocalItem("ff000001");
+    const itemPath = join(root, ".murmuration", "items", "ff000001.json");
+    expect(existsSync(itemPath)).toBe(true);
+
+    await runDirective(["delete", "ff000001"], root);
+    expect(existsSync(itemPath)).toBe(false);
+  });
+
+  it("close / delete / edit require an <id> argument", async () => {
+    for (const verb of ["close", "delete", "edit"] as const) {
+      await expect(runDirective([verb], root)).rejects.toThrow(/<id> is required/);
+    }
+  });
+
+  it("delete refuses when the directive file does not exist", async () => {
+    await expect(runDirective(["delete", "nonexistent"], root)).rejects.toThrow(/not found/);
+  });
+
+  it("create path still requires a scope (regression guard against the fix)", async () => {
+    // A bare positional arg that is NOT a manage subcommand should still
+    // fall through to the scope-required create path.
+    await expect(runDirective(["hello"], root)).rejects.toThrow(/specify --agent|scope/);
+  });
+
+  it("edit opens $EDITOR on the local item file", async () => {
+    writeLocalItem("aaaa1234");
+    const originalEditor = process.env.EDITOR;
+    process.env.EDITOR = "true"; // `true` is a POSIX command that exits 0; doesn't edit anything
+
+    try {
+      await runDirective(["edit", "aaaa1234"], root);
+    } finally {
+      if (originalEditor === undefined) delete process.env.EDITOR;
+      else process.env.EDITOR = originalEditor;
+    }
+    // If we got here without throwing, the edit dispatcher ran `$EDITOR <path>` successfully.
+    expect(true).toBe(true);
+  });
+});
+
+describe("runDirective — existing create path stays intact", () => {
+  it("creates an item when given --all + body", async () => {
+    await runDirective(["--all", "propose a weekly wake cadence"], root);
+
+    // Read back the created item — id is random so just find the first file
+    const files = readdirSync(join(root, ".murmuration", "items"));
+    const created = files.find((f) => f.endsWith(".json"));
+    expect(created).toBeDefined();
+    const item = JSON.parse(
+      readFileSync(join(root, ".murmuration", "items", created ?? ""), "utf8"),
+    ) as { title: string; labels: string[]; state: string };
+    expect(item.title).toMatch(/propose a weekly wake cadence/);
+    expect(item.labels).toContain("scope:all");
+    expect(item.state).toBe("open");
+  });
+});
+
+// Silence the console output the create path emits.
+const noop = (): void => {
+  /* swallow log output during tests */
+};
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(noop);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/packages/cli/src/directive.ts
+++ b/packages/cli/src/directive.ts
@@ -12,16 +12,97 @@
  *   murmuration directive --root ../my-murmuration --group content "Should this group hold meetings?"
  *   murmuration directive --root ../my-murmuration --all "Propose your ideal wake cadence"
  *   murmuration directive --root ../my-murmuration --list
+ *   murmuration directive --root ../my-murmuration close <id>
+ *   murmuration directive --root ../my-murmuration delete <id>   # local provider only
+ *   murmuration directive --root ../my-murmuration edit <id>     # local provider only
  */
 
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
 
 import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
+
+const MANAGE_SUBCOMMANDS = new Set(["close", "delete", "edit"]);
+
+/** Compute the local-provider path for a directive item by id. Local
+ *  items live as YAML frontmatter markdown files under
+ *  `<rootDir>/.murmuration/items/<id>.{json,md}`. Returns the first
+ *  match or `undefined` when no file exists. */
+const localItemPath = (rootDir: string, id: string): string | undefined => {
+  const itemsDir = join(rootDir, ".murmuration", "items");
+  for (const ext of ["json", "md"] as const) {
+    const candidate = join(itemsDir, `${id}.${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+};
 
 export const runDirective = async (args: readonly string[], rootDir: string): Promise<void> => {
   const root = resolve(rootDir);
 
-  // Determine scope
+  // -------------------------------------------------------------------
+  // Manage subcommands — close / delete / edit — handled first so they
+  // don't fall through to the scope-required create path. The
+  // subcommand may appear anywhere in argv (after `--root <path>` etc.),
+  // so we scan for the first known verb rather than trusting args[0].
+  // -------------------------------------------------------------------
+  const verbIdx = args.findIndex((a) => MANAGE_SUBCOMMANDS.has(a));
+  if (verbIdx >= 0) {
+    const verb = args[verbIdx] ?? "";
+    const id = args[verbIdx + 1];
+    if (!id || id.startsWith("--")) {
+      throw new Error(`murmuration directive ${verb}: <id> is required`);
+    }
+
+    if (verb === "close") {
+      let provider;
+      try {
+        ({ provider } = await buildCollaborationProvider(root));
+      } catch (err) {
+        if (err instanceof CollaborationBuildError) {
+          throw new Error(`murmuration directive close: ${err.message}`, { cause: err });
+        }
+        throw err;
+      }
+      const result = await provider.updateItemState({ id }, "closed");
+      if (!result.ok) {
+        throw new Error(
+          `${provider.displayName} error: ${result.error.code} — ${result.error.message}`,
+        );
+      }
+      console.log(`Directive ${id} closed.`);
+      return;
+    }
+
+    // delete and edit are local-provider-only — both operate on the
+    // on-disk JSON file directly. GitHub doesn't support true delete
+    // (only close), and editing a GitHub issue on the CLI is better
+    // served by `gh issue edit`.
+    const path = localItemPath(root, id);
+    if (!path) {
+      throw new Error(
+        `murmuration directive ${verb}: directive "${id}" not found in .murmuration/items/ ` +
+          `(${verb} works with the local collaboration provider; for GitHub use 'gh issue ${verb === "delete" ? "close" : "edit"}')`,
+      );
+    }
+
+    if (verb === "delete") {
+      await unlink(path);
+      console.log(`Directive ${id} deleted.`);
+      return;
+    }
+
+    // edit
+    const editor = process.env.EDITOR ?? "vi";
+    const { execSync } = await import("node:child_process");
+    execSync(`${editor} ${path}`, { stdio: "inherit" });
+    return;
+  }
+
+  // -------------------------------------------------------------------
+  // Scope determination for create / list
+  // -------------------------------------------------------------------
   const agentIdx = args.indexOf("--agent");
   const groupIdx = args.indexOf("--group");
   const allFlag = args.includes("--all");
@@ -40,7 +121,10 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
     scopeLabel = "scope:all";
     scopeDesc = "all agents";
   } else if (!args.includes("--list")) {
-    throw new Error("murmuration directive: specify --agent <id>, --group <id>, --all, or --list");
+    throw new Error(
+      "murmuration directive: specify --agent <id>, --group <id>, --all, --list, or a manage " +
+        "subcommand (close / delete / edit)",
+    );
   } else {
     scopeLabel = "";
     scopeDesc = "";

--- a/packages/init-skill/SKILL.md
+++ b/packages/init-skill/SKILL.md
@@ -29,26 +29,28 @@ Once the interview is complete, inform the user that you are synthesizing their 
 
 Use the `write` tool to generate the following exact file structure (relative to the current workspace), which complies with the v0.1 Murmuration Harness specification:
 
-*   **`murmuration/soul.md`**: Synthesize the Vision, Soul, and Domain answers into this single, unified constitutional document. Write the Soul sections in the first-person plural ("We believe...").
-*   **`governance/circles/`**: Create individual Markdown files for each circle defined by the user.
-*   **`agents/`**: For each agent identified, create a dedicated folder (e.g., `agents/[slug]/`). Inside each folder, generate:
-    *   **`agents/[slug]/soul.md`**: The agent's specific character, voice, and bright lines.
-    *   **`agents/[slug]/role.md`**: The agent's accountabilities, relationships, and schedule. 
+- **`murmuration/soul.md`**: Synthesize the Vision, Soul, and Domain answers into this single, unified constitutional document. Write the Soul sections in the first-person plural ("We believe...").
+- **`governance/circles/`**: Create individual Markdown files for each circle defined by the user.
+- **`agents/`**: For each agent identified, create a dedicated folder (e.g., `agents/[slug]/`). Inside each folder, generate:
+  - **`agents/[slug]/soul.md`**: The agent's specific character, voice, and bright lines.
+  - **`agents/[slug]/role.md`**: The agent's accountabilities, relationships, and schedule.
     **CRITICAL:** You must include the following YAML frontmatter at the top of every `role.md` file:
-    ```yaml
-    ---
-    agent_id: "[slug]"
-    name: "[Agent's full name]"
-    model_tier: "balanced"
-    soul_file: "agents/[slug]/soul.md"
-    ---
-    ```
+  ```yaml
+  ---
+  agent_id: "[slug]"
+  name: "[Agent's full name]"
+  model_tier: "balanced"
+  soul_file: "agents/[slug]/soul.md"
+  ---
+  ```
 
 **Formatting Guidelines for Generated Files:**
-*   Use clear Markdown with headers, bullet points, and bold text.
-*   Ensure the directory structure exactly matches the v0.1 Harness specification (`murmuration/`, `agents/`, `governance/circles/`).
+
+- Use clear Markdown with headers, bullet points, and bold text.
+- Ensure the directory structure exactly matches the v0.1 Harness specification (`murmuration/`, `agents/`, `governance/circles/`).
 
 ## Rules
-*   **NEVER ask multiple questions at once.**
-*   Do not rush. This is the most important conversation for the murmuration's foundation.
-*   Once generation is complete, provide a summary of the files created and tell the user they are ready to begin Phase 2 (Agent Identity Documents).
+
+- **NEVER ask multiple questions at once.**
+- Do not rush. This is the most important conversation for the murmuration's foundation.
+- Once generation is complete, provide a summary of the files created and tell the user they are ready to begin Phase 2 (Agent Identity Documents).


### PR DESCRIPTION
## Summary

Closes #111 — restores the \`close\` / \`delete\` / \`edit\` subcommands on \`murmuration directive\` that silently disappeared in the ADR-0021 refactor (PR #104).

### Restored

- \`murmuration directive close <id>\` — routes through \`CollaborationProvider.updateItemState(ref, \"closed\")\`. Works for both local and GitHub providers.
- \`murmuration directive delete <id>\` — removes the on-disk item file. Local-only; GitHub error message points operators at \`gh issue close\`.
- \`murmuration directive edit <id>\` — opens \`\$EDITOR\` on the local item file.

### Verified

- End-to-end on test02: created a smoke-test directive, closed it (state flipped), deleted it (file gone).
- 8 new unit tests locking the dispatch shape so a future refactor can't regress it again.
- 530 total tests passing (up from 522).

### Branch now contains two clean commits

1. \`fix: restore directive close/delete/edit CLI subcommands (#111)\` — the actual fix + tests
2. \`docs: add six architectural proposals for harness evolution\` — unrelated \`docs/proposals/\` content that was in the working tree

Each could be merged independently; filed together because the proposals landed on this branch before I split them.

### Gates

- \`pnpm run build\` — clean
- \`pnpm run typecheck\` — clean
- \`pnpm run lint\` — 0 errors, 19 pre-existing warnings
- \`pnpm run format:check\` — clean
- CI green on Node 20 + 22

Ships as v0.4.4 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)