### PR TITLE
fix: error legibility for new operators (v0.5.0 Milestone 1)

### DIFF
--- a/packages/cli/src/group-wake.test.ts
+++ b/packages/cli/src/group-wake.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { GroupWakeError } from "./group-wake.js";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CollaborationError } from "@murmurations-ai/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formatCollaborationError, GroupWakeError, resolveLLMConfig } from "./group-wake.js";
 
 describe("GroupWakeError", () => {
   it("has correct name property", () => {
@@ -29,6 +35,128 @@ describe("GroupWakeError", () => {
     for (const code of codes) {
       const err = new GroupWakeError(code, `test ${code}`);
       expect(err.code).toBe(code);
+    }
+  });
+});
+
+describe("formatCollaborationError (v0.5.0 Milestone 1)", () => {
+  it("includes the message alongside the code", () => {
+    const err = new CollaborationError("github", "PERMISSION_DENIED", "token missing repo scope");
+    expect(formatCollaborationError(err)).toBe("PERMISSION_DENIED: token missing repo scope");
+  });
+
+  it("falls back to just the code when the message is the generic fallback", () => {
+    const err = new CollaborationError("github", "UNKNOWN", "Unknown error");
+    expect(formatCollaborationError(err)).toBe("UNKNOWN");
+  });
+
+  it("falls back to just the code when the message is empty", () => {
+    const err = new CollaborationError("github", "NOT_FOUND", "");
+    expect(formatCollaborationError(err)).toBe("NOT_FOUND");
+  });
+
+  it("trims whitespace from the message", () => {
+    const err = new CollaborationError("github", "RATE_LIMITED", "  slow down please  ");
+    expect(formatCollaborationError(err)).toBe("RATE_LIMITED: slow down please");
+  });
+});
+
+describe("resolveLLMConfig (v0.5.0 Milestone 1)", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "group-wake-resolve-"));
+    await mkdir(join(rootDir, "murmuration"), { recursive: true });
+    await writeFile(join(rootDir, "murmuration", "soul.md"), "# soul\n", "utf8");
+  });
+
+  afterEach(async () => {
+    if (rootDir) await rm(rootDir, { recursive: true, force: true });
+  });
+
+  const writeAgent = async (slug: string, roleContent: string): Promise<void> => {
+    const dir = join(rootDir, "agents", slug);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "soul.md"), "# soul\n", "utf8");
+    await writeFile(join(dir, "role.md"), roleContent, "utf8");
+  };
+
+  it("returns ok=true with config when role.md has a valid llm block", async () => {
+    await writeAgent(
+      "facilitator",
+      `---
+agent_id: "facilitator"
+name: "Facilitator"
+model_tier: balanced
+llm:
+  provider: "gemini"
+  model: "gemini-2.5-pro"
+---
+body
+`,
+    );
+    const result = await resolveLLMConfig(rootDir, "facilitator");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("gemini");
+      expect(result.config.model).toBe("gemini-2.5-pro");
+    }
+  });
+
+  it("returns ok=false reason=no-llm-block when role.md is missing the llm: key", async () => {
+    await writeAgent(
+      "facilitator",
+      `---
+agent_id: "facilitator"
+name: "Facilitator"
+model_tier: balanced
+---
+body
+`,
+    );
+    const result = await resolveLLMConfig(rootDir, "facilitator");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("no-llm-block");
+      if (result.reason === "no-llm-block") {
+        expect(result.rolePath).toContain("agents/facilitator/role.md");
+      }
+    }
+  });
+
+  it("returns ok=false reason=file-not-found when agents/<id>/ is missing", async () => {
+    const result = await resolveLLMConfig(rootDir, "no-such-agent");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("file-not-found");
+      if (result.reason === "file-not-found") {
+        expect(result.path).toContain("agents/no-such-agent");
+      }
+    }
+  });
+
+  it("returns ok=false reason=frontmatter-invalid with the Zod issues when schema fails", async () => {
+    await writeAgent(
+      "facilitator",
+      `---
+agent_id: 22
+name: "Facilitator"
+model_tier: balanced
+---
+body
+`,
+    );
+    const result = await resolveLLMConfig(rootDir, "facilitator");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("frontmatter-invalid");
+      if (result.reason === "frontmatter-invalid") {
+        expect(result.path).toContain("agents/facilitator/role.md");
+        // Issue list carries both the Zod message and the v0.5.0 remediation hint
+        const joined = result.issues.join("\n");
+        expect(joined).toContain("agent_id");
+        expect(joined).toContain('"facilitator"');
+      }
     }
   });
 });

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -15,8 +15,11 @@ import { resolve, join } from "node:path";
 import {
   makeSecretKey,
   IdentityLoader,
+  IdentityFileMissingError,
+  FrontmatterInvalidError,
   runGroupWake,
   type CollaborationProvider,
+  type CollaborationError,
   type GroupConfig,
   type GroupWakeContext,
   type GroupWakeKind,
@@ -36,22 +39,110 @@ import {
   findDefaultRepo,
 } from "./collaboration-factory.js";
 
-/** Resolve LLM provider + model from the facilitator's role.md. */
-const resolveLLMConfig = async (
+/**
+ * Discriminated result for resolving the facilitator's LLM config.
+ *
+ * The reason field distinguishes the three things that can actually
+ * go wrong when a tester first runs `group-wake`, so the CLI can
+ * print a specific remediation instead of a generic "could not read
+ * LLM config" catch-all. (v0.5.0 Milestone 1 — error legibility.)
+ */
+type ResolveLLMResult =
+  | { readonly ok: true; readonly config: { provider: string; model: string } }
+  | { readonly ok: false; readonly reason: "no-llm-block"; readonly rolePath: string }
+  | { readonly ok: false; readonly reason: "file-not-found"; readonly path: string }
+  | {
+      readonly ok: false;
+      readonly reason: "frontmatter-invalid";
+      readonly path: string;
+      readonly issues: readonly string[];
+    }
+  | { readonly ok: false; readonly reason: "other"; readonly message: string };
+
+/**
+ * Resolve LLM provider + model from the facilitator's role.md.
+ *
+ * Exported for unit tests; callers inside this module use it directly.
+ */
+export const resolveLLMConfig = async (
   rootDir: string,
   facilitatorId: string,
-): Promise<{ provider: string; model: string } | null> => {
+): Promise<ResolveLLMResult> => {
+  const rolePath = resolve(rootDir, "agents", facilitatorId, "role.md");
   try {
     const loader = new IdentityLoader({ rootDir });
     const identity = await loader.load(facilitatorId);
     const llm = identity.frontmatter.llm;
     if (llm) {
-      return { provider: llm.provider, model: llm.model ?? getDefaultModel(llm.provider) };
+      return {
+        ok: true,
+        config: { provider: llm.provider, model: llm.model ?? getDefaultModel(llm.provider) },
+      };
     }
-  } catch {
-    /* skip */
+    return { ok: false, reason: "no-llm-block", rolePath };
+  } catch (err) {
+    if (err instanceof IdentityFileMissingError) {
+      return { ok: false, reason: "file-not-found", path: err.path };
+    }
+    if (err instanceof FrontmatterInvalidError) {
+      return {
+        ok: false,
+        reason: "frontmatter-invalid",
+        path: err.path,
+        issues: err.issues,
+      };
+    }
+    return {
+      ok: false,
+      reason: "other",
+      message: err instanceof Error ? err.message : String(err),
+    };
   }
-  return null;
+};
+
+/**
+ * Print a tester-legible failure message for a non-ok
+ * {@link ResolveLLMResult}. Each reason names the real problem and
+ * the fix, so operators aren't left googling "could not read LLM
+ * config".
+ */
+const printLLMResolveFailure = (
+  facilitatorId: string,
+  result: Exclude<ResolveLLMResult, { readonly ok: true }>,
+): void => {
+  const prefix = "murmuration group-wake:";
+  switch (result.reason) {
+    case "no-llm-block":
+      console.error(`${prefix} facilitator "${facilitatorId}" role.md has no llm: block`);
+      console.error(`  File: ${result.rolePath}`);
+      console.error(`  Fix:  add an llm: block to the facilitator's role.md. Example:`);
+      console.error(`          llm:`);
+      console.error(`            provider: "gemini"   # or anthropic, openai, ollama`);
+      console.error(`  Alternative: the harness default in murmuration/harness.yaml applies`);
+      console.error(`               only when the daemon spawns agents — group-wake needs`);
+      console.error(`               the facilitator's role.md to set the llm explicitly.`);
+      break;
+    case "file-not-found":
+      console.error(`${prefix} facilitator role.md not found`);
+      console.error(`  Expected: ${result.path}`);
+      console.error(
+        `  Fix:  check that the facilitator id "${facilitatorId}" matches an agents/<id>/ directory,`,
+      );
+      console.error(`        and that agents/${facilitatorId}/role.md exists.`);
+      break;
+    case "frontmatter-invalid":
+      console.error(`${prefix} facilitator role.md has invalid frontmatter`);
+      console.error(`  File: ${result.path}`);
+      for (const issue of result.issues) {
+        console.error(`    - ${issue}`);
+      }
+      console.error(`  Hint: run 'murmuration doctor' to auto-diagnose (coming in v0.5.0).`);
+      break;
+    case "other":
+      console.error(`${prefix} unexpected error resolving facilitator's LLM config`);
+      console.error(`  ${result.message}`);
+      break;
+  }
 };
 
 const getDefaultModel = (provider: string): string => {
@@ -69,11 +160,23 @@ const getDefaultModel = (provider: string): string => {
   }
 };
 
+/**
+ * Format a CollaborationError as `CODE: message` so operators see the
+ * real underlying problem instead of just `UNKNOWN`. v0.5.0 Milestone 1.
+ *
+ * Exported for unit tests.
+ */
+export const formatCollaborationError = (err: CollaborationError): string => {
+  const msg = err.message.trim();
+  if (!msg || msg === "Unknown error") return err.code;
+  return `${err.code}: ${msg}`;
+};
+
 /** Fetch the group's open items backlog via the collaboration provider. */
 const fetchGroupBacklog = async (provider: CollaborationProvider): Promise<string> => {
   try {
     const result = await provider.listItems({ state: "open", limit: 30 });
-    if (!result.ok) return `(backlog fetch failed: ${result.error.code})`;
+    if (!result.ok) return `(backlog fetch failed: ${formatCollaborationError(result.error)})`;
     const items = result.value;
     if (items.length === 0) return "(no open items)";
     return items.map((i) => `- ${i.ref.id} ${i.title} [${i.labels.join(", ")}]`).join("\n");
@@ -136,9 +239,13 @@ const executeActions = async (
             receipts.push({ action, success: true });
           } else {
             console.log(
-              `    \x1b[31m✗\x1b[0m label-issue #${String(action.issueNumber)}: ${result.error.code}`,
+              `    \x1b[31m✗\x1b[0m label-issue #${String(action.issueNumber)}: ${formatCollaborationError(result.error)}`,
             );
-            receipts.push({ action, success: false, error: result.error.code });
+            receipts.push({
+              action,
+              success: false,
+              error: formatCollaborationError(result.error),
+            });
           }
           break;
         }
@@ -163,8 +270,14 @@ const executeActions = async (
               ...(id !== undefined ? { issueNumber: id } : {}),
             });
           } else {
-            console.log(`    \x1b[31m✗\x1b[0m create-issue: ${result.error.code}`);
-            receipts.push({ action, success: false, error: result.error.code });
+            console.log(
+              `    \x1b[31m✗\x1b[0m create-issue: ${formatCollaborationError(result.error)}`,
+            );
+            receipts.push({
+              action,
+              success: false,
+              error: formatCollaborationError(result.error),
+            });
           }
           break;
         }
@@ -182,9 +295,13 @@ const executeActions = async (
             receipts.push({ action, success: true });
           } else {
             console.log(
-              `    \x1b[31m✗\x1b[0m close-issue #${String(action.issueNumber)}: ${result.error.code}`,
+              `    \x1b[31m✗\x1b[0m close-issue #${String(action.issueNumber)}: ${formatCollaborationError(result.error)}`,
             );
-            receipts.push({ action, success: false, error: result.error.code });
+            receipts.push({
+              action,
+              success: false,
+              error: formatCollaborationError(result.error),
+            });
           }
           break;
         }
@@ -202,9 +319,13 @@ const executeActions = async (
             receipts.push({ action, success: true });
           } else {
             console.log(
-              `    \x1b[31m✗\x1b[0m comment-issue #${String(action.issueNumber)}: ${result.error.code}`,
+              `    \x1b[31m✗\x1b[0m comment-issue #${String(action.issueNumber)}: ${formatCollaborationError(result.error)}`,
             );
-            receipts.push({ action, success: false, error: result.error.code });
+            receipts.push({
+              action,
+              success: false,
+              error: formatCollaborationError(result.error),
+            });
           }
           break;
         }
@@ -292,16 +413,15 @@ export const runGroupWakeCommand = async (
   console.log("");
 
   // Resolve LLM provider from facilitator's role.md
-  const llmConfig = await resolveLLMConfig(root, config.facilitator);
-  if (!llmConfig) {
-    console.error(
-      `murmuration group-wake: could not read LLM config from facilitator "${config.facilitator}" role.md`,
-    );
+  const llmResult = await resolveLLMConfig(root, config.facilitator);
+  if (!llmResult.ok) {
+    printLLMResolveFailure(config.facilitator, llmResult);
     throw new GroupWakeError(
       "LLM_CONFIG_FAILED",
       `could not read LLM config from facilitator "${config.facilitator}" role.md`,
     );
   }
+  const llmConfig = llmResult.config;
   console.log(`  LLM: ${llmConfig.provider}/${llmConfig.model}`);
 
   // Load secrets + clients

--- a/packages/core/src/collaboration/collaboration.test.ts
+++ b/packages/core/src/collaboration/collaboration.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import { GitHubCollaborationProvider, type GitHubClientLike } from "./github-provider.js";
 import { LocalCollaborationProvider } from "./local-provider.js";
 import { CollaborationError } from "./types.js";
 import type { CollaborationProvider, ItemRef } from "./types.js";
@@ -299,5 +300,92 @@ describe("CollaborationError", () => {
     const cause = new Error("underlying");
     const err = new CollaborationError("test", "UNKNOWN", "Wrapped", { cause });
     expect(err.cause).toBe(cause);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubCollaborationProvider error mapping (v0.5.0 Milestone 1)
+//
+// The GitHub client emits hyphen-case codes (e.g. "not-found"). Earlier
+// #mapError only recognized upper-case + underscore codes, so every real
+// error fell through to UNKNOWN and operators saw `create-issue: UNKNOWN`
+// with no useful signal. These tests lock in the new mapping + message
+// preservation behavior.
+// ---------------------------------------------------------------------------
+
+describe("GitHubCollaborationProvider error mapping (v0.5.0 Milestone 1)", () => {
+  const makeFailingClient = (code: string, message: string): GitHubClientLike => ({
+    createIssue: () => Promise.resolve({ ok: false, error: { code, message } }),
+    listIssues: () => Promise.resolve({ ok: false, error: { code, message } }),
+    createIssueComment: () => Promise.resolve({ ok: false, error: { code, message } }),
+    updateIssueState: () => Promise.resolve({ ok: false, error: { code, message } }),
+    addLabels: () => Promise.resolve({ ok: false, error: { code, message } }),
+    removeLabel: () => Promise.resolve({ ok: false, error: { code, message } }),
+    getRef: () => Promise.resolve({ ok: false, error: { code, message } }),
+    createCommitOnBranch: () => Promise.resolve({ ok: false, error: { code, message } }),
+  });
+
+  type HyphenCase = readonly [
+    string,
+    "NOT_FOUND" | "PERMISSION_DENIED" | "INVALID_INPUT" | "RATE_LIMITED" | "TRANSPORT" | "UNKNOWN",
+  ];
+
+  const cases: readonly HyphenCase[] = [
+    ["not-found", "NOT_FOUND"],
+    ["unauthorized", "PERMISSION_DENIED"],
+    ["forbidden", "PERMISSION_DENIED"],
+    ["write-scope-denied", "PERMISSION_DENIED"],
+    ["validation", "INVALID_INPUT"],
+    ["conflict", "INVALID_INPUT"],
+    ["rate-limited", "RATE_LIMITED"],
+    ["transport", "TRANSPORT"],
+    ["parse", "TRANSPORT"],
+    ["aborted", "TRANSPORT"],
+    ["mutation-aborted", "TRANSPORT"],
+    ["internal", "UNKNOWN"],
+  ];
+
+  for (const [upstreamCode, mappedCode] of cases) {
+    it(`maps upstream "${upstreamCode}" → ${mappedCode} and preserves the message`, async () => {
+      const originalMessage = `${upstreamCode}-original-message`;
+      const gh = new GitHubCollaborationProvider({
+        client: makeFailingClient(upstreamCode, originalMessage),
+        repo: { owner: "o", name: "r" },
+      });
+      const result = await gh.createItem({ title: "t", body: "b" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(mappedCode);
+        expect(result.error.message).toBe(originalMessage);
+      }
+    });
+  }
+
+  it("still accepts legacy upper-case codes for forward compat", async () => {
+    const gh = new GitHubCollaborationProvider({
+      client: makeFailingClient("UNAUTHORIZED", "legacy upper-case"),
+      repo: { owner: "o", name: "r" },
+    });
+    const result = await gh.createItem({ title: "t", body: "b" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("PERMISSION_DENIED");
+      expect(result.error.message).toBe("legacy upper-case");
+    }
+  });
+
+  it("falls back to UNKNOWN with the real message when code is unrecognized", async () => {
+    const gh = new GitHubCollaborationProvider({
+      client: makeFailingClient("brand-new-code", "not in the map"),
+      repo: { owner: "o", name: "r" },
+    });
+    const result = await gh.createItem({ title: "t", body: "b" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("UNKNOWN");
+      // Defense in depth: even for unknown codes, the underlying message
+      // is preserved rather than replaced with "Unknown error".
+      expect(result.error.message).toBe("not in the map");
+    }
   });
 });

--- a/packages/core/src/collaboration/github-provider.ts
+++ b/packages/core/src/collaboration/github-provider.ts
@@ -262,24 +262,53 @@ export class GitHubCollaborationProvider implements CollaborationProvider {
   // Error mapping
   // -------------------------------------------------------------------------
 
+  /**
+   * Map a GitHub client error to a CollaborationError.
+   *
+   * The GitHub client (`@murmurations-ai/github`) emits hyphen-case codes
+   * (`"not-found"`, `"unauthorized"`, `"write-scope-denied"`). Earlier
+   * versions of this adapter checked for upper-case + underscore codes
+   * (`"UNAUTHORIZED"`, `"NOT_FOUND"`), so every real error fell through
+   * to `"UNKNOWN"` and operators saw `create-issue: UNKNOWN` with no
+   * useful signal. v0.5.0 Milestone 1 — error legibility.
+   *
+   * Also tolerates upper-case + underscore codes for forward compat with
+   * any callers that hand-roll error objects.
+   */
   #mapError(err?: { code: string; message: string }): CollaborationError {
     if (!err) return new CollaborationError("github", "UNKNOWN", "Unknown error");
     const code = err.code;
-    if (code === "UNAUTHORIZED" || code === "FORBIDDEN" || code === "WRITE_SCOPE") {
+    // Hyphen-case (GithubClientErrorCode, actual shape emitted by the client)
+    if (
+      code === "unauthorized" ||
+      code === "forbidden" ||
+      code === "write-scope-denied" ||
+      code === "UNAUTHORIZED" ||
+      code === "FORBIDDEN" ||
+      code === "WRITE_SCOPE"
+    ) {
       return new CollaborationError("github", "PERMISSION_DENIED", err.message);
     }
-    if (code === "NOT_FOUND") {
+    if (code === "not-found" || code === "NOT_FOUND") {
       return new CollaborationError("github", "NOT_FOUND", err.message);
     }
-    if (code === "VALIDATION") {
+    if (code === "validation" || code === "conflict" || code === "VALIDATION") {
       return new CollaborationError("github", "INVALID_INPUT", err.message);
     }
-    if (code === "RATE_LIMIT") {
+    if (code === "rate-limited" || code === "RATE_LIMIT") {
       return new CollaborationError("github", "RATE_LIMITED", err.message);
     }
-    if (code === "TRANSPORT") {
+    if (
+      code === "transport" ||
+      code === "parse" ||
+      code === "aborted" ||
+      code === "mutation-aborted" ||
+      code === "TRANSPORT"
+    ) {
       return new CollaborationError("github", "TRANSPORT", err.message);
     }
+    // internal / unknown upstream — preserve the real message so the
+    // operator can act on it even without a named code.
     return new CollaborationError("github", "UNKNOWN", err.message);
   }
 }

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -220,6 +220,104 @@ model_tier: galactic
     await expect(loader.load("13-badtier")).rejects.toBeInstanceOf(FrontmatterInvalidError);
   });
 
+  describe("Zod issue annotation (v0.5.0 Milestone 1)", () => {
+    it("numeric agent_id: error message names the file path AND suggests the fix", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/facilitator/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/facilitator/role.md",
+        `---
+agent_id: 22
+name: "Facilitator"
+model_tier: balanced
+---
+
+# Body
+`,
+      );
+
+      const loader = new IdentityLoader({ rootDir });
+      try {
+        await loader.load("facilitator");
+        throw new Error("expected FrontmatterInvalidError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FrontmatterInvalidError);
+        if (err instanceof FrontmatterInvalidError) {
+          // File path present
+          expect(err.path).toContain("agents/facilitator/role.md");
+          // Remediation hint explicitly names the directory-matching slug
+          const joined = err.issues.join("\n");
+          expect(joined).toContain("agent_id");
+          expect(joined).toContain('"facilitator"');
+          expect(joined).toContain("quoted string");
+        }
+      }
+    });
+
+    it("wrong model_tier: issue names the valid enum values", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/badtier/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/badtier/role.md",
+        `---
+agent_id: "badtier"
+name: "BadTier"
+model_tier: galactic
+---
+
+# BadTier
+`,
+      );
+
+      const loader = new IdentityLoader({ rootDir });
+      try {
+        await loader.load("badtier");
+        throw new Error("expected FrontmatterInvalidError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FrontmatterInvalidError);
+        if (err instanceof FrontmatterInvalidError) {
+          const joined = err.issues.join("\n");
+          expect(joined).toContain("fast");
+          expect(joined).toContain("balanced");
+          expect(joined).toContain("deep");
+        }
+      }
+    });
+
+    it("wrong llm.provider: issue names the valid provider list", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/badllm/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/badllm/role.md",
+        `---
+agent_id: "badllm"
+name: "BadLLM"
+model_tier: balanced
+llm:
+  provider: "Claude"
+---
+
+# BadLLM
+`,
+      );
+
+      const loader = new IdentityLoader({ rootDir });
+      try {
+        await loader.load("badllm");
+        throw new Error("expected FrontmatterInvalidError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FrontmatterInvalidError);
+        if (err instanceof FrontmatterInvalidError) {
+          const joined = err.issues.join("\n");
+          expect(joined).toContain("gemini");
+          expect(joined).toContain("anthropic");
+          expect(joined).toContain("openai");
+          expect(joined).toContain("ollama");
+        }
+      }
+    });
+  });
+
   it("frontmatter schema defaults apply when optional fields are omitted", async () => {
     await writeFixture("murmuration/soul.md", "# Soul\n");
     await writeFixture("agents/14-defaults/soul.md", "# Soul\n");

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -57,6 +57,57 @@ export class IdentityFileMissingError extends IdentityLoaderError {
   }
 }
 
+/**
+ * Render a Zod issue with a remediation hint when the failure matches
+ * a well-known pattern a new operator is likely to hit (numeric
+ * `agent_id`, wrong `model_tier` spelling, etc.). Unknown patterns fall
+ * back to Zod's default message — which is already reasonable.
+ *
+ * v0.5.0 Milestone 1 — error legibility. The goal is that a tester who
+ * sees the error can fix it without opening Stack Overflow.
+ */
+const annotateZodIssue = (
+  issue: z.core.$ZodIssue,
+  agentDir: string,
+  frontmatterRaw: unknown,
+): string => {
+  const fieldPath = issue.path.map((p) => String(p)).join(".");
+  const base = `${fieldPath}: ${issue.message}`;
+
+  const rawFm =
+    typeof frontmatterRaw === "object" && frontmatterRaw !== null
+      ? (frontmatterRaw as Record<string, unknown>)
+      : {};
+
+  // Pattern: agent_id is not a string (e.g. operators with a pre-v0.5
+  // repo used `agent_id: 22` which YAML parses as a number).
+  if (fieldPath === "agent_id" && issue.code === "invalid_type") {
+    const rawAgentId = rawFm.agent_id;
+    const displayValue =
+      typeof rawAgentId === "string" || typeof rawAgentId === "number"
+        ? String(rawAgentId)
+        : "<value>";
+    return `${base} — change \`agent_id: ${displayValue}\` to \`agent_id: "${agentDir}"\` (quoted string matching this agent's directory name)`;
+  }
+
+  // Pattern: model_tier misspelled (common: "medium", "small", "large").
+  if (fieldPath === "model_tier" && issue.code === "invalid_value") {
+    return `${base} — valid values: "fast", "balanced", "deep"`;
+  }
+
+  // Pattern: llm.provider misspelled or capitalized.
+  if (fieldPath === "llm.provider" && issue.code === "invalid_value") {
+    return `${base} — valid providers: "gemini", "anthropic", "openai", "ollama"`;
+  }
+
+  // Pattern: missing required top-level field.
+  if (issue.code === "invalid_type" && "received" in issue && issue.received === "undefined") {
+    return `${base} — add this field to ${agentDir}/role.md frontmatter`;
+  }
+
+  return base;
+};
+
 /** Frontmatter validation failed (missing field, wrong type, etc). */
 export class FrontmatterInvalidError extends IdentityLoaderError {
   public readonly path: string;
@@ -525,8 +576,8 @@ export class IdentityLoader {
     const parsed = roleFrontmatterSchema.safeParse(frontmatterRaw);
     if (!parsed.success) {
       if (!this.#fallbackOnMissing) {
-        const issues = parsed.error.issues.map(
-          (issue) => `${issue.path.map((p) => String(p)).join(".")}: ${issue.message}`,
+        const issues = parsed.error.issues.map((issue) =>
+          annotateZodIssue(issue, agentDir, frontmatterRaw),
         );
         throw new FrontmatterInvalidError(agentRolePath, issues);
       }


### PR DESCRIPTION
## Summary

Milestone 1 of the [v0.5.0 init UX overhaul plan](https://github.com/murmurations-ai/murmurations-harness/blob/plan/v0.5.0-init-ux-overhaul/docs/plans/v0.5.0-init-ux-overhaul.md) (PR #124). Fixes three cryptic error paths that burned a motivated operator during yesterday's EP migration.

## Closes three error-swallow bugs

### Fix 1 — `resolveLLMConfig` (group-wake.ts)

**Before:** any failure produced the generic `could not read LLM config from facilitator "engineering-lead-agent" role.md`. A numeric `agent_id` (real root cause) was indistinguishable from a missing directory or a missing `llm:` block.

**After:** discriminated `ResolveLLMResult` with four reasons (`no-llm-block`, `file-not-found`, `frontmatter-invalid`, `other`). Each reason prints a targeted message with a concrete fix — a no-llm-block failure shows a minimal `llm: { provider: "gemini" }` snippet; frontmatter-invalid surfaces the full Zod issue list with remediation hints from Fix 3.

### Fix 2 — `GitHubCollaborationProvider` error mapping

**Before:** every real GitHub failure rendered as `create-issue: UNKNOWN`. Root cause: the GitHub client emits hyphen-case codes (`"not-found"`, `"unauthorized"`, `"write-scope-denied"`) but `#mapError` only recognized upper-case + underscore codes, so every real error fell through to `UNKNOWN`.

**After:** proper mapping for all 12 hyphen-case codes. Legacy upper-case codes still accepted (forward compat). Defense in depth: `executeActions` now prints `CODE: message` via `formatCollaborationError`, so even an unmapped future code carries the underlying error message.

| Upstream | Mapped |
|---|---|
| `not-found` | `NOT_FOUND` |
| `unauthorized` / `forbidden` / `write-scope-denied` | `PERMISSION_DENIED` |
| `validation` / `conflict` | `INVALID_INPUT` |
| `rate-limited` | `RATE_LIMITED` |
| `transport` / `parse` / `aborted` / `mutation-aborted` | `TRANSPORT` |
| `internal` (fallback) | `UNKNOWN` (with message preserved) |

### Fix 3 — `IdentityLoader` Zod issue annotation

**Before:** a numeric `agent_id: 22` produced `agent_id: Expected string, received number`. Accurate but unhelpful for a new operator.

**After:** `FrontmatterInvalidError` issues now carry targeted remediation hints for the four most common new-operator failures:

- Numeric `agent_id` → `change \`agent_id: 22\` to \`agent_id: "engineering-lead-agent"\` (quoted string matching this agent's directory name)`
- Misspelled `model_tier` → lists `"fast"`, `"balanced"`, `"deep"`
- Misspelled `llm.provider` → lists `"gemini"`, `"anthropic"`, `"openai"`, `"ollama"`
- Missing required field → `add this field to <agent-dir>/role.md frontmatter`

## Test plan

- [x] 16 new unit tests covering all three fixes
- [x] `pnpm run build` — all 8 packages
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (19 pre-existing warnings unchanged)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 578 passed, 1 skipped
- [ ] Manual: trigger each error path against a broken EP-style fixture and confirm messages render per spec

## Milestone status

- ✅ Milestone 1 — error legibility (this PR)
- ⏳ Milestone 2 — init UX overhaul
- ⏳ Milestone 3 — `murmuration doctor`
- ⏳ Milestone 4 — `hello-circle` example
- ⏳ Milestone 5 — docs + release

## Related

- Plan: [`docs/plans/v0.5.0-init-ux-overhaul.md`](../blob/plan/v0.5.0-init-ux-overhaul/docs/plans/v0.5.0-init-ux-overhaul.md) (PR #124)
- Evidence: `xeeban/emergent-praxis` PRs #464, #465 — the migration session where all three errors first bit

🤖 Generated with [Claude Code](https://claude.com/claude-code)