### PR TITLE
feat: init UX overhaul — interactive secret capture + hero command (v0.5.0 Milestone 2)

### DIFF
--- a/packages/cli/src/init-secrets.test.ts
+++ b/packages/cli/src/init-secrets.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  captureSecret,
+  GITHUB_TOKEN_SPEC,
+  LLM_KEY_SPECS,
+  maskSecret,
+  type ProviderKeySpec,
+} from "./init-secrets.js";
+
+describe("maskSecret (v0.5.0 Milestone 2)", () => {
+  it("returns <empty> for blank input", () => {
+    expect(maskSecret("")).toBe("<empty>");
+    expect(maskSecret("   ")).toBe("<empty>");
+  });
+
+  it("shows last 4 + length for a normal key", () => {
+    expect(maskSecret("AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZabcd")).toBe("…abcd (length 36)");
+  });
+
+  it("handles very short keys without leaking more than needed", () => {
+    expect(maskSecret("abc")).toBe("…abc (length 3)");
+  });
+
+  it("trims leading/trailing whitespace before masking", () => {
+    expect(maskSecret("  AIza...WXYZ  ")).toBe("…WXYZ (length 11)");
+  });
+});
+
+describe("ProviderKeySpec.validate (v0.5.0 Milestone 2)", () => {
+  describe("Gemini", () => {
+    const spec = LLM_KEY_SPECS.gemini;
+    it("accepts a well-formed Gemini key", () => {
+      expect(spec.validate("AIzaSy" + "x".repeat(30))).toBeNull();
+    });
+    it("rejects missing AIza prefix", () => {
+      expect(spec.validate("sk-ant-" + "x".repeat(40))).toMatch(/AIza/);
+    });
+    it("rejects too-short input", () => {
+      expect(spec.validate("AIza")).toMatch(/too short/);
+    });
+    it("treats empty input as skip (null)", () => {
+      expect(spec.validate("")).toBeNull();
+      expect(spec.validate("   ")).toBeNull();
+    });
+  });
+
+  describe("Anthropic", () => {
+    const spec = LLM_KEY_SPECS.anthropic;
+    it("accepts a well-formed Anthropic key", () => {
+      expect(spec.validate("sk-ant-" + "x".repeat(40))).toBeNull();
+    });
+    it("rejects wrong prefix", () => {
+      expect(spec.validate("AIzaSy" + "x".repeat(30))).toMatch(/sk-ant-/);
+    });
+  });
+
+  describe("OpenAI", () => {
+    const spec = LLM_KEY_SPECS.openai;
+    it("accepts a well-formed OpenAI key", () => {
+      expect(spec.validate("sk-" + "x".repeat(48))).toBeNull();
+    });
+    it("rejects missing sk- prefix", () => {
+      expect(spec.validate("AIzaSy" + "x".repeat(30))).toMatch(/sk-/);
+    });
+  });
+
+  describe("GitHub token", () => {
+    const spec = GITHUB_TOKEN_SPEC;
+    it("accepts ghp_ tokens", () => {
+      expect(spec.validate("ghp_" + "x".repeat(40))).toBeNull();
+    });
+    it("accepts gho_ tokens", () => {
+      expect(spec.validate("gho_" + "x".repeat(40))).toBeNull();
+    });
+    it("accepts github_pat_ fine-grained tokens", () => {
+      expect(spec.validate("github_pat_" + "x".repeat(40))).toBeNull();
+    });
+    it("rejects wrong prefix", () => {
+      expect(spec.validate("pat-" + "x".repeat(40))).toMatch(/ghp_/);
+    });
+  });
+});
+
+describe("captureSecret (v0.5.0 Milestone 2)", () => {
+  it("returns the validated secret when the first paste passes + operator confirms", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi.fn(() => Promise.resolve("y"));
+    const promptSecretFn = vi.fn(() => Promise.resolve("AIzaSy" + "a".repeat(30)));
+
+    const result = await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+    });
+
+    expect(result).toBe("AIzaSy" + "a".repeat(30));
+    expect(promptSecretFn).toHaveBeenCalledTimes(1);
+    const logged = log.mock.calls.map((c) => c[0]).join("");
+    expect(logged).toContain("Captured GEMINI_API_KEY");
+    expect(logged).toContain("…aaaa"); // last-4 masking
+  });
+
+  it("re-prompts on shape-validation failure, then succeeds", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi.fn(() => Promise.resolve(""));
+    const promptSecretFn = vi
+      .fn<(options: { question: string }) => Promise<string>>()
+      .mockResolvedValueOnce("not-a-key")
+      .mockResolvedValueOnce("AIzaSy" + "b".repeat(30));
+
+    const result = await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+    });
+
+    expect(result).toBe("AIzaSy" + "b".repeat(30));
+    expect(promptSecretFn).toHaveBeenCalledTimes(2);
+    const logged = log.mock.calls.map((c) => c[0]).join("");
+    expect(logged).toMatch(/doesn't look like a Gemini key/);
+    expect(logged).toContain("starts with `AIza`");
+  });
+
+  it("re-prompts when operator says 'n' to the masked confirmation", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi
+      .fn<(q: string) => Promise<string>>()
+      .mockResolvedValueOnce("n")
+      .mockResolvedValueOnce("y");
+    const promptSecretFn = vi
+      .fn<(options: { question: string }) => Promise<string>>()
+      .mockResolvedValueOnce("AIzaSy" + "c".repeat(30))
+      .mockResolvedValueOnce("AIzaSy" + "d".repeat(30));
+
+    const result = await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+    });
+
+    expect(result).toBe("AIzaSy" + "d".repeat(30));
+    expect(promptSecretFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats empty input as skip and returns empty string", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi.fn(() => Promise.resolve("y"));
+    const promptSecretFn = vi.fn(() => Promise.resolve(""));
+
+    const result = await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+    });
+
+    expect(result).toBe("");
+    expect(promptSecretFn).toHaveBeenCalledTimes(1);
+    const logged = log.mock.calls.map((c) => c[0]).join("");
+    expect(logged).toContain("skipped");
+  });
+
+  it("gives up after maxAttempts and returns empty string", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi.fn(() => Promise.resolve("y"));
+    const promptSecretFn = vi.fn(() => Promise.resolve("not-a-valid-key"));
+
+    const result = await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+      maxAttempts: 2,
+    });
+
+    expect(result).toBe("");
+    expect(promptSecretFn).toHaveBeenCalledTimes(2);
+    const logged = log.mock.calls.map((c) => c[0]).join("");
+    expect(logged).toMatch(/Skipping GEMINI_API_KEY after 2 attempts/);
+  });
+
+  it("never prints the raw secret in log output", async () => {
+    const log = vi.fn<(m: string) => void>();
+    const askYN = vi.fn(() => Promise.resolve("y"));
+    const rawSecret = "AIzaSy" + "SECRETSECRETSECRET".repeat(2);
+    const promptSecretFn = vi.fn(() => Promise.resolve(rawSecret));
+
+    await captureSecret({
+      spec: LLM_KEY_SPECS.gemini,
+      log,
+      askYN,
+      promptSecretFn,
+    });
+
+    const logged = log.mock.calls.map((c) => c[0]).join("");
+    expect(logged).not.toContain(rawSecret);
+    // Only the last 4 chars should appear.
+    const last4 = rawSecret.slice(-4);
+    expect(logged).toContain(`…${last4}`);
+  });
+
+  // Guard against false positives on the shape heuristic — a key that
+  // happens to pass prefix + length checks but we synthesize in tests.
+  it("treats any spec with correct prefix+length as valid", () => {
+    const spec: ProviderKeySpec = LLM_KEY_SPECS.anthropic;
+    const candidate = "sk-ant-" + "z".repeat(40);
+    expect(spec.validate(candidate)).toBeNull();
+  });
+});

--- a/packages/cli/src/init-secrets.ts
+++ b/packages/cli/src/init-secrets.ts
@@ -1,0 +1,269 @@
+/**
+ * Interactive secret capture for `murmuration init` — v0.5.0 Milestone 2.
+ *
+ * Prompts with stdin in raw mode so characters aren't echoed to the
+ * terminal. Provides a provider-specific shape-validation heuristic
+ * (catches paste-from-wrong-clipboard; not cryptographic). Shows a
+ * masked last-4 confirmation so the operator can verify the paste
+ * landed. ENTER-to-skip returns an empty string and the caller writes
+ * a placeholder to .env.
+ *
+ * Exported helpers are pure (no side effects beyond stdio) so init.ts
+ * composes them and tests exercise each piece in isolation.
+ */
+
+// ---------------------------------------------------------------------------
+// Known LLM providers
+// ---------------------------------------------------------------------------
+
+export type KnownProvider = "gemini" | "anthropic" | "openai" | "ollama";
+
+/** What env var name each provider's key lives under, and how to shape-check a paste. */
+export interface ProviderKeySpec {
+  readonly envVar: string;
+  readonly displayName: string;
+  /** Human phrase describing the expected prefix ("starts with `AIza`"). */
+  readonly prefixHint: string;
+  /** Returns null if the value is shape-valid; otherwise a remediation string. */
+  validate(value: string): string | null;
+}
+
+const buildSpec = (
+  envVar: string,
+  displayName: string,
+  prefixes: readonly string[],
+  minLength: number,
+): ProviderKeySpec => ({
+  envVar,
+  displayName,
+  prefixHint:
+    prefixes.length === 1
+      ? `starts with \`${prefixes[0]!}\``
+      : `starts with one of ${prefixes.map((p) => `\`${p}\``).join(", ")}`,
+  validate(value) {
+    const v = value.trim();
+    if (v.length === 0) return null; // empty = caller treats as skip
+    if (!prefixes.some((p) => v.startsWith(p))) {
+      return `expected to ${
+        prefixes.length === 1
+          ? `start with \`${prefixes[0]!}\``
+          : `start with one of ${prefixes.map((p) => `\`${p}\``).join(", ")}`
+      }`;
+    }
+    if (v.length < minLength) {
+      return `looks too short (got ${String(v.length)} chars, expected ≥${String(minLength)})`;
+    }
+    return null;
+  },
+});
+
+export const LLM_KEY_SPECS: Readonly<Record<Exclude<KnownProvider, "ollama">, ProviderKeySpec>> = {
+  gemini: buildSpec("GEMINI_API_KEY", "Gemini", ["AIza"], 35),
+  anthropic: buildSpec("ANTHROPIC_API_KEY", "Anthropic", ["sk-ant-"], 40),
+  openai: buildSpec("OPENAI_API_KEY", "OpenAI", ["sk-"], 40),
+};
+
+export const GITHUB_TOKEN_SPEC: ProviderKeySpec = buildSpec(
+  "GITHUB_TOKEN",
+  "GitHub",
+  ["ghp_", "gho_", "github_pat_"],
+  20,
+);
+
+// ---------------------------------------------------------------------------
+// Masking
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a masked representation of a secret: the last 4 characters
+ * prefixed with an ellipsis, plus the length. Returns "<empty>" if
+ * the secret is empty — never returns anything that leaks the key.
+ */
+export const maskSecret = (secret: string): string => {
+  const s = secret.trim();
+  if (s.length === 0) return "<empty>";
+  if (s.length <= 4) return `…${s} (length ${String(s.length)})`;
+  const last4 = s.slice(-4);
+  return `…${last4} (length ${String(s.length)})`;
+};
+
+// ---------------------------------------------------------------------------
+// Echo-off input
+// ---------------------------------------------------------------------------
+
+export interface SecretPromptOptions {
+  /** The prompt shown before raw-mode capture begins. */
+  readonly question: string;
+  /** Abort signal (Ctrl+C). Caller decides what to do with it. */
+  readonly onAbort?: () => void;
+  /**
+   * Input/output streams — override for tests. Defaults to
+   * `process.stdin` / `process.stdout`.
+   */
+  readonly stdin?: NodeJS.ReadStream;
+  readonly stdout?: NodeJS.WriteStream;
+}
+
+/**
+ * Prompt for a secret with stdin in raw mode (no echo). Returns the
+ * captured string with the trailing newline stripped. Empty return
+ * value means the operator pressed ENTER to skip.
+ *
+ * Composes cleanly with readline by asking callers to pause() their
+ * readline interface before calling this, then resume() afterwards.
+ * The function takes over stdin for the duration of the prompt and
+ * restores raw mode + listeners to their prior state on exit.
+ */
+export const promptSecret = async (options: SecretPromptOptions): Promise<string> => {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+
+  // Non-TTY fallback: read one line of input without raw-mode games.
+  // Used by CI and tests.
+  if (!stdin.isTTY) {
+    stdout.write(options.question);
+    return readOneLineFromStream(stdin);
+  }
+
+  stdout.write(options.question);
+
+  return new Promise((resolveFn, rejectFn) => {
+    const chars: string[] = [];
+    const previousRaw = stdin.isRaw;
+    let settled = false;
+
+    const cleanup = (): void => {
+      stdin.removeListener("data", onData);
+      stdin.setRawMode(previousRaw);
+      stdin.pause();
+    };
+
+    const settleResolve = (value: string): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      stdout.write("\n");
+      resolveFn(value);
+    };
+
+    const settleReject = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      stdout.write("\n");
+      rejectFn(err);
+    };
+
+    const onData = (data: Buffer | string): void => {
+      const str = typeof data === "string" ? data : data.toString("utf8");
+      for (const ch of str) {
+        const code = ch.charCodeAt(0);
+        if (code === 13 || code === 10) {
+          settleResolve(chars.join(""));
+          return;
+        }
+        if (code === 3) {
+          options.onAbort?.();
+          settleReject(new Error("aborted by Ctrl+C"));
+          return;
+        }
+        if (code === 8 || code === 127) {
+          // backspace / delete — pop one character silently
+          if (chars.length > 0) chars.pop();
+          continue;
+        }
+        if (code < 32) {
+          // swallow other control chars
+          continue;
+        }
+        chars.push(ch);
+      }
+    };
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("data", onData);
+  });
+};
+
+/** Non-TTY fallback: read one newline-terminated line from stdin. */
+const readOneLineFromStream = (stdin: NodeJS.ReadStream): Promise<string> =>
+  new Promise((resolveFn) => {
+    let buffer = "";
+    const onData = (chunk: Buffer | string): void => {
+      const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      buffer += s;
+      const newlineIdx = buffer.indexOf("\n");
+      if (newlineIdx >= 0) {
+        stdin.removeListener("data", onData);
+        stdin.pause();
+        resolveFn(buffer.slice(0, newlineIdx).replace(/\r$/, ""));
+      }
+    };
+    stdin.on("data", onData);
+    stdin.resume();
+  });
+
+// ---------------------------------------------------------------------------
+// Capture-loop with shape validation + masked confirmation
+// ---------------------------------------------------------------------------
+
+export interface CaptureSecretOptions {
+  readonly spec: ProviderKeySpec;
+  /** Write function for user-visible messages (log/err). Defaults to stdout.write. */
+  readonly log?: (message: string) => void;
+  /** ask(...) style prompt, for Y/n confirmation. */
+  readonly askYN: (question: string) => Promise<string>;
+  /**
+   * If set, used instead of {@link promptSecret}. Tests inject this
+   * to drive the capture loop deterministically.
+   */
+  readonly promptSecretFn?: (options: SecretPromptOptions) => Promise<string>;
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Full capture cycle: echo-off prompt → shape validation → masked
+ * confirmation → optional re-prompt. Returns the validated secret, or
+ * an empty string if the operator pressed ENTER to skip.
+ *
+ * Never echoes the secret. Never logs the secret. Only masked output
+ * reaches stdout.
+ */
+export const captureSecret = async (options: CaptureSecretOptions): Promise<string> => {
+  const log = options.log ?? ((msg) => process.stdout.write(msg));
+  const doPrompt = options.promptSecretFn ?? promptSecret;
+  const maxAttempts = options.maxAttempts ?? 3;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const value = await doPrompt({
+      question: `Enter your ${options.spec.envVar} (input hidden, press ENTER to skip): `,
+    });
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      log(`  (skipped — you can add ${options.spec.envVar} to .env later)\n`);
+      return "";
+    }
+
+    const validationError = options.spec.validate(trimmed);
+    if (validationError !== null) {
+      log(`  That doesn't look like a ${options.spec.displayName} key — ${validationError}.\n`);
+      log(
+        `  Expected: ${options.spec.prefixHint}. Paste again, or press ENTER to skip and add it manually later.\n`,
+      );
+      continue;
+    }
+
+    log(`  Captured ${options.spec.envVar} ending in ${maskSecret(trimmed)}.\n`);
+    const confirmation = await options.askYN(`  Looks right? (Y/n): `);
+    const normalized = confirmation.trim().toLowerCase();
+    if (normalized === "" || normalized === "y" || normalized === "yes") {
+      return trimmed;
+    }
+    log(`  OK — let's try again.\n`);
+  }
+
+  log(`  Skipping ${options.spec.envVar} after ${String(maxAttempts)} attempts.\n`);
+  return "";
+};

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -1,0 +1,72 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectExistingState } from "./init.js";
+
+describe("detectExistingState (v0.5.0 Milestone 2)", () => {
+  let dir = "";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "init-state-"));
+  });
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty-or-missing for a nonexistent path", () => {
+    const result = detectExistingState(join(dir, "does-not-exist"));
+    expect(result.kind).toBe("empty-or-missing");
+  });
+
+  it("returns empty-or-missing for an empty directory", () => {
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("empty-or-missing");
+  });
+
+  it("returns current when both murmuration/ and agents/ exist (ADR-0026)", async () => {
+    await mkdir(join(dir, "murmuration"), { recursive: true });
+    await mkdir(join(dir, "agents"), { recursive: true });
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("current");
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("murmuration/"),
+        expect.stringContaining("agents/"),
+      ]),
+    );
+  });
+
+  it("returns legacy-circles when governance/circles/ exists but governance/groups/ doesn't", async () => {
+    await mkdir(join(dir, "governance", "circles"), { recursive: true });
+    await writeFile(join(dir, "governance", "circles", "example.md"), "# Example\n", "utf8");
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("legacy-circles");
+    expect(result.signals.some((s) => s.includes("circles/"))).toBe(true);
+  });
+
+  it("returns current when both governance/circles/ and governance/groups/ coexist + murmuration/ + agents/", async () => {
+    await mkdir(join(dir, "murmuration"), { recursive: true });
+    await mkdir(join(dir, "agents"), { recursive: true });
+    await mkdir(join(dir, "governance", "circles"), { recursive: true });
+    await mkdir(join(dir, "governance", "groups"), { recursive: true });
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("current");
+  });
+
+  it("returns partial when murmuration/ exists but agents/ doesn't", async () => {
+    await mkdir(join(dir, "murmuration"), { recursive: true });
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("partial");
+    expect(result.signals.some((s) => s.includes("murmuration/"))).toBe(true);
+  });
+
+  it("returns partial when agents/ exists but murmuration/ doesn't", async () => {
+    await mkdir(join(dir, "agents"), { recursive: true });
+    const result = detectExistingState(dir);
+    expect(result.kind).toBe("partial");
+  });
+});

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -28,6 +28,12 @@ import { createInterface, type Interface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
 import { buildBuiltinProviderRegistry } from "./builtin-providers/index.js";
+import {
+  captureSecret,
+  GITHUB_TOKEN_SPEC,
+  LLM_KEY_SPECS,
+  type KnownProvider,
+} from "./init-secrets.js";
 
 // DO NOT create readline at module scope — it grabs stdin and corrupts
 // terminal mode for other commands (e.g., attach REPL double echo).
@@ -139,6 +145,67 @@ const askAgentQuestions = async (
   return { name: name.trim(), dir, provider, group, schedule };
 };
 
+/**
+ * Resolve the interactive key-capture spec for a given LLM provider.
+ * Returns null for `ollama` (locally hosted; no key) and for unknown
+ * providers (no interactive capture — the operator edits .env by hand).
+ */
+const getLLMKeySpec = (
+  provider: string,
+): (typeof LLM_KEY_SPECS)[keyof typeof LLM_KEY_SPECS] | null => {
+  if (provider === "gemini" || provider === "anthropic" || provider === "openai") {
+    return LLM_KEY_SPECS[provider satisfies Exclude<KnownProvider, "ollama">];
+  }
+  return null;
+};
+
+/**
+ * What kind of murmuration layout (if any) lives at targetDir.
+ * Used to tell the operator what they're about to run against so they
+ * don't accidentally overwrite half-migrated work. v0.5.0 Milestone 2.
+ */
+export type ExistingStateKind =
+  | "empty-or-missing"
+  | "current" // ADR-0026 compliant (murmuration/ + agents/)
+  | "legacy-circles" // governance/circles/ predating ADR-0026
+  | "partial"; // some ADR-0026 pieces but missing either murmuration/ or agents/
+
+export interface ExistingStateInfo {
+  readonly kind: ExistingStateKind;
+  /** Specific signals that informed the classification. */
+  readonly signals: readonly string[];
+}
+
+export const detectExistingState = (targetDir: string): ExistingStateInfo => {
+  if (!existsSync(targetDir)) {
+    return { kind: "empty-or-missing", signals: ["directory does not exist"] };
+  }
+  const hasMurmurationDir = existsSync(join(targetDir, "murmuration"));
+  const hasAgentsDir = existsSync(join(targetDir, "agents"));
+  const hasCirclesDir = existsSync(join(targetDir, "governance", "circles"));
+  const hasGroupsDir = existsSync(join(targetDir, "governance", "groups"));
+
+  const signals: string[] = [];
+  if (hasMurmurationDir) signals.push("murmuration/ present");
+  if (hasAgentsDir) signals.push("agents/ present");
+  if (hasCirclesDir) signals.push("governance/circles/ present (pre-ADR-0026)");
+  if (hasGroupsDir) signals.push("governance/groups/ present (ADR-0026)");
+
+  if (!hasMurmurationDir && !hasAgentsDir && !hasCirclesDir && !hasGroupsDir) {
+    return {
+      kind: "empty-or-missing",
+      signals: signals.length > 0 ? signals : ["no murmuration/governance artifacts found"],
+    };
+  }
+  if (hasCirclesDir && !hasGroupsDir) {
+    return { kind: "legacy-circles", signals };
+  }
+  if (hasMurmurationDir && hasAgentsDir) {
+    return { kind: "current", signals };
+  }
+  return { kind: "partial", signals };
+};
+
 const formatScheduleYaml = (schedule: string): string => {
   if (schedule === "daily") return 'cron: "0 9 * * *"  # daily at 9am UTC';
   if (schedule === "hourly") return 'cron: "0 * * * *"  # every hour';
@@ -158,8 +225,33 @@ export const runInit = async (targetArg?: string): Promise<void> => {
   const target = targetArg ?? (await ask("Directory to create (e.g. ../my-murmuration): "));
   const targetDir = resolve(target.trim());
 
-  if (existsSync(targetDir)) {
-    const existing = await ask(`${targetDir} already exists. Continue? (y/N): `);
+  // v0.5.0 Milestone 2: detect existing state so the operator knows what
+  // they're about to run against before anything is overwritten.
+  const existingState = detectExistingState(targetDir);
+  if (existingState.kind !== "empty-or-missing") {
+    console.log(`\n${targetDir} already exists.`);
+    for (const signal of existingState.signals) {
+      console.log(`  - ${signal}`);
+    }
+    let warning = "";
+    switch (existingState.kind) {
+      case "current":
+        warning =
+          "This looks like a current (ADR-0026) murmuration. Running init here will overwrite files.";
+        break;
+      case "legacy-circles":
+        warning =
+          "This looks like a pre-ADR-0026 murmuration (governance/circles/). Running init here will overwrite files. A migration tool is planned (see ADR-0026).";
+        break;
+      case "partial":
+        warning =
+          "This looks like a partially-initialized murmuration. Running init here will overwrite any files it generates.";
+        break;
+      default:
+        break;
+    }
+    console.log(`\n${warning}`);
+    const existing = await ask(`Continue anyway? (y/N): `);
     if (existing.trim().toLowerCase() !== "y") {
       console.log("Aborted.");
       rl?.close();
@@ -177,8 +269,23 @@ export const runInit = async (targetArg?: string): Promise<void> => {
   );
   const defaultProvider = normalizeProvider(defaultProviderInput, "gemini");
 
+  // 3a. Capture the LLM API key interactively (v0.5.0 Milestone 2).
+  //     Writes to .env at the end; empty string = operator skipped and
+  //     will populate .env by hand.
+  const capturedSecrets = new Map<string, string>();
+  const llmSpec = getLLMKeySpec(defaultProvider);
+  if (llmSpec) {
+    console.log(
+      `\nLet's capture your ${llmSpec.displayName} API key. Input is hidden; press ENTER to skip.`,
+    );
+    const key = await captureSecret({ spec: llmSpec, askYN: ask });
+    if (key) capturedSecrets.set(llmSpec.envVar, key);
+  } else {
+    console.log(`\nOllama is locally-hosted — no API key needed.`);
+  }
+
   // 4. Collaboration & Products
-  const collabInput = await ask("Collaboration provider (github / local) [github]: ");
+  const collabInput = await ask("\nCollaboration provider (github / local) [github]: ");
   const collaboration = collabInput.trim().toLowerCase() === "local" ? "local" : "github";
 
   let githubOwner = "";
@@ -191,6 +298,13 @@ export const runInit = async (targetArg?: string): Promise<void> => {
       githubOwner = parts[0] ?? "";
       githubRepoName = parts[1] ?? "";
     }
+
+    // 4a. Capture GITHUB_TOKEN (v0.5.0 Milestone 2).
+    console.log(
+      `\nLet's capture your GitHub personal access token. It needs "repo" scope. Input is hidden; press ENTER to skip.`,
+    );
+    const token = await captureSecret({ spec: GITHUB_TOKEN_SPEC, askYN: ask });
+    if (token) capturedSecrets.set(GITHUB_TOKEN_SPEC.envVar, token);
   }
 
   const productInput = await ask(
@@ -393,6 +507,13 @@ budget:
 secrets:
   required: [${secretName ? `"${secretName}"` : ""}]
   ${collaboration === "github" ? '\n  optional: ["GITHUB_TOKEN"]' : ""}
+
+# MCP tools and OpenClaw plugins this agent relies on. Empty = none.
+# See ADR-0020 (MCP tool integration) and ADR-0023 (extension system).
+tools:
+  mcp: []
+
+plugins: []
 ---
 
 # ${agent.name} — Role
@@ -434,22 +555,41 @@ ${members.map((m) => `- ${m}`).join("\n")}
   // uncovered on disk even for a moment. If a .gitignore already
   // exists (e.g. running init against an existing repo), append
   // only the missing entries instead of overwriting.
-  await ensureGitignoreCovers(targetDir, [".env", ".murmuration/"]);
+  await ensureGitignoreCovers(targetDir, [".env", ".env.*", "!.env.example", ".murmuration/"]);
 
-  // .env
+  // v0.5.0 Milestone 2: .env uses captured secrets when available,
+  // placeholder when the operator skipped. .env.example ships the
+  // same keys with empty values so operators committing the repo have
+  // a template to share.
+  const secretNamesToDeclare = new Set<string>(secretNames);
+  if (githubOwner) secretNamesToDeclare.add("GITHUB_TOKEN");
+  const orderedSecretNames = [...secretNamesToDeclare].sort();
+
   const envLines: string[] = [];
-  for (const secret of secretNames) {
-    envLines.push(`${secret}=your-api-key-here`);
+  for (const name of orderedSecretNames) {
+    const captured = capturedSecrets.get(name) ?? "";
+    if (captured) {
+      envLines.push(`${name}=${captured}`);
+    } else if (name === "GITHUB_TOKEN" && !githubOwner) {
+      envLines.push(`# ${name}=ghp_your-token-here`);
+    } else {
+      envLines.push(`${name}=your-api-key-here`);
+    }
   }
-  if (githubOwner) {
-    envLines.push("GITHUB_TOKEN=ghp_your-token-here");
-  } else {
-    envLines.push("# GITHUB_TOKEN=ghp_your-token-here");
-  }
-  const envContent = envLines.join("\n") + "\n";
   const envPath = join(targetDir, ".env");
-  await writeFile(envPath, envContent, "utf8");
+  await writeFile(envPath, envLines.join("\n") + "\n", "utf8");
   await chmod(envPath, 0o600);
+
+  // .env.example — commit-friendly template. Never carries captured values.
+  const envExampleLines: string[] = [
+    "# Copy to .env and fill in. Never commit .env — .gitignore covers it.",
+    "# Permissions: chmod 600 .env",
+    "",
+  ];
+  for (const name of orderedSecretNames) {
+    envExampleLines.push(`${name}=`);
+  }
+  await writeFile(join(targetDir, ".env.example"), envExampleLines.join("\n") + "\n", "utf8");
 
   // Register session
   const sessionName = targetDir.split("/").pop() ?? "murmuration";
@@ -464,39 +604,37 @@ ${members.map((m) => `- ${m}`).join("\n")}
   // Print next steps
   // -------------------------------------------------------------------
 
-  const agentList = agents.map((a) => `    agents/${a.dir}/soul.md + role.md`).join("\n");
-  const groupList =
-    groups.length > 0 ? "\n" + groups.map((g) => `    governance/groups/${g}.md`).join("\n") : "";
+  // v0.5.0 Milestone 2: lead with the hero command a tester runs next.
+  // Optional per-agent tuning hints follow; no step-by-step chore list.
+  const firstGroup = groups[0];
+  const heroCommand = firstGroup
+    ? `  murmuration group-wake --name ${sessionName} --group ${firstGroup}\n`
+    : `  murmuration start --name ${sessionName}\n`;
+
+  const capturedSecretsSummary = [...capturedSecrets.keys()].sort();
+  const capturedHint =
+    capturedSecretsSummary.length > 0
+      ? `  ✓ Captured: ${capturedSecretsSummary.join(", ")} (written to .env at 0600)\n`
+      : `  ⚠ No secrets captured — edit .env before running any command.\n`;
 
   const governanceNote =
     governance !== "none"
-      ? `\n4. To use governance, point to the plugin:\n   murmuration start --name ${sessionName} --governance examples/governance-s3/index.mjs`
+      ? `\n  Governance plugin: ${governancePlugin ?? governance} (configured in murmuration/harness.yaml)`
       : "";
 
-  const githubNote = githubOwner
-    ? `\n${governance !== "none" ? "5" : "4"}. Ensure GITHUB_TOKEN has repo scope for ${githubOwner}/${githubRepoName}`
-    : "";
+  console.log(`
+✓ Murmuration initialized at ${targetDir}
+  Registered as "${sessionName}".${governanceNote}
 
-  console.log(`Done! Created:
-  ${targetDir}/
-    murmuration/soul.md
-    murmuration/harness.yaml
-    murmuration/default-agent/soul.md  (fallback identity — ADR-0027)
-    murmuration/default-agent/role.md  (fallback identity — ADR-0027)
-${agentList}${groupList}
-    .env (0600)
-    .gitignore
+${capturedHint}
+Try it now:
 
-Registered as "${sessionName}".
+  murmuration doctor --name ${sessionName}   # validate the setup
+${heroCommand}
+Next:
 
-Next steps:
-
-1. Edit .env — add your real API keys
-2. Edit the soul.md and role.md files — fill in the placeholders
-3. Review murmuration/default-agent/{soul,role}.md — these are used as
-   the fallback identity for any agent directory that's missing its
-   own files. Tune them to your murmuration's defaults.
-4. Boot the daemon:
-   murmuration start --name ${sessionName}${governanceNote}${githubNote}
+  - Edit agents/<id>/soul.md and role.md to flesh out each agent's voice
+  - Edit governance/groups/<id>.md to flesh out each group's domain
+  - Edit murmuration/default-agent/{soul,role}.md to tune fallback identity
 `);
 };


### PR DESCRIPTION
## Summary

Closes the last mile of the init UX per [v0.5.0 plan §4.1](https://github.com/murmurations-ai/murmurations-harness/blob/plan/v0.5.0-init-ux-overhaul/docs/plans/v0.5.0-init-ux-overhaul.md#41-init-ux-overhaul-single-pr). A new operator now runs `murmuration init`, answers ~10 questions, pastes API keys when prompted, and gets a runnable murmuration with zero file editing.

## What changes

### 1. Interactive secret capture (`init-secrets.ts` — new)

- **Echo-off prompt** (`promptSecret`) — raw-mode stdin handler that coexists with readline, supports backspace / Ctrl+C / multi-byte paste, and falls back to a plain line read when stdin isn't a TTY (CI, tests).
- **Shape validators** per provider:
  - Gemini: starts with `AIza`, ≥35 chars
  - Anthropic: starts with `sk-ant-`, ≥40 chars
  - OpenAI: starts with `sk-`, ≥40 chars
  - GitHub tokens: starts with `ghp_` / `gho_` / `github_pat_`, ≥20 chars
- **Masked-last-4 confirmation** (`maskSecret`) — e.g. `Captured GEMINI_API_KEY ending in …AbCd (length 39). Looks right? (Y/n)`.
- **Capture loop** (`captureSecret`) — echo-off prompt → shape validation → confirmation → optional retry. Any validation failure offers ENTER-to-skip rather than hard-rejecting (heuristics can drift).

### 2. Wired into `runInit`

- After the LLM provider question → prompt for `<PROVIDER>_API_KEY`
- After GitHub collaboration confirmed → prompt for `GITHUB_TOKEN`
- Captured values written directly into `.env` at `0600`. Skipped values get a placeholder.
- New `.env.example` with empty values (commit-friendly template)
- Updated `.gitignore` to cover `.env.*` while allowing `.env.example`

### 3. Pre-init state detection

`detectExistingState(targetDir)` classifies pre-existing directories as:
- `empty-or-missing` — proceed freely
- `current` — ADR-0026 compliant; warn about overwrites
- `legacy-circles` — pre-ADR-0026; warn about overwrites + note migration tool planned
- `partial` — halfway-initialized; warn

The init now reports what it found before asking "continue anyway?" — operators don't accidentally overwrite half-migrated repos.

### 4. `role.md` + hero command

- Generated `role.md` now emits `tools.mcp: []` and `plugins: []` for parity with the default-agent template and ADR-0020 / ADR-0023.
- Post-init message replaced with a hero-command sequence:

  ```
  ✓ Murmuration initialized at /path/to/dir
    Registered as "my-murm".

    ✓ Captured: GEMINI_API_KEY, GITHUB_TOKEN (written to .env at 0600)

  Try it now:

    murmuration doctor --name my-murm   # validate the setup
    murmuration group-wake --name my-murm --group research
  ```

### 5. Live credential validation — deferred to Milestone 3

Spec'd as part of M2 but deferred to `murmuration doctor --live` (Milestone 3). Rationale: keeps init flow tight; one place for every live check; operators can run `doctor --live` at any time, not just at init.

## Test plan

- [x] 30 new unit tests, all green
- [x] `pnpm run build` — all 8 packages
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 608 passed, 1 skipped
- [ ] Manual smoke: `murmuration init` in a /tmp dir, paste a test key, observe flow
- [ ] Manual smoke: `murmuration init` in an existing EP-like dir, confirm `legacy-circles` is detected and prompted

## Milestone status

- ✅ Milestone 1 — error legibility (#125, merged)
- ✅ Milestone 2 — init UX overhaul (this PR)
- ⏳ Milestone 3 — `murmuration doctor`
- ⏳ Milestone 4 — `hello-circle` example
- ⏳ Milestone 5 — docs + release

## Related

- Plan: [`docs/plans/v0.5.0-init-ux-overhaul.md`](../blob/plan/v0.5.0-init-ux-overhaul/docs/plans/v0.5.0-init-ux-overhaul.md) (PR #124)
- Precursor: #125 (error legibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)