### PR TITLE
docs: v0.5.0 release notes + tester onboarding (Milestone 5 — NOT RELEASED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,72 @@
 All notable changes to the Murmuration Harness are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.5.0] — Unreleased (in tester validation)
+
+**"Out of the box" — a non-technical tester can go from `npm install` to a running meeting in under 10 minutes with zero file editing beyond pasting one API key.**
+
+The v0.5.0 work started from a lived failure: on 2026-04-20, a motivated operator hit seven distinct failure points between `murmuration init` and a working circle meeting. v0.5.0 makes each of those failures impossible to reproduce.
+
+### Added
+
+- **`murmuration doctor`** — preflight diagnosis command with six check categories (layout, schema, secrets, governance, live, drift). `--fix` applies safe auto-remediations (rename `circles/` → `groups/`, `chmod 600 .env`, patch missing `.gitignore` entries). `--live` opts into provider API calls that verify credentials actually authenticate. `--json` emits machine-readable output for CI. 12 integration tests.
+- **`murmuration init --example hello`** — scaffold the bundled `hello-circle` example (2 agents, 1 group, local collaboration, Gemini default) into a fresh directory. From npm install to first meeting in 6 commands.
+- **Interactive secret capture in `init`** — after the LLM provider question, init prompts for the matching `<PROVIDER>_API_KEY` with echo-off, provider-specific shape validation (`AIza…` for Gemini, `sk-ant-…` for Anthropic, `sk-…` for OpenAI, `ghp_…` / `gho_…` / `github_pat_…` for GitHub), and masked-last-4 confirmation. Written directly to `.env` at `0600`; never echoed.
+- **Pre-init state detection** — `init` classifies an existing target directory as `empty-or-missing`, `current` (ADR-0026), `legacy-circles` (pre-ADR-0026), or `partial` before anything is overwritten. Operators see what's there with a specific warning per kind.
+- **`.env.example` on init** — commit-friendly template shipped alongside the 0600-permissioned `.env`. `.gitignore` updated to cover `.env.*` but preserve `.env.example`.
+- **Engineering Standard #11: Reasonable defaults** — codified in `docs/ARCHITECTURE.md`. Any field that isn't a secret or a unique identity claim has a reasonable default; the harness boots against sparse configuration.
+- **Engineering Standard #11 cascade in `role.md`**:
+  - `agent_id` defaults to the directory slug
+  - Numeric `agent_id: 22` coerces to `"22"` (no crash)
+  - `name` defaults to the humanized directory slug
+  - `model_tier` defaults to `"balanced"`
+  - `soul_file` defaults to `"soul.md"`
+  - `llm` cascades from `harness.yaml`'s `llm:` block when role.md omits it
+- **`humanizeSlug(slug)` + `enrichRoleFrontmatter(raw, agentDir, roleDefaults)`** exported from `@murmurations-ai/core` for programmatic use.
+- **`IdentityLoaderConfig.roleDefaults`** — threads the harness-level `llm:` block into the loader so the cascade runs everywhere (boot.ts, group-wake.ts).
+- **`murmuration doctor --name <session>` + hero-command post-init message** — init's final output shows the next command to run verbatim, with the session registered so `--name` shortcuts work immediately.
+- **`tools.mcp: []` + `plugins: []`** emitted in init-generated `role.md` for parity with the default-agent template.
+- **`docs/GETTING-STARTED.md`** rewritten as a tester walkthrough with expected output and a "what to do when…" table for the top 10 failure modes.
+- **`docs/MIGRATION-GUIDE.md`** — upgrade path from pre-v0.5 murmurations, including the Emergent Praxis migration case study.
+
+### Changed
+
+- **Generated `role.md` is ~15 lines shorter.** Init emits minimum-viable frontmatter; Engineering Standard #11 fills in the rest at load time.
+- **`murmuration/default-agent/` fallback role.md** now uses Engineering Standard #11 shape (no duplicated agent_id/name/model_tier when defaults are correct).
+- **README quickstart** leads with the 6-command tester flow instead of the developer-from-source install. Developer install moved to its own section below.
+- **Facilitator LLM resolution** (`group-wake.ts`) — new `ResolveLLMResult` discriminated union replaces the catch-all return-null. Each failure mode (`no-llm-block`, `file-not-found`, `frontmatter-invalid`, `other`) prints targeted remediation instead of `could not read LLM config`.
+- **`IdentityLoader` error messages** — Zod issues for role.md are annotated with remediation hints when the failure matches a common new-operator pattern (numeric `agent_id`, wrong `model_tier`, wrong `llm.provider`, missing required field).
+- **`GitHubCollaborationProvider` error mapping** — GitHub client's hyphen-case codes (`"not-found"`, `"unauthorized"`, `"write-scope-denied"`) now map correctly to `CollaborationErrorCode`. The previous upper-case-only check meant every real GitHub error rendered as `UNKNOWN`. Legacy upper-case codes still accepted for forward compat. Defense in depth: `executeActions` now prints `CODE: message` so even unmapped codes carry the real underlying error.
+
+### Fixed
+
+- **Operators saw `could not read LLM config from facilitator` when the real failure was a schema validation error.** The catch-all in `resolveLLMConfig` swallowed the actual Zod error. Fixed to distinguish and report the true cause.
+- **Operators saw `create-issue: UNKNOWN` on every GitHub action failure.** GitHub provider error codes now map correctly.
+- **`FrontmatterInvalidError` for numeric `agent_id`** used to be cryptic. Now explicitly suggests `agent_id: "<directory-name>"` as the fix (and in v0.5.0, the loader coerces automatically so operators rarely see the error at all).
+
+### Engineering
+
+- 631 tests pass (+86 net from v0.4.5), 0 lint errors, format clean.
+- New modules: `packages/cli/src/init-secrets.ts`, `packages/cli/src/doctor.ts`, `packages/cli/src/examples/hello-circle/` (12 files).
+- New tests: `init-secrets.test.ts`, `init.test.ts`, `doctor.test.ts`, `init-example.test.ts` (+ updated `group-wake.test.ts`, `identity.test.ts`, `collaboration.test.ts`).
+
+### Deferred to v0.5.1+
+
+- **Cross-repo write scopes in `CollaborationProvider`** — the engineering circle's attempt to cross-post meeting minutes onto a different repo's PR failed silently because providers are scoped to one repo. Design via ADR after v0.5.0 ships.
+- **S3 governance plugin as a standalone npm package** — v0.5.0 ships with the no-op plugin as default; real pluggable governance is v0.5.1 material.
+- **`murmuration init` live credential validation** — spec'd for M2 but deferred to `murmuration doctor --live` where it unifies with the other live checks.
+
+### Not yet released
+
+This entry documents the v0.5.0 scope. Source (Nori) wants to test locally before publishing to npm. When ready:
+
+```sh
+pnpm version minor            # bumps 0.4.5 → 0.5.0 across packages
+git tag v0.5.0
+git push --tags
+pnpm -F '@murmurations-ai/*' publish --access public
+```
+
 ## [0.4.5] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,36 @@
 
 The Murmuration Harness is an open-source TypeScript runtime that lets a single human — the **Source** — coordinate a murmuration of AI agents to do real work. It is not an autonomous agent framework. It is a tool that amplifies human agency.
 
-> **v0.3.5** — Extensions (OpenClaw-compatible), web search, `harness.yaml` config, local collaboration, `cd && murmuration`. 8 packages on npm, 486 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
+> **v0.5.0** (in testing) — Out-of-the-box init UX, `murmuration doctor` preflight, hello-circle example, reasonable defaults everywhere. 8 packages, 631 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
+
+## Quickstart (5 minutes, 6 commands)
+
+```sh
+# 1. Install
+npm install -g @murmurations-ai/cli
+
+# 2. Scaffold a working murmuration from the bundled example
+murmuration init --example hello my-first-murm
+cd my-first-murm
+
+# 3. Paste your Gemini API key (free tier is plenty — https://aistudio.google.com/apikey)
+cp .env.example .env
+chmod 600 .env
+# edit .env and paste GEMINI_API_KEY=AIza...
+
+# 4. Verify the setup
+murmuration doctor
+
+# 5. Run your first meeting
+murmuration group-wake --group example --directive "what should we scout next?"
+```
+
+You'll see the facilitator invite the scout, the scout contribute, and the facilitator synthesize a next step. Meeting minutes land in `.murmuration/items/` locally.
+
+For a real murmuration (no example), run `murmuration init` without `--example` and answer the interview.
+
+→ Full walkthrough: [docs/GETTING-STARTED.md](./docs/GETTING-STARTED.md)
+→ Upgrading from pre-v0.5: [docs/MIGRATION-GUIDE.md](./docs/MIGRATION-GUIDE.md)
 
 ## Philosophy: Source as a human role
 
@@ -33,44 +62,22 @@ The harness runs any number of AI agents as a coordinated "murmuration" — sche
 6. **Real work, not theater** — every action produces artifacts; meetings execute structured actions against GitHub
 7. **Identity is inherited** — murmuration soul → agent soul → role; governance and operations are separate concerns
 
-## Quick start
+## Developer install from source
 
-```bash
-# Prerequisites: Node 20+, pnpm 9+
-npm install -g @murmurations-ai/cli
-
-murmuration init my-murmuration
-cd my-murmuration
-
-# Add API keys to .env:
-#   GEMINI_API_KEY=...    (or ANTHROPIC_API_KEY, OPENAI_API_KEY)
-#   GITHUB_TOKEN=...      (optional — use --collaboration local for offline)
-
-murmuration start
-```
-
-That's it. The harness auto-detects the `murmuration/` directory and loads all configuration from `murmuration/harness.yaml`. No flags needed for governance, collaboration, or log level — they're all in the config file.
-
-For offline development (no GitHub):
-
-```bash
-murmuration start --collaboration local
-```
-
-Or install from source:
+For contributors working against the harness directly:
 
 ```bash
 git clone https://github.com/murmurations-ai/murmurations-harness.git
 cd murmurations-harness
 pnpm install && pnpm build
-
 alias murmuration="node $(pwd)/packages/cli/dist/bin.js"
-murmuration init ../my-murmuration
-cd ../my-murmuration
-murmuration start
+
+# Then iterate:
+murmuration init --example hello ../test-murm
+cd ../test-murm
 ```
 
-See [docs/GETTING-STARTED.md](./docs/GETTING-STARTED.md) for the full walkthrough.
+The harness auto-detects the `murmuration/` directory and loads all configuration from `murmuration/harness.yaml` — no flags needed for governance, collaboration, or log level. Use `murmuration doctor` to validate a setup before running.
 
 ## LLM providers
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,221 +1,182 @@
 # Getting Started with the Murmuration Harness
 
-The Murmuration Harness is a generic agent coordination runtime. It runs any number of AI agents on scheduled wakes, each with their own LLM provider, GitHub access scopes, signal sources, and governance model. You bring the agents; the harness handles scheduling, cost tracking, artifact capture, and governance lifecycle.
+The Murmuration Harness is a generic AI-agent coordination runtime. One human (the **Source**) runs any number of AI agents as a coordinated "murmuration" — scheduling wakes, convening group meetings, tracking costs, and producing artifacts.
 
-This guide walks you from zero to a running murmuration in ~10 minutes.
+This guide walks you from zero to a running meeting in under 10 minutes. No prior harness experience required.
+
+---
 
 ## Prerequisites
 
-- **Node.js 20+**
-- **pnpm 9+** (`npm install -g pnpm`)
-- An API key for at least one LLM provider (Gemini, Anthropic, OpenAI) — or Ollama running locally for free
+- **Node.js 20+** (`node --version`)
+- **npm** (ships with Node)
+- **An API key** for your LLM provider of choice. Free-tier Gemini works great for testing — get one at [aistudio.google.com/apikey](https://aistudio.google.com/apikey) (no credit card required).
+- **Optional: a GitHub personal access token** if you want agents to read/write GitHub Issues. For the tutorial you can skip it — the example uses local-only collaboration.
 
-## 1. Clone and build
+---
 
-```sh
-git clone https://github.com/murmurations-ai/murmurations-harness.git
-cd murmurations-harness
-pnpm install
-pnpm build
-```
+## Path A — Fast: run the bundled example (5 minutes)
 
-Verify: `pnpm check` should report all tests passing.
+The fastest way to see the harness work is to scaffold the bundled `hello-circle` example. Two agents, one group, no GitHub required.
 
-## 2. Create your murmuration
+### 1. Install the CLI
 
 ```sh
-node packages/cli/dist/bin.js init ../my-murmuration
+npm install -g @murmurations-ai/cli
 ```
 
-The interactive wizard asks:
+Expected output: `added 123 packages` (varies).
 
-1. **Target directory** — where to create the murmuration
-2. **Purpose** — one sentence describing what this murmuration does
-3. **First agent name** — e.g. `researcher`, `coordinator`, `builder`
-4. **LLM provider** — `gemini`, `anthropic`, `openai`, or `ollama`
-5. **Circle** — optional organizational unit (leave blank for none)
-6. **Governance model** — `self-organizing`, `chain-of-command`, `meritocratic`, `consensus`, `parliamentary`, or `none`
-
-This creates:
-
-```
-my-murmuration/
-  murmuration/soul.md          ← your murmuration's purpose + values
-  agents/<name>/soul.md        ← agent identity
-  agents/<name>/role.md        ← agent config (LLM, schedule, scopes, budget)
-  governance/circles/<circle>.md  ← if you named a circle
-  .env                         ← API key placeholders (chmod 0600)
-  .gitignore
-```
-
-## 3. Configure
-
-### Add your API key
-
-Edit `my-murmuration/.env`:
-
-```
-GEMINI_API_KEY=your-real-key-here
-# GITHUB_TOKEN=ghp_your-token-here  ← uncomment if the agent writes to GitHub
-```
-
-The `.env` file must be `chmod 0600` — the harness refuses to load it otherwise.
-
-### Edit the role
-
-Open `agents/<name>/role.md` and customize the frontmatter:
-
-```yaml
-agent_id: "my-agent"
-name: "My Agent"
-model_tier: "balanced"
-
-llm:
-  provider: "gemini"
-  model: "gemini-2.5-flash" # optional; resolved from tier if absent
-
-wake_schedule:
-  delayMs: 2000 # fires 2s after boot (for testing)
-  # cron: "0 18 * * *"        # daily at 18:00 UTC (for production)
-  # tz: "America/Vancouver"   # optional timezone for cron
-
-signals:
-  sources:
-    - "github-issue"
-    - "private-note"
-
-budget:
-  max_cost_micros: 100000 # 10¢ per wake
-  max_github_api_calls: 10
-  on_breach: "warn" # or "abort"
-```
-
-### That's it — no code required
-
-You do not need to write any code for a standard agent. The harness
-reads your `soul.md` / `role.md`, loads signals, calls the configured
-LLM, and captures the output. Governance participants, researchers,
-builders — all of them work from markdown identity alone.
-
-If an agent has no `llm:` block yet, the daemon still boots — the
-wake just records a "skipped — no LLM client" summary. Add an `llm:`
-block to `role.md` when you're ready and the next wake will call it.
-
-## 4. Boot
+### 2. Scaffold the example
 
 ```sh
-node packages/cli/dist/bin.js start --root ../my-murmuration
+murmuration init --example hello my-first-murm
+cd my-first-murm
 ```
 
-The daemon:
-
-1. Discovers all agents in `agents/*/role.md`
-2. Loads their identities (soul → role → circle contexts)
-3. Constructs per-agent LLM clients + GitHub clients with write-scope enforcement
-4. Registers each agent on its declared wake schedule
-5. Fires wakes, captures artifacts to `.murmuration/runs/<agent>/`
-6. Stays alive until SIGINT
-
-### What you'll see in the logs
-
-```json
-{"event":"daemon.boot.config","rootDir":"...","agentDirs":["my-agent"]}
-{"event":"daemon.compose.agent","agentId":"my-agent","llm":{"provider":"gemini","instantiated":true}}
-{"event":"daemon.agent.registered","agentId":"my-agent","trigger":{"kind":"delay-once","delayMs":2000}}
-{"event":"daemon.wake.fire","agentId":"my-agent","signalCount":0}
-{"event":"daemon.wake.completed","outcome":"completed","cost":{"costMicros":5000}}
-```
-
-### Artifacts
-
-After each wake, the harness writes:
-
-- `.murmuration/runs/<agent>/<YYYY-MM-DD>/digest-<wakeId>.md` — the agent's wake summary with a YAML provenance header
-- `.murmuration/runs/<agent>/index.jsonl` — one structured line per wake with full cost + LLM + GitHub metrics
-
-## 5. Add more agents
-
-Just create more directories under `agents/`:
+Expected output:
 
 ```
-my-murmuration/agents/
-  researcher/role.md     ← already exists
-  coordinator/role.md    ← new agent
-  builder/role.md        ← another new agent
+✓ Copied example "hello-circle" to /path/to/my-first-murm
+  Registered as "my-first-murm".
+
+Next:
+
+  cd my-first-murm
+  cp .env.example .env
+  chmod 600 .env
+  # edit .env and paste your GEMINI_API_KEY
+
+  murmuration doctor --name my-first-murm
+  murmuration group-wake --name my-first-murm --group example --directive "what should we scout next?"
 ```
 
-Each agent gets its own wake schedule, LLM provider, signal scopes, and budget. Restart the daemon and all agents are discovered automatically.
-
-## 6. Add governance (optional)
-
-The harness ships with a pluggable governance interface. Boot with a governance plugin to enable decision tracking, state machines, and review dates:
+### 3. Paste your Gemini API key
 
 ```sh
-# Self-Organizing (Sociocracy 3.0)
-node packages/cli/dist/bin.js start --root ../my-murmuration \
-  --governance examples/governance-s3/index.mjs
+cp .env.example .env
+chmod 600 .env
 ```
 
-When agents emit governance events during wakes (e.g. tensions, proposals), the plugin routes them, tracks items through states, and sets review dates. Five governance models are supported by the interface:
+Then open `.env` in your editor and paste your key:
 
-| Model                | Style                             |
-| -------------------- | --------------------------------- |
-| **Self-Organizing**  | Consent-based, circles (S3)       |
-| **Chain of Command** | Hierarchical approvals            |
-| **Meritocratic**     | Track-record-based authority      |
-| **Consensus**        | Collective agreement              |
-| **Parliamentary**    | Motions + voting (Robert's Rules) |
+```
+GEMINI_API_KEY=AIzaSy...your-actual-key...
+```
 
-Write your own plugin by implementing the `GovernancePlugin` interface from `@murmurations-ai/core`.
-
-## 7. Useful flags
+### 4. Validate the setup
 
 ```sh
-# Boot one specific agent (instead of discovering all)
-murmuration start --root ../my-murmuration --agent my-agent
-
-# Dry-run mode — GitHub mutations are default-denied
-murmuration start --root ../my-murmuration --dry-run
-
-# Exit after the first wake completes (useful for CI/scripting)
-murmuration start --root ../my-murmuration --once
+murmuration doctor
 ```
 
-## 8. Run on a schedule
+Expected output:
 
-For production, use `cron` in the role.md frontmatter instead of `delayMs`:
+```
+murmuration doctor — checking /path/to/my-first-murm
 
-```yaml
-wake_schedule:
-  cron: "0 18 * * *" # daily at 18:00 UTC
-  tz: "America/Vancouver" # optional: interpret cron in local time
+  Layout .................. ✓
+  Schema .................. ✓
+  Secrets ................. ✓
+  Governance .............. ℹ 1 info
+  Live validation ......... (skipped; pass --live to enable)
+  Drift / best-practice ... ✓
+
+  Summary
+  ✓ No errors. Your murmuration should run.
 ```
 
-Then run the daemon as a long-lived process:
+The one info notice is about the no-op governance plugin — expected for hello-circle.
+
+Want to verify your API key actually works? Add `--live`:
 
 ```sh
-# nohup (survives terminal close)
-nohup node packages/cli/dist/bin.js start --root ../my-murmuration \
-  >> ../my-murmuration/.murmuration/daemon.log 2>&1 &
-
-# or tmux (can reattach later)
-tmux new -d -s harness 'node packages/cli/dist/bin.js start --root ../my-murmuration'
+murmuration doctor --live
 ```
 
-The daemon's cron scheduler fires wakes on time. If the machine sleeps, the wake fires immediately when it wakes up.
+### 5. Run your first meeting
 
-## Reference
+```sh
+murmuration group-wake --group example --directive "what should we scout next?"
+```
 
-| Package                           | What it does                                                                       |
-| --------------------------------- | ---------------------------------------------------------------------------------- |
-| `@murmurations-ai/core`           | Daemon, scheduler, executors, identity loader, cost tracking, governance interface |
-| `@murmurations-ai/llm`            | Four-provider LLM client (Gemini, Anthropic, OpenAI, Ollama)                       |
-| `@murmurations-ai/github`         | Typed GitHub REST + GraphQL client with write-scope enforcement                    |
-| `@murmurations-ai/signals`        | Signal aggregator (GitHub issues, private notes, inbox messages, custom)           |
-| `@murmurations-ai/secrets-dotenv` | .env file loader with permission enforcement                                       |
+The facilitator (`host-agent`) invites the scout (`scout-agent`) to contribute. The scout offers observations. The facilitator synthesizes a summary and names a next step. You'll see a streaming transcript in your terminal.
 
-| Example                       | What it demonstrates                                   |
-| ----------------------------- | ------------------------------------------------------ |
-| `examples/hello-world-agent/` | Minimal subprocess agent (no LLM)                      |
-| `examples/research-agent/`    | Full LLM agent with real Gemini calls + GitHub commits |
-| `examples/governance-s3/`     | Self-Organizing governance plugin with state machine   |
+Meeting minutes land in `.murmuration/items/` locally. That's it — you've run a meeting.
+
+---
+
+## Path B — Real: create your own murmuration (~20 minutes)
+
+Once the example works, scaffold a real murmuration tailored to your use case:
+
+```sh
+murmuration init my-production-murm
+```
+
+The interactive interview will ask:
+
+1. **Purpose** — a sentence describing what this murmuration is for
+2. **Default LLM provider** — gemini / anthropic / openai / ollama
+3. **API key** — paste it; input is hidden; you'll see a last-4 confirmation
+4. **Collaboration provider** — `github` (recommended) or `local`
+5. **GitHub repo + token** (if github chosen)
+6. **Agent definitions** — name, provider override, group, wake schedule (one loop per agent)
+7. **Governance model** — self-organizing (S3) / chain-of-command / meritocratic / consensus / parliamentary / none
+
+Every question has a reasonable default you can ENTER through. API keys are validated for shape before confirmation (the init rejects an obviously wrong paste and lets you try again).
+
+After init, run `murmuration doctor` to validate, edit the scaffolded `role.md` / `soul.md` / `governance/groups/*.md` to flesh out your agents and groups, then `murmuration start` to boot the daemon (or `murmuration group-wake` for on-demand meetings).
+
+---
+
+## What to do when…
+
+The top things that can go wrong, with the exact fix.
+
+| Symptom                                                  | What it means                                                               | Fix                                                                                           |
+| -------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `murmuration: command not found`                         | CLI isn't installed or PATH doesn't include npm's global bin                | `npm install -g @murmurations-ai/cli`; verify with `which murmuration`                        |
+| `doctor` reports `layout.murmuration.missing`            | You're not in a murmuration directory                                       | `cd` into the directory you created with `init`, or pass `--root <path>`                      |
+| `doctor` reports `secrets.env.<KEY>.missing`             | Your `.env` has the placeholder but not a real key                          | Edit `.env` and paste your actual key; save                                                   |
+| `doctor` reports `layout.env.mode`                       | `.env` is group/world-readable                                              | `chmod 600 .env`, or run `murmuration doctor --fix`                                           |
+| `doctor` reports `schema.role.<slug>.model_tier`         | A role.md has a non-enum `model_tier`                                       | Use one of `"fast"`, `"balanced"`, `"deep"`                                                   |
+| `doctor` reports `schema.role.<slug>.llm.provider`       | A role.md has an unrecognized provider                                      | Use one of `"gemini"`, `"anthropic"`, `"openai"`, `"ollama"`                                  |
+| `doctor` reports `layout.legacy-circles.only`            | You migrated from pre-ADR-0026 but still have `governance/circles/`         | `murmuration doctor --fix` renames it to `governance/groups/`                                 |
+| `group-wake: could not read LLM config from facilitator` | The facilitator agent's `role.md` has a schema issue                        | Run `murmuration doctor` — the real error is reported there                                   |
+| `create-issue: PERMISSION_DENIED`                        | Your `GITHUB_TOKEN` lacks `repo` scope, or the repo is wrong                | Regenerate token with `repo` scope; verify `collaboration.repo` in `murmuration/harness.yaml` |
+| `group-wake` runs but the facilitator fails mid-turn     | Usually hit rate limit or out of quota on the LLM provider                  | Check the provider's dashboard; try again, or switch providers per-agent in role.md           |
+| Meeting minutes don't appear in GitHub Issues            | Collaboration provider is `local` (writes to `.murmuration/items/` instead) | Check `collaboration.provider` in `murmuration/harness.yaml`                                  |
+
+When in doubt, `murmuration doctor` is the first thing to run. It validates against the full rubric and auto-fixes what it can.
+
+---
+
+## Key commands reference
+
+| Command                                                 | What it does                                  |
+| ------------------------------------------------------- | --------------------------------------------- |
+| `murmuration init [dir]`                                | Interactive scaffold of a new murmuration     |
+| `murmuration init --example hello [dir]`                | Scaffold the bundled hello-circle example     |
+| `murmuration doctor [--live] [--fix] [--json]`          | Diagnose a murmuration's setup                |
+| `murmuration start [--root\|--name]`                    | Boot the daemon                               |
+| `murmuration group-wake --group <id> --directive "..."` | Convene a group meeting on demand             |
+| `murmuration directive --agent <id> "..."`              | Send a directive to a specific agent          |
+| `murmuration agents`                                    | List registered agents and their state        |
+| `murmuration attach <name>`                             | Interactive REPL attached to a running daemon |
+| `murmuration status`                                    | Show daemon + agent state summary             |
+| `murmuration stop`                                      | Graceful shutdown                             |
+
+Pass `--help` to any command for full flag documentation.
+
+---
+
+## Next steps
+
+- **Flesh out your agents.** Each `agents/<slug>/role.md` and `soul.md` is yours to edit. The init scaffolds sensible defaults; you make them specific.
+- **Pick a governance model.** v0.5.0 ships with five: S3 (self-organizing), chain-of-command, meritocratic, consensus, parliamentary. Declare one in `murmuration/harness.yaml`.
+- **Set real wake schedules.** By default, new agents are dispatch-only. Add `wake_schedule.cron` when you're ready for autonomous wakes.
+- **Tune budgets and write scopes** per agent as you observe what they actually need.
+- **Read the architecture docs.** [docs/ARCHITECTURE.md](./ARCHITECTURE.md) covers the engineering standards; ADRs under [docs/adr/](./adr/) cover every load-bearing design decision.
+
+Questions, bugs, feedback: open an issue on [murmurations-ai/murmurations-harness](https://github.com/murmurations-ai/murmurations-harness/issues).

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -1,0 +1,159 @@
+# Migration Guide — pre-v0.5 → v0.5.0
+
+v0.5.0 is mostly **additive** — no deprecations, no removed fields, no breaking runtime behavior. Your existing murmuration will keep running. But there are new conveniences worth picking up, and one scenario where you should run `murmuration doctor --fix` to clean up legacy layout.
+
+---
+
+## If your murmuration already uses the ADR-0026 layout
+
+If you ran `murmuration init` on v0.4.x and have `murmuration/`, `agents/<slug>/`, `governance/groups/`, you're already compliant. v0.5.0 is strictly additive for you.
+
+Optional but recommended:
+
+```sh
+cd /path/to/your/murmuration
+murmuration doctor
+```
+
+This will surface anything that would have broken in v0.5.0 (none of it should, but `doctor` is worth running on every murmuration after any upgrade). If it reports `layout.env.mode` or `layout.gitignore.incomplete`, run `murmuration doctor --fix`.
+
+### You can simplify your role.md files
+
+Under Engineering Standard #11 (introduced in v0.5.0), `role.md` frontmatter inherits from directory context and from `murmuration/harness.yaml`. Fields that now default automatically:
+
+- `agent_id` — defaults to the directory slug
+- `name` — defaults to the humanized directory name (`research-agent` → `"Research Agent"`)
+- `model_tier` — defaults to `"balanced"`
+- `soul_file` — defaults to `"soul.md"`
+- `llm` — inherits from `murmuration/harness.yaml`'s `llm:` block
+
+You don't have to change your existing role.md files — they'll keep working. But if you want to tidy up, you can remove these fields when they just duplicate the defaults. New agents scaffolded by `murmuration init` on v0.5.0 already ship with the minimum viable frontmatter.
+
+---
+
+## If your murmuration still uses `governance/circles/` (pre-ADR-0026)
+
+ADR-0026 (late v0.4) renamed `governance/circles/` → `governance/groups/`. v0.5.0 `doctor --fix` automates the rename.
+
+### Upgrade path
+
+```sh
+cd /path/to/your/murmuration
+murmuration doctor
+```
+
+If it reports:
+
+```
+✗ Layout: governance/circles/ is used — needs renaming to governance/groups/
+     Fix: Rename governance/circles/ → governance/groups/ (preserves history if using `git mv`).
+     Auto-fix available: `murmuration doctor --fix`
+```
+
+Then:
+
+```sh
+murmuration doctor --fix
+```
+
+This renames `governance/circles/` to `governance/groups/` on disk. Your git history of the old directory is preserved; the next `git status` will show deletes + additions that git detects as renames (at high similarity).
+
+### Also update any live doc references
+
+After the rename, grep your repo for `governance/circles/` in live docs and update them to `governance/groups/`. Historical documents (dated decision records, notes, reports) are audit-trail — leave them alone.
+
+```sh
+grep -rl "governance/circles" --exclude-dir=.git --exclude-dir=archive .
+```
+
+### Add harness-parseable metadata to each group
+
+v0.5.0 `group-wake` requires each `governance/groups/<id>.md` to have:
+
+```markdown
+## Members
+
+- agent-slug-1
+- agent-slug-2
+- ...
+
+facilitator: agent-slug-1
+```
+
+`murmuration doctor` will flag any group missing this. Add the sections inline; they don't disrupt the existing body content.
+
+---
+
+## If your agents have numeric `agent_id: 22` (YAML integer)
+
+Legacy schemas allowed operators to write `agent_id: 22` (a number) in role.md frontmatter. The Zod schema has always wanted a string. v0.5.0 **coerces** numeric `agent_id` to a string automatically — no crash, no migration required.
+
+You can still tidy up by quoting:
+
+```yaml
+agent_id: "22"
+```
+
+But it's not required. `murmuration doctor` won't flag numeric `agent_id` as an error in v0.5.0.
+
+---
+
+## If you're migrating from Phase 0 (pre-ADR-0026, pre-init) by hand
+
+This is the scenario Emergent Praxis hit on 2026-04-20 — manually assembling a murmuration from flat identity docs. The v0.5.0 init + doctor combination handles most of this now, but you'll still do some manual work.
+
+Honest path:
+
+1. **Scaffold a fresh v0.5.0 murmuration next to your legacy one**:
+
+   ```sh
+   murmuration init --example hello /tmp/reference-murm
+   ```
+
+   Use the example as a reference for what v0.5.0 expects.
+
+2. **Run `doctor` on your legacy repo** and fix what it flags, either manually or with `--fix`:
+
+   ```sh
+   cd /path/to/legacy-murm
+   murmuration doctor
+   ```
+
+3. **Address each reported issue.** Most will be:
+   - Missing `murmuration/harness.yaml` (copy from the reference, then edit)
+   - Missing `murmuration/default-agent/{soul,role}.md` (copy from the reference)
+   - Missing `.env` / `.gitignore` (init generates; copy or re-run `init` in a tmp dir and lift)
+   - `governance/circles/` → `governance/groups/` (doctor --fix)
+   - Group files missing `## Members` + `facilitator:` (add inline)
+
+4. **Leave historical flat identity docs in place** as audit trail. If you still have `governance/agents/<legacy>.md` files, consider moving them to `archive/legacy-governance/` so they don't confuse future operators. They're not on the runtime path; `agents/<slug>/role.md` is.
+
+5. **Validate end-to-end** with a group-wake once doctor is clean:
+   ```sh
+   murmuration group-wake --group <your-group> --directive "test"
+   ```
+
+The Emergent Praxis migration is the reference case study for this path. See [`xeeban/emergent-praxis` PRs #463–#465](https://github.com/xeeban/emergent-praxis/pulls?q=is%3Apr+adr-0026) for what it looked like in practice (with all the missteps we fixed in v0.5.0 by making them impossible to reproduce).
+
+---
+
+## Breaking changes: none
+
+v0.5.0 deliberately avoids breaking anything. Every v0.5.0 change is either additive (new command, new field defaults, new example) or stricter-by-default error reporting (real messages instead of swallowed `UNKNOWN` codes).
+
+If you hit an unexpected behavior change, open an issue — it's a bug we'd want to fix before v0.5.1.
+
+---
+
+## CLI command additions
+
+New in v0.5.0:
+
+- `murmuration init --example hello [dir]` — scaffold the bundled hello-circle example
+- `murmuration doctor [--live] [--fix] [--json]` — preflight diagnosis + auto-remediation
+
+---
+
+## Summary
+
+For almost every operator: `murmuration doctor --fix` is the migration. It catches the handful of real cleanups (circles→groups rename, chmod 600 on .env, missing .gitignore entries) and leaves your content alone.


### PR DESCRIPTION
## Summary

Final milestone for v0.5.0 — documentation only. **No release.** Nori wants to test locally first.

## What changes

- **`README.md`** — quickstart lead is now the 6-command tester flow: install → `init --example hello` → paste key → `doctor` → `group-wake`. Developer-from-source install moved to its own section below. Banner updated to v0.5.0 "in testing."
- **`docs/GETTING-STARTED.md`** — rewritten as a tester walkthrough. Path A (fast, example) and Path B (real interactive init), expected output at every step, and a "what to do when…" table covering the top 10 failure modes we saw during the EP migration.
- **`docs/MIGRATION-GUIDE.md`** (new) — upgrade path for pre-v0.5 murmurations. Calls out the non-breaking nature of the release, documents the `doctor --fix` path for legacy `circles/`, and includes the EP migration as a reference case study.
- **`CHANGELOG.md`** — comprehensive v0.5.0 entry listing M1–M4 (error legibility, init UX, reasonable defaults, doctor, hello-circle) + Engineering Standard #11. Explicit "Unreleased (in tester validation)" header with release steps for when Nori signs off.

## Release is NOT included in this PR

Deliberately. Per Nori's direction in this session:
> start milestone 5 but DO NOT release, I would like to test it first

- `package.json` stays at `0.4.5`. `HARNESS_VERSION` stays at `0.4.5`.
- No `v0.5.0` tag. No `pnpm version minor`.
- No `pnpm publish` to npm.
- CHANGELOG entry labeled **"Unreleased (in tester validation)"** and documents the release steps for later.

## When Nori is ready to release

```sh
# From main, after merging this PR
pnpm version minor            # bumps 0.4.5 → 0.5.0 across all packages
git push origin main --tags   # push the auto-generated v0.5.0 tag
pnpm -F '@murmurations-ai/*' publish --access public
```

Then remove the "(in tester validation)" suffix on the CHANGELOG header in a one-line follow-up.

## Test plan

- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 631 pass
- [ ] Manual: follow `docs/GETTING-STARTED.md` Path A from scratch; confirm commands produce the documented output
- [ ] Manual: follow Path B from scratch; confirm the interview flow matches what's documented
- [ ] Manual: validate `docs/MIGRATION-GUIDE.md` against a legacy fixture

## Milestone status

- ✅ M1 — error legibility (#125)
- ✅ M2 — init UX overhaul (#126)
- ✅ M2.5 — reasonable defaults (#127)
- ✅ M3 — `murmuration doctor` (#128)
- ✅ M4 — hello-circle example (#129)
- ✅ **M5 — docs (this PR)**
- ⏸ Release — waiting for Nori's sign-off after local testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)