### PR TITLE
feat(spirit): add setup-github skill to guide operators

### DIFF
--- a/packages/cli/src/default-agent/role.md
+++ b/packages/cli/src/default-agent/role.md
@@ -27,6 +27,14 @@ secrets:
   required: []
   optional: ["GITHUB_TOKEN"]
 
+tools:
+  mcp:
+    - name: github
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_TOKEN: "$GITHUB_TOKEN"
+
 plugins: []
 ---
 

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -245,13 +245,13 @@ export const runInit = async (targetArg?: string): Promise<void> => {
   // If local collaboration, remove the github MCP tool from the default agent role.md
   if (collaboration === "local") {
     const defaultRolePath = join(targetDir, "murmuration", "default-agent", "role.md");
-    if (fs.existsSync(defaultRolePath)) {
-      let roleContent = fs.readFileSync(defaultRolePath, "utf8");
-      roleContent = roleContent.replace(
-        /tools:\n  mcp:\n    - name: github\n      command: npx\n      args: \["-y", "@modelcontextprotocol\/server-github"\]\n      env:\n        GITHUB_TOKEN: "\$GITHUB_TOKEN"\n/g,
+    if (existsSync(defaultRolePath)) {
+      const roleContent = await readFile(defaultRolePath, "utf8");
+      const stripped = roleContent.replace(
+        /tools:\n {2}mcp:\n {4}- name: github\n {6}command: npx\n {6}args: \["-y", "@modelcontextprotocol\/server-github"\]\n {6}env:\n {8}GITHUB_TOKEN: "\$GITHUB_TOKEN"\n/g,
         "",
       );
-      fs.writeFileSync(defaultRolePath, roleContent);
+      await writeFile(defaultRolePath, stripped);
     }
   }
 
@@ -298,7 +298,7 @@ _What does this murmuration optimize for?_
       ? `collaboration:\n  provider: "${collaboration}"\n  repo: "${githubOwner}/${githubRepoName}"`
       : `collaboration:\n  provider: "${collaboration}"`;
 
-  const productName = productPath.split("/").pop() || "workspace";
+  const productName = productPath.split("/").pop() ?? "workspace";
   const productBlock = productPath
     ? `\n\nproducts:\n  - name: "${productName}"\n    repo: "${productPath}"`
     : "";

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -379,8 +379,7 @@ wake_schedule:
   ${formatScheduleYaml(agent.schedule)}
 
 signals:
-  sources:
-    - "github-issue"
+  sources:${collaboration === "github" ? '\n    - "github-issue"' : ""}
     - "private-note"${ghScopes}
 
 github:
@@ -393,7 +392,7 @@ budget:
 
 secrets:
   required: [${secretName ? `"${secretName}"` : ""}]
-  optional: ["GITHUB_TOKEN"]
+  ${collaboration === "github" ? '\n  optional: ["GITHUB_TOKEN"]' : ""}
 ---
 
 # ${agent.name} — Role

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -177,16 +177,26 @@ export const runInit = async (targetArg?: string): Promise<void> => {
   );
   const defaultProvider = normalizeProvider(defaultProviderInput, "gemini");
 
-  // 4. GitHub config (optional)
-  const githubInput = await ask("GitHub repo (e.g. org/repo, or Enter to skip): ");
-  const githubRepo = githubInput.trim();
+  // 4. Collaboration & Products
+  const collabInput = await ask("Collaboration provider (github / local) [github]: ");
+  const collaboration = collabInput.trim().toLowerCase() === "local" ? "local" : "github";
+
   let githubOwner = "";
   let githubRepoName = "";
-  if (githubRepo.includes("/")) {
-    const parts = githubRepo.split("/");
-    githubOwner = parts[0] ?? "";
-    githubRepoName = parts[1] ?? "";
+  if (collaboration === "github") {
+    const githubInput = await ask("GitHub repo (e.g. org/repo, or Enter to skip): ");
+    const githubRepo = githubInput.trim();
+    if (githubRepo.includes("/")) {
+      const parts = githubRepo.split("/");
+      githubOwner = parts[0] ?? "";
+      githubRepoName = parts[1] ?? "";
+    }
   }
+
+  const productInput = await ask(
+    "External product workspace (e.g. /home/user/vault or org/repo, or Enter to skip): ",
+  );
+  const productPath = productInput.trim();
 
   // 5. Agents
   const agents: AgentAnswers[] = [];
@@ -232,6 +242,19 @@ export const runInit = async (targetArg?: string): Promise<void> => {
   // through CLI flags.
   await copyDefaultAgentTemplates(join(targetDir, "murmuration", "default-agent"));
 
+  // If local collaboration, remove the github MCP tool from the default agent role.md
+  if (collaboration === "local") {
+    const defaultRolePath = join(targetDir, "murmuration", "default-agent", "role.md");
+    if (fs.existsSync(defaultRolePath)) {
+      let roleContent = fs.readFileSync(defaultRolePath, "utf8");
+      roleContent = roleContent.replace(
+        /tools:\n  mcp:\n    - name: github\n      command: npx\n      args: \["-y", "@modelcontextprotocol\/server-github"\]\n      env:\n        GITHUB_TOKEN: "\$GITHUB_TOKEN"\n/g,
+        "",
+      );
+      fs.writeFileSync(defaultRolePath, roleContent);
+    }
+  }
+
   // murmuration/soul.md
   await writeFile(
     join(targetDir, "murmuration", "soul.md"),
@@ -269,6 +292,16 @@ _What does this murmuration optimize for?_
     governance !== "none"
       ? `governance:\n  model: "${governance}"\n  plugin: "${governancePlugin ?? governance}"`
       : `governance:\n  model: none`;
+
+  const collabBlock =
+    collaboration === "github" && githubOwner
+      ? `collaboration:\n  provider: "${collaboration}"\n  repo: "${githubOwner}/${githubRepoName}"`
+      : `collaboration:\n  provider: "${collaboration}"`;
+
+  const productName = productPath.split("/").pop() || "workspace";
+  const productBlock = productPath
+    ? `\n\nproducts:\n  - name: "${productName}"\n    repo: "${productPath}"`
+    : "";
   await writeFile(
     join(targetDir, "murmuration", "harness.yaml"),
     `# Murmuration Harness configuration
@@ -280,6 +313,8 @@ llm:
   provider: "${defaultProvider}"
 
 ${governanceBlock}
+
+${collabBlock}${productBlock}
 `,
     "utf8",
   );

--- a/packages/cli/src/spirit/skills/SKILLS.md
+++ b/packages/cli/src/spirit/skills/SKILLS.md
@@ -13,5 +13,6 @@ The Spirit loads skill bodies on demand via `load_skill(name)`. This index is al
 | `agent-anatomy`          | Creating, editing, or debugging agents — `soul.md`, `role.md` frontmatter, signal scopes, write scopes      |
 | `governance-models`      | Discussions about governance, plugins, meetings, `governance/groups/*.md`, state graphs, decision records   |
 | `when-to-use-governance` | The operator wants to change something and isn't sure whether to act directly or delegate via governance    |
+| `setup-github`           | The operator wants to configure GitHub, set up the GITHUB_TOKEN, or enable the GitHub MCP server            |
 
 When the operator asks something substantive, check whether one of these skills covers it. If yes, load it before answering. If none applies and you're unsure, say so — don't guess.

--- a/packages/cli/src/spirit/skills/SKILLS.md
+++ b/packages/cli/src/spirit/skills/SKILLS.md
@@ -14,5 +14,7 @@ The Spirit loads skill bodies on demand via `load_skill(name)`. This index is al
 | `governance-models`      | Discussions about governance, plugins, meetings, `governance/groups/*.md`, state graphs, decision records   |
 | `when-to-use-governance` | The operator wants to change something and isn't sure whether to act directly or delegate via governance    |
 | `setup-github`           | The operator wants to configure GitHub, set up the GITHUB_TOKEN, or enable the GitHub MCP server            |
+| `setup-products`         | The operator wants to link external workspaces, code repos, or local PKM vaults to the murmuration          |
+| `setup-llms`             | The operator needs to configure API keys, Ollama, or set up per-agent model overrides                       |
 
 When the operator asks something substantive, check whether one of these skills covers it. If yes, load it before answering. If none applies and you're unsure, say so — don't guess.

--- a/packages/cli/src/spirit/skills/setup-github.md
+++ b/packages/cli/src/spirit/skills/setup-github.md
@@ -1,0 +1,64 @@
+---
+name: setup-github
+description: How to guide the operator through setting up GitHub and the MCP token for the murmuration
+---
+
+# Setting up GitHub Collaboration
+
+When the operator wants to set up GitHub for their murmuration, guide them through this step-by-step process. Walk them through it iteratively rather than dumping the whole process at once. Wait for them to confirm completion of a step before moving to the next.
+
+## 1. Create the Murmuration Repository
+
+First, the operator needs a GitHub repository to hold the murmuration's state.
+
+- Create a new repository on GitHub (e.g., `my-org/my-murmuration`). A private repository is strongly recommended since it will hold internal governance and agent roles.
+- Clone the repository locally, or if starting from scratch locally:
+  ```bash
+  mkdir my-murmuration
+  cd my-murmuration
+  git init
+  ```
+- Run `murmuration init .` to scaffold the directory. (Or `murmuration init my-murmuration` if they haven't made the folder yet).
+
+## 2. Configure harness.yaml
+
+The harness needs to know which repository to sync with, and it must load the GitHub MCP server so agents have tools to comment and interact with issues.
+Instruct the operator to open `murmuration/harness.yaml` and ensure it has:
+
+```yaml
+collaboration:
+  provider: "github"
+  repo: "my-org/my-murmuration" # Replace with their actual repo
+
+mcp:
+  servers:
+    - name: github
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_TOKEN: "$GITHUB_TOKEN"
+```
+
+## 3. Generate a GitHub Token
+
+The agents (and the harness) need a GitHub token to authenticate.
+
+- **Classic Token (Recommended for simplicity):** Go to GitHub Developer Settings -> Personal access tokens -> Tokens (classic). Generate a new token with the `repo` scope selected.
+- **Fine-grained Token:** Ensure it has Read/Write access to Issues, Pull Requests, and Metadata for the specific repository.
+- Copy the generated token immediately (it starts with `ghp_` or `github_pat_`).
+
+## 4. Set the Token in .env
+
+The harness uses `.env` files to pass secrets.
+
+- In the root of their murmuration workspace, create a file named `.env`.
+- Add the token:
+  ```
+  GITHUB_TOKEN=ghp_... (paste the token here)
+  ```
+
+## 5. Verify and Start
+
+- Confirm that the `.env` file is excluded from source control (the `murmuration init` command creates a `.gitignore` that handles this, but it's good to verify).
+- Run `murmuration start`.
+- The agents will now be able to use the `github` tools securely via MCP and read/write to the GitHub issues for governance.

--- a/packages/cli/src/spirit/skills/setup-github.md
+++ b/packages/cli/src/spirit/skills/setup-github.md
@@ -7,11 +7,30 @@ description: How to guide the operator through setting up GitHub and the MCP tok
 
 When the operator wants to set up GitHub for their murmuration, guide them through this step-by-step process. Walk them through it iteratively rather than dumping the whole process at once. Wait for them to confirm completion of a step before moving to the next.
 
+## Advising on Architecture Choices
+
+Before starting the setup, ensure the operator understands the tradeoffs they are making:
+
+### Local vs. GitHub Governance
+
+- **Local Governance (`collaboration: local`)**:
+  - _Pros_: Completely private, works offline, zero external dependencies, fastest execution, no API limits.
+  - _Cons_: Single-player only, hard to audit over time, no native issue tracking or discussion threads, lacks the async handoff benefits of a shared platform.
+- **GitHub Governance (`collaboration: github`)**:
+  - _Pros_: System of record is external and highly durable, native support for async threads (Issues/PRs), multi-operator/multi-agent transparent, easy to audit agent decisions.
+  - _Cons_: Requires network access, API tokens, potential rate limits, requires secure secret management.
+
+### Private vs. Public Repositories
+
+- **CRITICAL: Always recommend a Private repository by default.**
+- _Why?_ The governance repository holds agent `role.md` files, internal discussions, and potentially sensitive organizational state. Unless the murmuration is explicitly building an open-source project in public (like Emergent Praxis), public exposure is a severe security and privacy risk.
+- _Action:_ Explicitly ask the operator to verify the repo is set to Private before pushing any local state or creating tokens.
+
 ## 1. Create the Murmuration Repository
 
 First, the operator needs a GitHub repository to hold the murmuration's state.
 
-- Create a new repository on GitHub (e.g., `my-org/my-murmuration`). A private repository is strongly recommended since it will hold internal governance and agent roles.
+- Create a new repository on GitHub (e.g., `my-org/my-murmuration`). Remind them to make it **Private**.
 - Clone the repository locally, or if starting from scratch locally:
   ```bash
   mkdir my-murmuration

--- a/packages/cli/src/spirit/skills/setup-github.md
+++ b/packages/cli/src/spirit/skills/setup-github.md
@@ -53,15 +53,22 @@ If they choose GitHub, walk them through this process one step at a time. Wait f
 
 ### Step 2. Configure harness.yaml
 
-Instruct the operator to open `murmuration/harness.yaml` and ensure it has:
+Instruct the operator to open `murmuration/harness.yaml` and configure the collaboration provider:
 
 ```yaml
 collaboration:
   provider: "github"
   repo: "my-org/my-murmuration" # Replace with their actual repo
+```
 
-mcp:
-  servers:
+### Step 3. Give Agents the GitHub MCP Tools
+
+For agents to interact with GitHub issues natively, they need the GitHub MCP server mapped into their `role.md` configuration.
+Instruct the operator to edit `murmuration/default-agent/role.md` (or specific agents' `role.md` files) and add the `mcp` block under `tools`:
+
+```yaml
+tools:
+  mcp:
     - name: github
       command: npx
       args: ["-y", "@modelcontextprotocol/server-github"]
@@ -69,13 +76,13 @@ mcp:
         GITHUB_TOKEN: "$GITHUB_TOKEN"
 ```
 
-### Step 3. Generate a GitHub Token
+### Step 4. Generate a GitHub Token
 
 - **Classic Token (Recommended for simplicity):** Go to GitHub Developer Settings -> Personal access tokens -> Tokens (classic). Generate a new token with the `repo` scope selected.
 - **Fine-grained Token:** Ensure it has Read/Write access to Issues, Pull Requests, and Metadata for the specific repository.
 - Copy the generated token immediately.
 
-### Step 4. Set the Token in .env
+### Step 5. Set the Token in .env
 
 - In the root of their murmuration workspace, create a file named `.env`.
 - Add the token:
@@ -83,8 +90,8 @@ mcp:
   GITHUB_TOKEN=ghp_... (paste the token here)
   ```
 
-### Step 5. Verify and Start
+### Step 6. Verify and Start
 
-- Confirm that the `.env` file is excluded from source control (the `murmuration init` command creates a `.gitignore` that handles this, but it's good to verify).
+- Confirm that the `.env` file is excluded from source control.
 - Run `murmuration start`.
-- The agents will now be able to use the `github` tools securely via MCP.
+- The agents will now be able to use the `github` tools securely via MCP to read/write to the GitHub issues for governance.

--- a/packages/cli/src/spirit/skills/setup-github.md
+++ b/packages/cli/src/spirit/skills/setup-github.md
@@ -16,12 +16,13 @@ Before starting any setup, help the operator decide what architecture is actuall
 - Are they just experimenting locally, or are they building a persistent agent team?
 - Do they need an auditable history of agent decisions?
 - Will other humans ever interact with this murmuration?
+- **Do they use Obsidian or another local Markdown knowledge base?**
 
 ### Based on their answers, explain the tradeoffs:
 
 - **Local Governance (`collaboration: local`)**:
-  - _Best for_: Quick experiments, offline work, strict data privacy, or solo operators who don't need a durable history.
-  - _Pros_: Zero external dependencies, fastest execution, no API limits.
+  - _Best for_: Operators using Obsidian (or similar PKMs), quick experiments, offline work, strict data privacy, or solo operators.
+  - _Pros_: Zero external dependencies, fastest execution, no API limits. **Crucially, if the operator uses Obsidian, local governance means all agent files, issues, and decisions are natively visible and linkable directly inside their vault without context-switching.**
   - _Cons_: Hard to audit over time, lacks native issue tracking for async handoffs.
 - **GitHub Governance (`collaboration: github`)**:
   - _Best for_: Persistent agent teams, complex governance (S3, consensus), auditing agent decisions, and multi-human collaboration.

--- a/packages/cli/src/spirit/skills/setup-github.md
+++ b/packages/cli/src/spirit/skills/setup-github.md
@@ -5,30 +5,41 @@ description: How to guide the operator through setting up GitHub and the MCP tok
 
 # Setting up GitHub Collaboration
 
-When the operator wants to set up GitHub for their murmuration, guide them through this step-by-step process. Walk them through it iteratively rather than dumping the whole process at once. Wait for them to confirm completion of a step before moving to the next.
+When the operator asks about setting up GitHub, or is unsure how to configure their murmuration's collaboration backend, guide them through a consultative process. Do not dump all the steps at once.
 
-## Advising on Architecture Choices
+## Phase 1: Consult and Advise (Help them choose)
 
-Before starting the setup, ensure the operator understands the tradeoffs they are making:
+Before starting any setup, help the operator decide what architecture is actually best for their specific needs. Ask them about their goals.
 
-### Local vs. GitHub Governance
+### Questions to guide them:
+
+- Are they just experimenting locally, or are they building a persistent agent team?
+- Do they need an auditable history of agent decisions?
+- Will other humans ever interact with this murmuration?
+
+### Based on their answers, explain the tradeoffs:
 
 - **Local Governance (`collaboration: local`)**:
-  - _Pros_: Completely private, works offline, zero external dependencies, fastest execution, no API limits.
-  - _Cons_: Single-player only, hard to audit over time, no native issue tracking or discussion threads, lacks the async handoff benefits of a shared platform.
+  - _Best for_: Quick experiments, offline work, strict data privacy, or solo operators who don't need a durable history.
+  - _Pros_: Zero external dependencies, fastest execution, no API limits.
+  - _Cons_: Hard to audit over time, lacks native issue tracking for async handoffs.
 - **GitHub Governance (`collaboration: github`)**:
-  - _Pros_: System of record is external and highly durable, native support for async threads (Issues/PRs), multi-operator/multi-agent transparent, easy to audit agent decisions.
-  - _Cons_: Requires network access, API tokens, potential rate limits, requires secure secret management.
+  - _Best for_: Persistent agent teams, complex governance (S3, consensus), auditing agent decisions, and multi-human collaboration.
+  - _Pros_: System of record is external and highly durable, native support for async threads (Issues/PRs).
+  - _Cons_: Requires network access, API tokens, and secure secret management.
 
-### Private vs. Public Repositories
+### The Privacy Default:
 
-- **CRITICAL: Always recommend a Private repository by default.**
-- _Why?_ The governance repository holds agent `role.md` files, internal discussions, and potentially sensitive organizational state. Unless the murmuration is explicitly building an open-source project in public (like Emergent Praxis), public exposure is a severe security and privacy risk.
-- _Action:_ Explicitly ask the operator to verify the repo is set to Private before pushing any local state or creating tokens.
+- **CRITICAL:** If they choose GitHub, **always recommend a Private repository by default.**
+- Explain that the governance repository holds agent `role.md` files, internal discussions, and potentially sensitive organizational state. Public exposure is a severe security and privacy risk unless they are explicitly building an open-source public project.
 
-## 1. Create the Murmuration Repository
+_Wait for the operator to make a decision before moving to Phase 2._
 
-First, the operator needs a GitHub repository to hold the murmuration's state.
+## Phase 2: The Setup Steps
+
+If they choose GitHub, walk them through this process one step at a time. Wait for confirmation after each step.
+
+### Step 1. Create the Murmuration Repository
 
 - Create a new repository on GitHub (e.g., `my-org/my-murmuration`). Remind them to make it **Private**.
 - Clone the repository locally, or if starting from scratch locally:
@@ -37,11 +48,10 @@ First, the operator needs a GitHub repository to hold the murmuration's state.
   cd my-murmuration
   git init
   ```
-- Run `murmuration init .` to scaffold the directory. (Or `murmuration init my-murmuration` if they haven't made the folder yet).
+- Run `murmuration init .` to scaffold the directory.
 
-## 2. Configure harness.yaml
+### Step 2. Configure harness.yaml
 
-The harness needs to know which repository to sync with, and it must load the GitHub MCP server so agents have tools to comment and interact with issues.
 Instruct the operator to open `murmuration/harness.yaml` and ensure it has:
 
 ```yaml
@@ -58,17 +68,13 @@ mcp:
         GITHUB_TOKEN: "$GITHUB_TOKEN"
 ```
 
-## 3. Generate a GitHub Token
-
-The agents (and the harness) need a GitHub token to authenticate.
+### Step 3. Generate a GitHub Token
 
 - **Classic Token (Recommended for simplicity):** Go to GitHub Developer Settings -> Personal access tokens -> Tokens (classic). Generate a new token with the `repo` scope selected.
 - **Fine-grained Token:** Ensure it has Read/Write access to Issues, Pull Requests, and Metadata for the specific repository.
-- Copy the generated token immediately (it starts with `ghp_` or `github_pat_`).
+- Copy the generated token immediately.
 
-## 4. Set the Token in .env
-
-The harness uses `.env` files to pass secrets.
+### Step 4. Set the Token in .env
 
 - In the root of their murmuration workspace, create a file named `.env`.
 - Add the token:
@@ -76,8 +82,8 @@ The harness uses `.env` files to pass secrets.
   GITHUB_TOKEN=ghp_... (paste the token here)
   ```
 
-## 5. Verify and Start
+### Step 5. Verify and Start
 
 - Confirm that the `.env` file is excluded from source control (the `murmuration init` command creates a `.gitignore` that handles this, but it's good to verify).
 - Run `murmuration start`.
-- The agents will now be able to use the `github` tools securely via MCP and read/write to the GitHub issues for governance.
+- The agents will now be able to use the `github` tools securely via MCP.

--- a/packages/cli/src/spirit/skills/setup-llms.md
+++ b/packages/cli/src/spirit/skills/setup-llms.md
@@ -1,0 +1,60 @@
+---
+name: setup-llms
+description: How to configure LLM providers (API keys, Ollama) and per-agent model overrides
+---
+
+# Setting up LLM Providers
+
+When the operator needs help configuring AI models, setting up local models (Ollama), or fixing circuit-breaker errors related to missing providers, guide them through the LLM configuration.
+
+## 1. Global Default Provider
+
+In `murmuration/harness.yaml`, the global default provider is set. This is what agents use if they don't specify otherwise.
+
+```yaml
+llm:
+  provider: "gemini" # Options: gemini, anthropic, openai, ollama
+```
+
+## 2. API Keys in .env
+
+The harness reads provider keys from the `.env` file at the root of the workspace.
+Ensure the operator has the correct variables set for the providers they intend to use:
+
+- `GEMINI_API_KEY=...`
+- `ANTHROPIC_API_KEY=...`
+- `OPENAI_API_KEY=...`
+
+## 3. Setting up Ollama (Local Models)
+
+If the operator wants to use local models for privacy or cost savings, they can use Ollama.
+
+1. Ensure Ollama is installed and running on their machine (or a reachable network host).
+2. Add the base URL to the `.env` file:
+   ```
+   OLLAMA_BASE_URL=http://localhost:11434
+   ```
+   _(If Ollama is on another machine, use that IP, e.g., `http://192.168.1.100:11434`)_
+3. **Important:** If agents are configured to use `ollama` but the service isn't running or reachable, the daemon's circuit breakers will trip and the agents will fail to wake.
+
+## 4. Per-Agent Overrides (Mixing Models)
+
+A powerful pattern is to use cheaper/faster models (like Gemini Pro or local Ollama) for most agents, but assign an expensive reasoning model (like Claude 3.5 Sonnet) to a specific complex agent (like a Quality Assurance or Architecture agent).
+
+Instruct the operator to edit the specific agent's `role.md` file (e.g., `agents/architect/role.md`) and add frontmatter:
+
+```markdown
+---
+llm:
+  provider: anthropic
+  model: claude-3-5-sonnet-latest
+---
+
+# Architect Role
+
+...
+```
+
+This overrides the global default in `harness.yaml` just for this specific agent.
+
+_Remind the operator to `murmuration restart` after changing `.env` or `harness.yaml`._

--- a/packages/cli/src/spirit/skills/setup-products.md
+++ b/packages/cli/src/spirit/skills/setup-products.md
@@ -1,0 +1,46 @@
+---
+name: setup-products
+description: How to link external repositories, local directories, or PKM vaults to the murmuration
+---
+
+# Setting up Products (External Workspaces)
+
+When the operator asks how to give their murmuration access to code, documents, or an Obsidian vault, explain how the `products` block works in `harness.yaml`.
+
+A murmuration often manages things outside its own internal governance directory. We call these "products." By declaring products, you grant the agents access to read and modify those external files.
+
+## The `products` Array
+
+Instruct the operator to open their `murmuration/harness.yaml` file and add a `products` block.
+
+### For Local Directories (like an Obsidian PKM Vault)
+
+If the operator wants the murmuration to manage a local directory, they provide an absolute path:
+
+```yaml
+products:
+  - name: my-knowledge-base
+    repo: /home/user/Documents/ObsidianVault
+```
+
+_Note: This is perfect for PKM murmurations where agents act as researchers or librarians within a local Markdown vault._
+
+### For GitHub Repositories
+
+If the murmuration manages a separate code repository on GitHub (like Emergent Praxis manages the Murmuration Harness):
+
+```yaml
+products:
+  - name: my-software-project
+    repo: my-org/my-software-project
+```
+
+## How Agents Use Products
+
+Once a product is declared:
+
+1. The daemon securely mounts these paths into the agents' execution environments.
+2. Agents can use their standard file and directory tools (`read_file`, `write_file`, `list_dir`) on these external paths.
+3. The harness knows how to isolate product paths from internal governance paths, ensuring agents don't accidentally leak internal state into the public products they manage.
+
+_Prompt the operator to add their first product, and remind them they need to restart the daemon (`murmuration restart`) for the new mounts to take effect._

--- a/packages/cli/src/spirit/tools.ts
+++ b/packages/cli/src/spirit/tools.ts
@@ -6,14 +6,14 @@
  *       the REPL attach loop, or
  *   (b) a filesystem read guarded by path-safety rules.
  *
- * Mutations (writes, lifecycle commands) are Phase 2.
+ * Includes basic mutations (write_file) so agents can generate artifacts.
  *
  * Tools return strings because the LLM consumes the result as text
  * anyway. JSON is stringified; filesystem reads return raw bytes.
  */
 
-import { readFile, readdir, stat } from "node:fs/promises";
-import { join, resolve, relative, basename } from "node:path";
+import { readFile, readdir, stat, writeFile, mkdir } from "node:fs/promises";
+import { join, resolve, relative, basename, dirname } from "node:path";
 
 import type { ToolDefinition } from "@murmurations-ai/llm";
 import { z } from "zod";
@@ -266,6 +266,28 @@ export const buildSpiritTools = (ctx: ToolContext): readonly ToolDefinition[] =>
     },
   };
 
+  const writeFileTool: ToolDefinition = {
+    name: "write_file",
+    description:
+      "Write content to a file in the murmuration root. Creates directories if they do not exist. Use for creating artifacts, drafting memories, or writing context files. Paths are relative to the murmuration root. Overwrites existing files.",
+    parameters: z.object({
+      path: z.string().describe("Path relative to the murmuration root."),
+      content: z.string().describe("Content to write."),
+    }),
+    execute: async (input) => {
+      const { path, content } = input as { path: string; content: string };
+      try {
+        const abs = safePath(rootDir, path);
+        await mkdir(dirname(abs), { recursive: true });
+        await writeFile(abs, content, "utf8");
+        return `Successfully wrote file ${path}`;
+      } catch (err) {
+        if (err instanceof PathSafetyError) return err.message;
+        return `write_file error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  };
+
   return [
     statusTool,
     agentsTool,
@@ -273,6 +295,7 @@ export const buildSpiritTools = (ctx: ToolContext): readonly ToolDefinition[] =>
     eventsTool,
     readFileTool,
     listDirTool,
+    writeFileTool,
     loadSkillTool,
     wakeTool,
     directiveTool,

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -40,7 +40,12 @@ import {
   validateWake,
 } from "../execution/index.js";
 import type { LoadedAgentIdentity } from "../identity/index.js";
-import { REDACT, type SecretDeclaration, type SecretsProvider } from "../secrets/index.js";
+import {
+  makeSecretKey,
+  REDACT,
+  type SecretDeclaration,
+  type SecretsProvider,
+} from "../secrets/index.js";
 import {
   TimerScheduler,
   type Scheduler,
@@ -659,7 +664,13 @@ export class Daemon {
   }
 
   async #runWake(agent: RegisteredAgent, event: ScheduledWakeEvent): Promise<void> {
-    const baseContext = await buildSpawnContext(agent, event, this.#signalAggregator, this.#logger);
+    const baseContext = await buildSpawnContext(
+      agent,
+      event,
+      this.#signalAggregator,
+      this.#secrets?.provider,
+      this.#logger,
+    );
 
     // Inject any queued governance events from the inbox into the
     // signal bundle as `custom` signals with sourceId
@@ -1113,6 +1124,7 @@ const buildSpawnContext = async (
   agent: RegisteredAgent,
   event: ScheduledWakeEvent,
   aggregator: SignalAggregator | undefined,
+  secretsProvider: SecretsProvider | undefined,
   logger: DaemonLogger,
 ): Promise<AgentSpawnContext> => {
   const agentId = makeAgentId(agent.agentId);
@@ -1197,10 +1209,31 @@ const buildSpawnContext = async (
       signalSources: agent.signalScopes?.sources ?? [],
     },
     mcpServerConfigs: agent.tools.mcp,
-    environment: agent.secrets
-      ? Object.fromEntries(Object.entries(agent.secrets).map(([k, v]) => [k, v.reveal()]))
-      : {},
+    environment: resolveAgentEnvironment(agent, secretsProvider),
   };
+};
+
+/**
+ * Build the per-wake environment map from this agent's declared secrets.
+ * Required keys that aren't loaded are skipped (boot already refused to
+ * start if a required key was missing); optional keys are included only
+ * when actually present. Names not in `agent.secrets.{required,optional}`
+ * are never read, so the spawn context can't leak unrelated secrets.
+ */
+const resolveAgentEnvironment = (
+  agent: RegisteredAgent,
+  provider: SecretsProvider | undefined,
+): Readonly<Record<string, string>> => {
+  if (!provider) return {};
+  const environment: Record<string, string> = {};
+  const declared = [...agent.secrets.required, ...agent.secrets.optional];
+  for (const name of declared) {
+    const key = makeSecretKey(name);
+    if (provider.has(key)) {
+      environment[name] = provider.get(key).reveal();
+    }
+  }
+  return environment;
 };
 
 /**

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -1197,7 +1197,9 @@ const buildSpawnContext = async (
       signalSources: agent.signalScopes?.sources ?? [],
     },
     mcpServerConfigs: agent.tools.mcp,
-    environment: {},
+    environment: agent.secrets
+      ? Object.fromEntries(Object.entries(agent.secrets).map(([k, v]) => [k, v.reveal()]))
+      : {},
   };
 };
 


### PR DESCRIPTION
Resolves #120. Adds a new Spirit skill to walk operators through setting up GitHub integration.