### PR TITLE
fix: dashboard UX — real sparkline + missing-root guidance

### DIFF
--- a/packages/dashboard-tui/src/dashboard.ts
+++ b/packages/dashboard-tui/src/dashboard.ts
@@ -6,7 +6,8 @@
  */
 
 import { TUI, Text, ProcessTerminal } from "@mariozechner/pi-tui";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import {
   readPipelineState,
@@ -153,21 +154,17 @@ const renderCostSummary = (cost: CostSummary): string => {
     `  Today: ${bold(formatUsd(cost.todayMicros))} (${String(cost.todayWakes)}w)  ${dim("|")}  Week: ${formatUsd(cost.weekMicros)} (${String(cost.weekWakes)}w)  ${dim("|")}  Month: ${formatUsd(cost.monthMicros)} (${String(cost.monthWakes)}w)`,
   );
 
-  // Sparkline (last 7 days) with day count labels
+  // Sparkline (last 7 days) — real buckets from finishedAt timestamps,
+  // computed in readCostSummary (fixes #59: previously we distributed
+  // week wakes evenly across days 0-5, which misled Source about
+  // activity shape).
   const sparkChars = " ▁▂▃▄▅▆▇█";
-  const days: number[] = [];
+  const days: number[] = [...cost.wakesPerDay7d];
   const dayLabels: string[] = [];
   const now = new Date();
   for (let i = 6; i >= 0; i--) {
     const d = new Date(now.getTime() - i * 86_400_000);
     dayLabels.push(d.toISOString().slice(8, 10));
-    days.push(0);
-  }
-  if (cost.weekWakes > 0) {
-    const otherDays = cost.weekWakes - cost.todayWakes;
-    const perDay = otherDays > 0 ? Math.round(otherDays / 6) : 0;
-    for (let i = 0; i < 6; i++) days[i] = perDay;
-    days[6] = cost.todayWakes;
   }
   const maxDay = Math.max(...days, 1);
   const spark = days
@@ -258,6 +255,30 @@ const renderActivity = (entries: readonly ActivityEntry[]): string => {
 // Dashboard entry point
 // ---------------------------------------------------------------------------
 
+/** Full-screen preflight message shown when `.murmuration/` is absent
+ *  (fixes #61). Four empty panels with no explanation was worse than
+ *  no dashboard — a new operator had no signal about what was wrong. */
+const renderNoMurmurationDir = (root: string): string => {
+  const lines = [
+    "",
+    `  ${bold("Murmuration Dashboard")}`,
+    "",
+    `  ${red("No .murmuration/ directory found at:")}`,
+    `    ${root}`,
+    "",
+    `  ${dim("The dashboard reads daemon state from .murmuration/ under")}`,
+    `  ${dim("your murmuration root. It doesn't exist here yet.")}`,
+    "",
+    `  ${bold("To fix:")}`,
+    `    ${cyan("•")} cd to your murmuration root, then run murmuration-dashboard`,
+    `    ${cyan("•")} Or pass the correct path: ${dim("murmuration-dashboard --root <path>")}`,
+    `    ${cyan("•")} Run ${dim("murmuration start")} first if the daemon has never run here`,
+    "",
+    `  ${dim("[r] refresh  [q] quit")}`,
+  ];
+  return lines.join("\n");
+};
+
 export const startDashboard = async (rootDir: string): Promise<void> => {
   const root = resolve(rootDir);
   const terminal = new ProcessTerminal();
@@ -267,6 +288,12 @@ export const startDashboard = async (rootDir: string): Promise<void> => {
   tui.addChild(display);
 
   const refresh = async (): Promise<void> => {
+    if (!existsSync(join(root, ".murmuration"))) {
+      display.setText(renderNoMurmurationDir(root));
+      tui.requestRender();
+      return;
+    }
+
     const [pipeline, activity, governance, cost] = await Promise.all([
       readPipelineState(root),
       readRecentActivity(root),

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -478,6 +478,10 @@ export interface CostSummary {
   readonly weekWakes: number;
   readonly monthMicros: number;
   readonly monthWakes: number;
+  /** Wake counts for the last 7 calendar days, oldest first. Index 6
+   *  is today. Bucketed by `finishedAt` date (local time) — real data,
+   *  not a uniform distribution. */
+  readonly wakesPerDay7d: readonly number[];
   readonly perAgent: readonly { agentId: string; totalMicros: number; wakes: number }[];
 }
 
@@ -494,6 +498,7 @@ export const readCostSummary = async (rootDir: string): Promise<CostSummary> => 
       weekWakes: 0,
       monthMicros: 0,
       monthWakes: 0,
+      wakesPerDay7d: [0, 0, 0, 0, 0, 0, 0],
       perAgent: [],
     };
   }
@@ -502,6 +507,15 @@ export const readCostSummary = async (rootDir: string): Promise<CostSummary> => 
   const todayStr = now.toISOString().slice(0, 10);
   const weekAgo = new Date(now.getTime() - 7 * 86_400_000);
   const monthAgo = new Date(now.getTime() - 30 * 86_400_000);
+
+  // 7-day wake histogram, index 0 = 6 days ago, index 6 = today.
+  // Keyed by YYYY-MM-DD (ISO date) so finishedAt lookups are O(1).
+  const wakesPerDay: number[] = [0, 0, 0, 0, 0, 0, 0];
+  const dayKeys: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    dayKeys.push(new Date(now.getTime() - i * 86_400_000).toISOString().slice(0, 10));
+  }
+  const dayKeyIndex = new Map(dayKeys.map((k, i) => [k, i]));
 
   let todayMicros = 0,
     todayWakes = 0,
@@ -529,7 +543,8 @@ export const readCostSummary = async (rootDir: string): Promise<CostSummary> => 
           agentTotal += cost;
           agentWakes++;
           if (finishedAt) {
-            if (finishedAt.toISOString().slice(0, 10) === todayStr) {
+            const dateKey = finishedAt.toISOString().slice(0, 10);
+            if (dateKey === todayStr) {
               todayMicros += cost;
               todayWakes++;
             }
@@ -540,6 +555,11 @@ export const readCostSummary = async (rootDir: string): Promise<CostSummary> => 
             if (finishedAt >= monthAgo) {
               monthMicros += cost;
               monthWakes++;
+            }
+            const idx = dayKeyIndex.get(dateKey);
+            if (idx !== undefined) {
+              const current = wakesPerDay[idx] ?? 0;
+              wakesPerDay[idx] = current + 1;
             }
           }
         } catch {
@@ -552,5 +572,14 @@ export const readCostSummary = async (rootDir: string): Promise<CostSummary> => 
     if (agentWakes > 0) perAgent.push({ agentId, totalMicros: agentTotal, wakes: agentWakes });
   }
 
-  return { todayMicros, todayWakes, weekMicros, weekWakes, monthMicros, monthWakes, perAgent };
+  return {
+    todayMicros,
+    todayWakes,
+    weekMicros,
+    weekWakes,
+    monthMicros,
+    monthWakes,
+    wakesPerDay7d: wakesPerDay,
+    perAgent,
+  };
 };


### PR DESCRIPTION
## Summary

Two small dashboard DX fixes, both from the earlier design-review passes:

- **#59 — Sparkline fabricates shape.** Previously `renderCostSummary` distributed \`weekWakes - todayWakes\` evenly across days 0–5, producing a flat line even when all activity was yesterday. Now \`readCostSummary\` exposes a real 7-day histogram (\`wakesPerDay7d\`) bucketed from \`finishedAt\` timestamps in \`index.jsonl\`, and the renderer reads from it directly. Option A from the issue.
- **#61 — No --root guidance on missing .murmuration/.** The dashboard used to render four empty panels with no explanation when \`.murmuration/\` was absent. Now it renders a single full-screen panel with the path it tried, three fix paths (cd, --root, or run \`murmuration start\`), and the \`r\`/\`q\` keys still work so the operator can refresh after starting the daemon.

## Test plan

- [x] \`pnpm run check\` — 534 tests passing, no new lint errors
- [x] Build verifies TypeScript strictness across the histogram typing
- [ ] Manual: run \`murmuration-dashboard --root /tmp/nonexistent\` — confirm the guidance panel renders
- [ ] Manual: run against an active murmuration and confirm the sparkline reflects actual day-by-day wake counts

Closes #59, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)