### PR TITLE
feat: reasonable defaults cascade (v0.5.0 Milestone 2.5 — Engineering Standard #11)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -604,6 +604,38 @@ Empty catch blocks (`catch { /* best effort */ }`) hide real failures. If an err
 
 The `/api/status` response shape is a public API consumed by the web dashboard, TUI, and future external tools. Define it as a TypeScript interface. Don't compute it with ad-hoc object literals scattered across closures.
 
+### 11. Reasonable defaults everywhere except for identity and secrets
+
+The harness boots and runs against **sparse configuration**. Every field that isn't a secret or a unique identity claim has a reasonable default; missing ≠ broken. Operators should be able to scaffold a murmuration with the minimum frontmatter and have the harness fill in the rest.
+
+The only fields that legitimately require operator input:
+
+- **Secrets** — API keys, tokens. These can't be defaulted by definition; `init` captures them interactively, `doctor` verifies them.
+- **Unique identity claims** — a directory name that means something to the operator (agent slug, group id). The harness can't invent these; but when it has the directory in hand at load time (e.g., `IdentityLoader.load(agentDir)`), it derives reasonable defaults from that context rather than demanding duplicate declarations.
+
+Everything else inherits, cascades, or has a sensible built-in:
+
+- Missing `harness.yaml` → `loadHarnessConfig` returns documented defaults
+- Missing `role.md` → ADR-0027 fallback identity with a visible `daemon.agent.fallback` warning
+- Missing `agent_id` in role.md → derived from the agent directory slug
+- Missing `name` → humanized directory slug (`research-agent` → `"Research Agent"`)
+- Missing `model_tier` → `"balanced"`
+- Missing `soul_file` → `"soul.md"` (relative to the agent directory)
+- Missing `llm.provider` in role.md → cascade to `harness.yaml` `llm.provider`; then to the harness-wide built-in default
+- Missing `signals.sources` → `["github-issue", "private-note"]`
+- Missing `group_memberships` → `[]`
+- Missing `wake_schedule` → dispatch-only (no cron registration; the daemon won't wake this agent on a timer)
+- Missing `governance.plugin` → no-op plugin that allows every action and emits no events
+- Missing `tools.mcp` / `plugins` → `[]`
+
+**Anti-pattern:** Require every operator to list `llm.provider` on every agent even though they already set it in `harness.yaml`. Mistake → init boot-time failure with a cryptic schema error.
+**Fix:** `role.md` `llm:` is optional; if absent, the agent inherits `harness.yaml`'s `llm:`.
+
+**Anti-pattern:** Require `agent_id` in the frontmatter even though the loader already knows the directory name.
+**Fix:** Loader fills `agent_id` from the directory slug before Zod validation runs; explicit operator value still wins.
+
+This principle is what makes `murmuration init` → `murmuration group-wake` a 4-command experience instead of a 40-minute tour of every YAML field.
+
 ---
 
 ## What We Don't Build

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -631,6 +631,13 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         ...(reason.detail !== undefined ? { detail: reason.detail } : {}),
       });
     },
+    // Engineering Standard #11: cascade harness.yaml `llm:` into each
+    // agent's role.md when the agent omits it.
+    roleDefaults: {
+      llm: config.llm.model
+        ? { provider: config.llm.provider, model: config.llm.model }
+        : { provider: config.llm.provider },
+    },
   });
 
   // -------------------------------------------------------------------

--- a/packages/cli/src/group-wake.test.ts
+++ b/packages/cli/src/group-wake.test.ts
@@ -104,6 +104,13 @@ body
   });
 
   it("returns ok=false reason=no-llm-block when role.md is missing the llm: key", async () => {
+    // v0.5.0 Engineering Standard #11: when role.md has no llm: block,
+    // the loader cascades from harness.yaml. If harness.yaml is present
+    // with an llm: block, the cascade fills in the agent. If neither
+    // role.md nor harness.yaml set llm, and loadHarnessConfig returns
+    // its built-in default (gemini), cascade still succeeds — so
+    // `no-llm-block` is now a degenerate case that requires explicit
+    // setup to produce.
     await writeAgent(
       "facilitator",
       `---
@@ -115,12 +122,11 @@ body
 `,
     );
     const result = await resolveLLMConfig(rootDir, "facilitator");
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe("no-llm-block");
-      if (result.reason === "no-llm-block") {
-        expect(result.rolePath).toContain("agents/facilitator/role.md");
-      }
+    // With harness.yaml built-in defaults cascading in, the facilitator
+    // inherits gemini and resolveLLMConfig succeeds.
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("gemini");
     }
   });
 
@@ -136,12 +142,13 @@ body
   });
 
   it("returns ok=false reason=frontmatter-invalid with the Zod issues when schema fails", async () => {
+    // Numeric agent_id used to trigger schema failure. v0.5.0 coerces
+    // numerics to strings (Engineering Standard #11). To exercise the
+    // frontmatter-invalid path today, use an actually-invalid enum.
     await writeAgent(
       "facilitator",
       `---
-agent_id: 22
-name: "Facilitator"
-model_tier: balanced
+model_tier: galactic
 ---
 body
 `,
@@ -152,10 +159,9 @@ body
       expect(result.reason).toBe("frontmatter-invalid");
       if (result.reason === "frontmatter-invalid") {
         expect(result.path).toContain("agents/facilitator/role.md");
-        // Issue list carries both the Zod message and the v0.5.0 remediation hint
         const joined = result.issues.join("\n");
-        expect(joined).toContain("agent_id");
-        expect(joined).toContain('"facilitator"');
+        expect(joined).toContain("model_tier");
+        expect(joined).toContain("balanced");
       }
     }
   });

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -70,7 +70,18 @@ export const resolveLLMConfig = async (
 ): Promise<ResolveLLMResult> => {
   const rolePath = resolve(rootDir, "agents", facilitatorId, "role.md");
   try {
-    const loader = new IdentityLoader({ rootDir });
+    // Engineering Standard #11: cascade harness.yaml's `llm:` into the
+    // facilitator's role.md when absent.
+    const { loadHarnessConfig } = await import("./harness-config.js");
+    const harness = await loadHarnessConfig(rootDir);
+    const loader = new IdentityLoader({
+      rootDir,
+      roleDefaults: {
+        llm: harness.llm.model
+          ? { provider: harness.llm.provider, model: harness.llm.model }
+          : { provider: harness.llm.provider },
+      },
+    });
     const identity = await loader.load(facilitatorId);
     const llm = identity.frontmatter.llm;
     if (llm) {

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -27,6 +27,8 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface, type Interface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
+import { humanizeSlug } from "@murmurations-ai/core";
+
 import { buildBuiltinProviderRegistry } from "./builtin-providers/index.js";
 import {
   captureSecret,
@@ -477,18 +479,28 @@ _Define the agent-specific bright lines beyond the murmuration soul._
     labels: []
     issues: []`;
 
+    // Engineering Standard #11 — emit only fields the operator explicitly
+    // chose or that differ from schema/cascade defaults. Omitted fields
+    // inherit: agent_id from dir; name humanized from dir; model_tier
+    // "balanced"; soul_file "soul.md"; llm from harness.yaml.
+    const llmOverride =
+      agent.provider !== defaultProvider ? `\nllm:\n  provider: "${agent.provider}"\n` : "";
+
     await writeFile(
       join(targetDir, "agents", agent.dir, "role.md"),
       `---
-agent_id: "${agent.dir}"
-name: "${agent.name}"
-model_tier: "balanced"
+# Minimum-viable frontmatter. Anything omitted inherits reasonable
+# defaults per docs/ARCHITECTURE.md Engineering Standard #11:
+#   agent_id    → directory name ("${agent.dir}")
+#   name        → humanized directory ("${humanizeSlug(agent.dir)}")
+#   model_tier  → "balanced"
+#   soul_file   → "soul.md"
+#   llm         → inherits murmuration/harness.yaml
+# Uncomment any line to override.
+
 max_wall_clock_ms: 120000
 group_memberships:${groupLine || "\n  []"}
-
-llm:
-  provider: "${agent.provider}"
-
+${llmOverride}
 wake_schedule:
   ${formatScheduleYaml(agent.schedule)}
 
@@ -508,8 +520,7 @@ secrets:
   required: [${secretName ? `"${secretName}"` : ""}]
   ${collaboration === "github" ? '\n  optional: ["GITHUB_TOKEN"]' : ""}
 
-# MCP tools and OpenClaw plugins this agent relies on. Empty = none.
-# See ADR-0020 (MCP tool integration) and ADR-0023 (extension system).
+# MCP tools and OpenClaw plugins. Empty = none.
 tools:
   mcp: []
 

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -174,7 +174,9 @@ group_memberships:
     await expect(loader.load("11-bad")).rejects.toBeInstanceOf(FrontmatterInvalidError);
   });
 
-  it("throws FrontmatterInvalidError when required fields are missing", async () => {
+  it("fills in missing agent_id from the directory name (Reasonable defaults)", async () => {
+    // Engineering Standard #11: operators shouldn't have to repeat the
+    // directory name as agent_id. The loader derives it automatically.
     await writeFixture("murmuration/soul.md", "# Soul\n");
     await writeFixture("agents/12-incomplete/soul.md", "# Soul\n");
     await writeFixture(
@@ -188,16 +190,10 @@ name: "Incomplete"
     );
 
     const loader = new IdentityLoader({ rootDir });
-
-    try {
-      await loader.load("12-incomplete");
-      throw new Error("expected FrontmatterInvalidError");
-    } catch (err) {
-      expect(err).toBeInstanceOf(FrontmatterInvalidError);
-      if (err instanceof FrontmatterInvalidError) {
-        expect(err.issues.some((i) => i.includes("agent_id"))).toBe(true);
-      }
-    }
+    const loaded = await loader.load("12-incomplete");
+    expect(loaded.frontmatter.agent_id).toBe("12-incomplete");
+    expect(loaded.frontmatter.name).toBe("Incomplete");
+    expect(loaded.frontmatter.model_tier).toBe("balanced");
   });
 
   it("throws FrontmatterInvalidError when model_tier is invalid", async () => {
@@ -221,7 +217,11 @@ model_tier: galactic
   });
 
   describe("Zod issue annotation (v0.5.0 Milestone 1)", () => {
-    it("numeric agent_id: error message names the file path AND suggests the fix", async () => {
+    it("numeric agent_id is coerced to a string rather than rejected (Engineering Standard #11)", async () => {
+      // A legacy `agent_id: 22` (YAML integer) used to crash boot with a
+      // schema error. v0.5.0 coerces to string before validation — the
+      // operator's intent was clearly "a string ID", and the harness
+      // doesn't enforce agent_id === dirname, so 22 is accepted as "22".
       await writeFixture("murmuration/soul.md", "# Soul\n");
       await writeFixture("agents/facilitator/soul.md", "# Soul\n");
       await writeFixture(
@@ -237,21 +237,8 @@ model_tier: balanced
       );
 
       const loader = new IdentityLoader({ rootDir });
-      try {
-        await loader.load("facilitator");
-        throw new Error("expected FrontmatterInvalidError");
-      } catch (err) {
-        expect(err).toBeInstanceOf(FrontmatterInvalidError);
-        if (err instanceof FrontmatterInvalidError) {
-          // File path present
-          expect(err.path).toContain("agents/facilitator/role.md");
-          // Remediation hint explicitly names the directory-matching slug
-          const joined = err.issues.join("\n");
-          expect(joined).toContain("agent_id");
-          expect(joined).toContain('"facilitator"');
-          expect(joined).toContain("quoted string");
-        }
-      }
+      const loaded = await loader.load("facilitator");
+      expect(loaded.frontmatter.agent_id).toBe("22");
     });
 
     it("wrong model_tier: issue names the valid enum values", async () => {
@@ -315,6 +302,70 @@ llm:
           expect(joined).toContain("ollama");
         }
       }
+    });
+  });
+
+  describe("Reasonable defaults cascade (Engineering Standard #11)", () => {
+    it("derives agent_id from directory when omitted", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/my-agent/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/my-agent/role.md",
+        `---
+name: "My Agent"
+---
+
+body
+`,
+      );
+      const loader = new IdentityLoader({ rootDir });
+      const loaded = await loader.load("my-agent");
+      expect(loaded.frontmatter.agent_id).toBe("my-agent");
+    });
+
+    it("humanizes the directory name when name is omitted", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/research-agent/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/research-agent/role.md",
+        "---\n# minimum frontmatter\n---\nbody\n",
+      );
+      const loader = new IdentityLoader({ rootDir });
+      const loaded = await loader.load("research-agent");
+      expect(loaded.frontmatter.name).toBe("Research Agent");
+    });
+
+    it("cascades llm from harness.yaml when role.md omits it", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/silent/soul.md", "# Soul\n");
+      await writeFixture("agents/silent/role.md", "---\n# minimum frontmatter\n---\nbody\n");
+      const loader = new IdentityLoader({
+        rootDir,
+        roleDefaults: { llm: { provider: "anthropic" } },
+      });
+      const loaded = await loader.load("silent");
+      expect(loaded.frontmatter.llm?.provider).toBe("anthropic");
+    });
+
+    it("role.md llm wins over harness-level default when both are set", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/opinionated/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/opinionated/role.md",
+        `---
+llm:
+  provider: "openai"
+---
+
+body
+`,
+      );
+      const loader = new IdentityLoader({
+        rootDir,
+        roleDefaults: { llm: { provider: "gemini" } },
+      });
+      const loaded = await loader.load("opinionated");
+      expect(loaded.frontmatter.llm?.provider).toBe("openai");
     });
   });
 

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -58,6 +58,73 @@ export class IdentityFileMissingError extends IdentityLoaderError {
 }
 
 /**
+ * Convert a kebab-case directory slug into a human-readable name.
+ * `engineering-lead-agent` → `"Engineering Lead Agent"`.
+ * Used by {@link enrichRoleFrontmatter} when role.md doesn't declare
+ * a `name` — per Engineering Standard #11 (Reasonable defaults).
+ */
+export const humanizeSlug = (slug: string): string =>
+  slug
+    .split(/[-_]/)
+    .filter((s) => s.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+/**
+ * Enrich a parsed role.md frontmatter with directory-derived and
+ * harness-level defaults per Engineering Standard #11.
+ *
+ * Cascade rules (operator explicit > directory context > harness
+ * default > schema default):
+ *   - `agent_id` — defaults to the agent directory slug
+ *   - `name` — defaults to the humanized directory slug
+ *   - `model_tier` — defaults to `"balanced"`
+ *   - `soul_file` — defaults to `"soul.md"` (relative to the agent dir)
+ *   - `llm` — inherits from `harness.yaml`'s `llm:` when role.md
+ *     omits it; preserves role.md's value when present.
+ *
+ * The returned value is intentionally pre-validation so the schema
+ * still enforces type correctness on everything (including the
+ * defaults). Exported for unit tests.
+ */
+export const enrichRoleFrontmatter = (
+  raw: unknown,
+  agentDir: string,
+  roleDefaults?: { readonly llm?: { readonly provider: LLMProvider; readonly model?: string } },
+): Record<string, unknown> => {
+  const base =
+    typeof raw === "object" && raw !== null ? { ...(raw as Record<string, unknown>) } : {};
+
+  // Coerce numeric values to strings before deciding whether to default.
+  // A legacy `agent_id: 22` parses as a number; operators clearly meant
+  // that as a string ID, so stringify rather than blocking or replacing.
+  if (typeof base.agent_id === "number") base.agent_id = String(base.agent_id);
+  if (typeof base.name === "number") base.name = String(base.name);
+
+  if (typeof base.agent_id !== "string" || base.agent_id.length === 0) {
+    base.agent_id = agentDir;
+  }
+  if (typeof base.name !== "string" || base.name.length === 0) {
+    base.name = humanizeSlug(agentDir);
+  }
+  if (typeof base.model_tier !== "string" || base.model_tier.length === 0) {
+    base.model_tier = "balanced";
+  }
+  if (typeof base.soul_file !== "string" || base.soul_file.length === 0) {
+    base.soul_file = "soul.md";
+  }
+  // `llm` cascade: inherit harness-level default only when role.md
+  // declared nothing. Explicit operator override always wins.
+  if ((base.llm === undefined || base.llm === null) && roleDefaults?.llm !== undefined) {
+    base.llm =
+      roleDefaults.llm.model !== undefined
+        ? { provider: roleDefaults.llm.provider, model: roleDefaults.llm.model }
+        : { provider: roleDefaults.llm.provider };
+  }
+  return base;
+};
+
+/**
  * Render a Zod issue with a remediation hint when the failure matches
  * a well-known pattern a new operator is likely to hit (numeric
  * `agent_id`, wrong `model_tier` spelling, etc.). Unknown patterns fall
@@ -134,6 +201,10 @@ const modelTierSchema = z.enum(["fast", "balanced", "deep"]);
  * `ProviderId`. Extended in ADR-0016 (Phase 2C role template).
  */
 const llmProviderSchema = z.enum(["gemini", "anthropic", "openai", "ollama"]);
+
+/** LLM provider enum surface used by harness-level defaults. Kept in
+ *  sync with `llmProviderSchema` above. */
+export type LLMProvider = z.infer<typeof llmProviderSchema>;
 
 /**
  * Cron expression validator. Uses `cron-parser` at load time; any
@@ -376,6 +447,20 @@ export interface IdentityLoaderConfig {
    * host process can log a visible warning (`daemon.agent.fallback`).
    */
   readonly onFallback?: (agentDir: string, reason: IdentityFallbackReason) => void;
+  /**
+   * Harness-level defaults that cascade into each agent's role.md
+   * frontmatter when the agent didn't declare them locally. Per
+   * Engineering Standard #11 (Reasonable defaults), any field absent
+   * from role.md should inherit from this block rather than blocking
+   * boot. Today the only cascading field is `llm` — if role.md has no
+   * `llm:` block, the agent inherits the harness-level provider.
+   *
+   * Callers (boot.ts, group-wake.ts) load `harness.yaml` and pass its
+   * `llm:` block here. Undefined means "no cascade" (legacy behavior).
+   */
+  readonly roleDefaults?: {
+    readonly llm?: { readonly provider: LLMProvider; readonly model?: string };
+  };
 }
 
 /** Why a fallback identity was synthesized for an agent directory. */
@@ -418,6 +503,7 @@ export class IdentityLoader {
   readonly #groupsDir: string;
   readonly #fallbackOnMissing: boolean;
   readonly #onFallback: ((agentDir: string, reason: IdentityFallbackReason) => void) | undefined;
+  readonly #roleDefaults: IdentityLoaderConfig["roleDefaults"];
 
   public constructor(config: IdentityLoaderConfig) {
     this.#rootDir = resolve(config.rootDir);
@@ -426,6 +512,7 @@ export class IdentityLoader {
     this.#groupsDir = config.groupsDir ?? "governance/groups";
     this.#fallbackOnMissing = config.fallbackOnMissing ?? false;
     this.#onFallback = config.onFallback;
+    this.#roleDefaults = config.roleDefaults;
   }
 
   /**
@@ -573,6 +660,12 @@ export class IdentityLoader {
       );
     }
 
+    // Engineering Standard #11 — fill in reasonable defaults BEFORE
+    // schema validation. Explicit operator values always win; missing
+    // fields get directory-derived (agent_id, name) or harness-level
+    // (llm) fallbacks.
+    frontmatterRaw = enrichRoleFrontmatter(frontmatterRaw, agentDir, this.#roleDefaults);
+
     const parsed = roleFrontmatterSchema.safeParse(frontmatterRaw);
     if (!parsed.success) {
       if (!this.#fallbackOnMissing) {
@@ -586,8 +679,12 @@ export class IdentityLoader {
         missingFiles,
         detail: parsed.error.issues.map((i) => i.message).join("; "),
       };
-      frontmatterRaw = parseYaml(
-        splitFrontmatter(await this.#resolveDefaultAgentRole(agentDir)).frontmatter ?? "",
+      frontmatterRaw = enrichRoleFrontmatter(
+        parseYaml(
+          splitFrontmatter(await this.#resolveDefaultAgentRole(agentDir)).frontmatter ?? "",
+        ),
+        agentDir,
+        this.#roleDefaults,
       );
     }
 


### PR DESCRIPTION
## Summary

Codifies **Reasonable defaults** as Engineering Standard #11 in `docs/ARCHITECTURE.md` and makes the harness boot against sparse role.md frontmatter. A new operator writing only the minimum fields gets a working agent; everything missing inherits from directory context or `harness.yaml`.

This is v0.5.0 Milestone 2.5 — slotted between Milestone 2 (init UX overhaul, merged in #126) and Milestone 3 (`murmuration doctor`) so that doctor can rely on "if the operator skipped a field, it has a default" rather than flagging every omission.

## The principle (new §11 in `docs/ARCHITECTURE.md`)

> The harness boots and runs against sparse configuration. Every field that isn't a secret or a unique identity claim has a reasonable default; missing ≠ broken.

## What now defaults automatically

In `role.md` frontmatter, at load time:

| Field | Source when omitted |
|---|---|
| `agent_id` | directory slug |
| `agent_id` (numeric) | stringified, preserved |
| `name` | humanized directory (`research-agent` → `"Research Agent"`) |
| `name` (numeric) | stringified |
| `model_tier` | `"balanced"` |
| `soul_file` | `"soul.md"` |
| `llm` | cascades from `harness.yaml`'s `llm:` block |
| (explicit `llm`) | wins — cascade doesn't override operator intent |

## Implementation

- **`enrichRoleFrontmatter(raw, agentDir, roleDefaults)`** in `packages/core/src/identity/index.ts`. Called inside `IdentityLoader.load` right after YAML parse, before Zod validation. Schema stays strict; enrichment happens upstream.
- **`humanizeSlug(slug)`** helper exported from core; `init.ts` uses it to tell operators what their directory names will become.
- **`IdentityLoaderConfig.roleDefaults`** threads `harness.yaml`'s `llm:` through the loader. `boot.ts` and `group-wake.ts` both load `harness.yaml` and pass the block.
- **Simplified init-generated `role.md`** — drops `agent_id` / `name` / `model_tier` / `soul_file`; only emits `llm:` when the operator chose a per-agent override. Replaced with an inline comment block documenting each inherited default.

## Tests

**612 pass** (+3 from main). Updates to match inverted behavior:

- "throws FrontmatterInvalidError when required fields are missing" → "fills in missing agent_id from directory name"
- Numeric `agent_id` Zod-annotation test → "numeric agent_id is coerced to string"
- `group-wake` no-llm-block test → updated: cascade now fills in harness.yaml's default
- `group-wake` frontmatter-invalid test → switched to an actually-invalid enum (model_tier)

**4 new tests:** agent_id from dir, humanized name, llm cascade from `roleDefaults`, explicit `llm` wins over cascade.

## Effect on EP (the repo that motivated this)

EP had `agent_id: 22` (numeric) which blocked boot pre-v0.5. After this change, that agent loads with `agent_id: "22"` (stringified). Migration PR #465 quoted these by hand; had M2.5 existed first, that PR would have been unnecessary.

## Milestone status

- ✅ M1 — error legibility (#125)
- ✅ M2 — init UX overhaul (#126)
- ✅ **M2.5 — reasonable defaults (this PR)**
- ⏳ M3 — `murmuration doctor`
- ⏳ M4 — `hello-circle` example
- ⏳ M5 — docs + release

## Test plan

- [x] `pnpm run build` — all 8 packages
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 612 passed, 1 skipped
- [ ] Manual: scaffold a murmuration with minimum role.md (just a body, no frontmatter fields) and confirm it boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)