### PR TITLE
feat: default to S3 governance; bundle plugin with CLI (v0.5.0 Milestone 4.6)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,13 @@ export default tseslint.config(
       // Bundled extensions are plain JS (.mjs) loaded at runtime via
       // the extension loader — they don't participate in the TS project.
       "packages/*/src/builtin-extensions/**",
+      // Bundled governance plugins (v0.5.0 Milestone 4.6) — plain .mjs
+      // shipped with the CLI and copied into operator repos. Not part
+      // of the TS project; format and runtime-check only.
+      "packages/*/src/governance-plugins/**",
+      // Bundled CLI examples (v0.5.0 Milestone 4) — template .mjs files
+      // inside example trees are not part of the TS project either.
+      "packages/*/src/examples/**",
     ],
   },
   js.configs.recommended,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.build.json && mkdir -p dist/spirit/skills && cp src/spirit/skills/*.md dist/spirit/skills/ && mkdir -p dist/builtin-extensions/files && cp src/builtin-extensions/files/*.json src/builtin-extensions/files/*.mjs dist/builtin-extensions/files/ && mkdir -p dist/builtin-extensions/memory && cp src/builtin-extensions/memory/*.json src/builtin-extensions/memory/*.mjs dist/builtin-extensions/memory/ && mkdir -p dist/default-agent && cp src/default-agent/*.md dist/default-agent/ && mkdir -p dist/examples && cp -R src/examples/. dist/examples/",
+    "build": "tsc --build tsconfig.build.json && mkdir -p dist/spirit/skills && cp src/spirit/skills/*.md dist/spirit/skills/ && mkdir -p dist/builtin-extensions/files && cp src/builtin-extensions/files/*.json src/builtin-extensions/files/*.mjs dist/builtin-extensions/files/ && mkdir -p dist/builtin-extensions/memory && cp src/builtin-extensions/memory/*.json src/builtin-extensions/memory/*.mjs dist/builtin-extensions/memory/ && mkdir -p dist/default-agent && cp src/default-agent/*.md dist/default-agent/ && mkdir -p dist/examples && cp -R src/examples/. dist/examples/ && mkdir -p dist/governance-plugins/s3 && cp src/governance-plugins/s3/index.mjs dist/governance-plugins/s3/",
     "clean": "rm -rf dist .tsbuildinfo .tsbuildinfo.build",
     "typecheck": "tsc --noEmit",
     "start": "node dist/bin.js start"

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -140,6 +140,18 @@ describe("runDoctor (v0.5.0 Milestone 3)", () => {
     expect(ids).not.toContain("layout.env.mode");
   });
 
+  it("flags missing relative-path governance plugin as error (Milestone 4.6)", async () => {
+    await writeHealthy();
+    // Overwrite harness.yaml to reference a nonexistent plugin
+    await writeFile2(
+      "murmuration/harness.yaml",
+      `llm:\n  provider: "gemini"\ngovernance:\n  model: self-organizing\n  plugin: "./murmuration/governance-s3/index.mjs"\ncollaboration:\n  provider: local\n`,
+    );
+    const report = await runDoctor({ rootDir });
+    const ids = report.findings.map((f) => f.checkId);
+    expect(ids).toContain("governance.plugin-missing");
+  });
+
   it("live category is skipped by default", async () => {
     await writeHealthy();
     const report = await runDoctor({ rootDir });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -514,7 +514,7 @@ const isTrackedByGit = (rootDir: string, relPath: string): boolean => {
 // ---------------------------------------------------------------------------
 
 const runGovernanceChecks = (ctx: CheckContext): void => {
-  const { findings, harness } = ctx;
+  const { rootDir, findings, harness } = ctx;
   const plugin = harness.governance.plugin;
   if (plugin === undefined || plugin === "" || plugin === "none") {
     findings.push({
@@ -525,7 +525,25 @@ const runGovernanceChecks = (ctx: CheckContext): void => {
       detail: "group-wake meetings will run with no state machine (no-op plugin).",
       remediation: `Set \`governance.plugin\` in murmuration/harness.yaml when you're ready to use S3 (or another model).`,
     });
+    return;
   }
+  // If plugin looks like a relative file path, verify it resolves.
+  if (plugin.startsWith("./") || plugin.startsWith("../")) {
+    const resolved = join(rootDir, plugin.replace(/^\.\//, ""));
+    if (!existsSync(resolved)) {
+      findings.push({
+        checkId: "governance.plugin-missing",
+        category: "governance",
+        severity: "error",
+        title: `Governance plugin not found: ${plugin}`,
+        detail: `Expected a file at ${resolved}. boot.ts will fail to load the plugin.`,
+        remediation: `Check the path in murmuration/harness.yaml, or remove the \`governance.plugin\` line to fall back to the no-op plugin.`,
+      });
+    }
+  }
+  // npm package paths are not verified here — that would require a
+  // full `require.resolve`. boot.ts will surface the real error if
+  // the package is missing. Doctor stays fast.
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/examples/hello-circle/murmuration/governance-s3/index.mjs
+++ b/packages/cli/src/examples/hello-circle/murmuration/governance-s3/index.mjs
@@ -1,0 +1,269 @@
+/**
+ * Self-Organizing (S3) Governance Plugin
+ *
+ * First concrete governance plugin for the Murmuration Harness.
+ * Implements Sociocracy 3.0 patterns:
+ *
+ *   - Tensions as the driver for all governance work
+ *   - Consent rounds for decision-making (no objections = approved)
+ *   - Circle-based routing (tensions route to circle lead or Source)
+ *   - 90-day default review cadence on all ratified decisions
+ *
+ * State graph:
+ *   open → deliberating → consent-round → resolved | withdrawn
+ *
+ * Usage:
+ *   murmuration start --root ../my-murmuration --governance examples/governance-s3/index.mjs
+ *
+ * This is an example plugin — it lives in examples/ because the
+ * governance model is a choice the operator makes, not a harness
+ * default. The harness ships with NoOpGovernancePlugin; the operator
+ * opts into S3 (or any other model) via the --governance flag.
+ */
+
+// ---------------------------------------------------------------------------
+// S3 event kinds
+// ---------------------------------------------------------------------------
+
+/** Well-known S3 governance event kinds. Agents emit these via the
+ *  `::governance::<kind>:: <payload>` subprocess protocol or via
+ *  the in-process runner's governanceEvents return value. */
+export const S3_TENSION = "tension";
+export const S3_PROPOSAL = "proposal-opened";
+export const S3_NOTIFY = "notify";
+export const S3_AUTONOMOUS_ACTION = "autonomous-action";
+export const S3_HELD = "held";
+
+// ---------------------------------------------------------------------------
+// S3 state graphs
+// ---------------------------------------------------------------------------
+
+/**
+ * Tension lifecycle — the driver for governance work.
+ * A tension is NOT decided on directly — it's resolved when a
+ * proposal addressing it is ratified. The tension tracks awareness,
+ * not decisions.
+ *
+ *   open → proposal-needed → resolved (proposal ratified)
+ *        → withdrawn
+ */
+const TENSION_GRAPH = {
+  kind: "tension",
+  initialState: "open",
+  terminalStates: ["resolved", "withdrawn"],
+  defaultReviewDays: 90,
+  transitions: [
+    { from: "open", to: "proposal-needed", trigger: "agent-action" },
+    { from: "proposal-needed", to: "resolved", trigger: "agent-action" },
+    { from: "open", to: "resolved", trigger: "agent-action" },
+    { from: "open", to: "withdrawn", trigger: "agent-action" },
+    { from: "proposal-needed", to: "withdrawn", trigger: "agent-action" },
+    // Timeout: tensions without a proposal for 7 days escalate to Source
+    {
+      from: "proposal-needed",
+      to: "proposal-needed",
+      trigger: "timeout",
+      timeoutMs: 7 * 86_400_000,
+    },
+  ],
+};
+
+/**
+ * Proposal lifecycle — a formalized response to a tension.
+ * This is where consent happens. The circle deliberates, then
+ * runs a consent round. No objections = ratified.
+ *
+ *   drafted → deliberating → consent-round → ratified
+ *                           ↗ (objection)  ← consent-round → back to deliberating
+ *           → rejected
+ *           → withdrawn
+ */
+const PROPOSAL_GRAPH = {
+  kind: "proposal",
+  initialState: "drafted",
+  terminalStates: ["ratified", "rejected", "withdrawn"],
+  defaultReviewDays: 90,
+  transitions: [
+    { from: "drafted", to: "deliberating", trigger: "agent-action" },
+    { from: "deliberating", to: "consent-round", trigger: "agent-action" },
+    { from: "consent-round", to: "ratified", trigger: "consent-achieved" },
+    { from: "consent-round", to: "deliberating", trigger: "objection-raised" },
+    { from: "consent-round", to: "rejected", trigger: "agent-action" },
+    { from: "drafted", to: "withdrawn", trigger: "agent-action" },
+    { from: "deliberating", to: "withdrawn", trigger: "agent-action" },
+    // Timeout: deliberation stuck for 7 days escalates
+    { from: "deliberating", to: "deliberating", trigger: "timeout", timeoutMs: 7 * 86_400_000 },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// S3 Plugin implementation
+// ---------------------------------------------------------------------------
+
+/** @type {import('@murmurations-ai/core').GovernancePlugin} */
+const S3GovernancePlugin = {
+  name: "self-organizing",
+  version: "0.1.0",
+
+  terminology: {
+    group: "circle",
+    groupPlural: "circles",
+    governanceItem: "proposal",
+    governanceEvent: "tension",
+  },
+
+  stateGraphs() {
+    return [TENSION_GRAPH, PROPOSAL_GRAPH];
+  },
+
+  async onEventsEmitted(batch, _reader) {
+    const decisions = [];
+
+    for (const event of batch.events) {
+      switch (event.kind) {
+        case "agent-governance-event":
+        case S3_TENSION: {
+          // Route to Source for visibility + to any targeted agent.
+          /** @type {import('@murmurations-ai/core').GovernanceRouteTarget[]} */
+          const routes = [{ target: "source" }];
+          if (event.targetAgentId) {
+            routes.push({ target: "agent", agentId: event.targetAgentId });
+          }
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "tension", payload: event.payload },
+          });
+          break;
+        }
+
+        case S3_PROPOSAL: {
+          // Proposals route to Source for consent round initiation.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+            create: { kind: "proposal", payload: event.payload },
+          });
+          break;
+        }
+
+        case S3_NOTIFY: {
+          // Notify events go to the targeted agent (or Source if no target).
+          if (event.targetAgentId) {
+            decisions.push({
+              event,
+              routes: [{ target: "agent", agentId: event.targetAgentId }],
+            });
+          } else {
+            decisions.push({
+              event,
+              routes: [{ target: "source" }],
+            });
+          }
+          break;
+        }
+
+        case S3_AUTONOMOUS_ACTION: {
+          // Autonomous actions are logged for Source audit trail.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+          });
+          break;
+        }
+
+        case S3_HELD: {
+          // Held items escalate to Source immediately.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+          });
+          break;
+        }
+
+        default: {
+          // Unknown governance event kind — discard silently.
+          // The harness is extensible; other plugins may handle this kind.
+          decisions.push({ event, routes: [{ target: "discard" }] });
+        }
+      }
+    }
+
+    return decisions;
+  },
+
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
+    // S3 authorization: check whether a ratified governance item
+    // covers the requested action.
+    //
+    // The `context` object may carry a `tier` field ("autonomous",
+    // "notify", "consent", "source") from the agent's role.md
+    // decision-tiers section. The plugin uses this to decide whether
+    // the store needs a ratified item or the agent can proceed.
+    //
+    // Flow:
+    //   tier "autonomous" → always allow
+    //   tier "notify"     → allow + (caller logs)
+    //   tier "consent"    → check store for ratified proposal
+    //                       covering this action → allow if found,
+    //                       deny if not
+    //   tier "source"     → deny (requires explicit Source approval)
+    //   no tier specified → allow (backward compat / NoOp fallback)
+
+    const ctx = typeof context === "object" && context !== null ? context : {};
+    const tier = /** @type {string|undefined} */ (/** @type {any} */ (ctx).tier);
+
+    if (!tier || tier === "autonomous" || tier === "notify") {
+      return { allow: true };
+    }
+
+    if (tier === "source") {
+      return {
+        allow: false,
+        reason: `action "${action}" requires explicit Source approval (tier: source)`,
+      };
+    }
+
+    if (tier === "consent") {
+      // Look for a ratified proposal that covers this action.
+      // We match on `payload.action` in the governance item.
+      const ratified = store.query({ kind: "proposal", state: "ratified" });
+      const covering = ratified.find((item) => {
+        const payload =
+          typeof item.payload === "object" && item.payload !== null ? item.payload : {};
+        return /** @type {any} */ (payload).action === action;
+      });
+
+      if (covering) {
+        return { allow: true };
+      }
+
+      return {
+        allow: false,
+        reason: `action "${action}" requires a ratified consent-round proposal (tier: consent). Open a [CONSENT] issue to start the round.`,
+      };
+    }
+
+    // Unknown tier — allow with a warning (forward compatibility).
+    return { allow: true };
+  },
+
+  async onDaemonStart(store) {
+    // Log how many governance items survived from a previous session
+    // (will be zero until the durable store is implemented).
+    const existing = store.query();
+    if (existing.length > 0) {
+      console.log(`[s3-governance] restored ${String(existing.length)} governance items`);
+    }
+
+    // Check for items due for review.
+    const due = store.query({ reviewDue: true });
+    if (due.length > 0) {
+      console.warn(
+        `[s3-governance] ${String(due.length)} governance items are past their review date`,
+      );
+    }
+  },
+};
+
+export default S3GovernancePlugin;

--- a/packages/cli/src/examples/hello-circle/murmuration/harness.yaml
+++ b/packages/cli/src/examples/hello-circle/murmuration/harness.yaml
@@ -2,15 +2,17 @@
 # Shipped with @murmurations-ai/cli via `murmuration init --example hello`.
 #
 # Local collaboration (no GitHub token needed) — items go to
-# .murmuration/items/ on disk. No governance plugin — meetings run
-# without a state machine. Both choices minimize setup friction so a
-# tester can get a meeting running in under 5 minutes.
+# .murmuration/items/ on disk. Sociocracy 3.0 governance plugin ships
+# alongside (see murmuration/governance-s3/) — meetings will route
+# tensions, proposals, and consent events through it when agents emit
+# them. Nothing explodes if they don't.
 
 llm:
   provider: "gemini"
 
 governance:
-  model: none
+  model: self-organizing
+  plugin: "./murmuration/governance-s3/index.mjs"
 
 collaboration:
   provider: local

--- a/packages/cli/src/governance-plugins/s3/index.mjs
+++ b/packages/cli/src/governance-plugins/s3/index.mjs
@@ -1,0 +1,269 @@
+/**
+ * Self-Organizing (S3) Governance Plugin
+ *
+ * First concrete governance plugin for the Murmuration Harness.
+ * Implements Sociocracy 3.0 patterns:
+ *
+ *   - Tensions as the driver for all governance work
+ *   - Consent rounds for decision-making (no objections = approved)
+ *   - Circle-based routing (tensions route to circle lead or Source)
+ *   - 90-day default review cadence on all ratified decisions
+ *
+ * State graph:
+ *   open → deliberating → consent-round → resolved | withdrawn
+ *
+ * Usage:
+ *   murmuration start --root ../my-murmuration --governance examples/governance-s3/index.mjs
+ *
+ * This is an example plugin — it lives in examples/ because the
+ * governance model is a choice the operator makes, not a harness
+ * default. The harness ships with NoOpGovernancePlugin; the operator
+ * opts into S3 (or any other model) via the --governance flag.
+ */
+
+// ---------------------------------------------------------------------------
+// S3 event kinds
+// ---------------------------------------------------------------------------
+
+/** Well-known S3 governance event kinds. Agents emit these via the
+ *  `::governance::<kind>:: <payload>` subprocess protocol or via
+ *  the in-process runner's governanceEvents return value. */
+export const S3_TENSION = "tension";
+export const S3_PROPOSAL = "proposal-opened";
+export const S3_NOTIFY = "notify";
+export const S3_AUTONOMOUS_ACTION = "autonomous-action";
+export const S3_HELD = "held";
+
+// ---------------------------------------------------------------------------
+// S3 state graphs
+// ---------------------------------------------------------------------------
+
+/**
+ * Tension lifecycle — the driver for governance work.
+ * A tension is NOT decided on directly — it's resolved when a
+ * proposal addressing it is ratified. The tension tracks awareness,
+ * not decisions.
+ *
+ *   open → proposal-needed → resolved (proposal ratified)
+ *        → withdrawn
+ */
+const TENSION_GRAPH = {
+  kind: "tension",
+  initialState: "open",
+  terminalStates: ["resolved", "withdrawn"],
+  defaultReviewDays: 90,
+  transitions: [
+    { from: "open", to: "proposal-needed", trigger: "agent-action" },
+    { from: "proposal-needed", to: "resolved", trigger: "agent-action" },
+    { from: "open", to: "resolved", trigger: "agent-action" },
+    { from: "open", to: "withdrawn", trigger: "agent-action" },
+    { from: "proposal-needed", to: "withdrawn", trigger: "agent-action" },
+    // Timeout: tensions without a proposal for 7 days escalate to Source
+    {
+      from: "proposal-needed",
+      to: "proposal-needed",
+      trigger: "timeout",
+      timeoutMs: 7 * 86_400_000,
+    },
+  ],
+};
+
+/**
+ * Proposal lifecycle — a formalized response to a tension.
+ * This is where consent happens. The circle deliberates, then
+ * runs a consent round. No objections = ratified.
+ *
+ *   drafted → deliberating → consent-round → ratified
+ *                           ↗ (objection)  ← consent-round → back to deliberating
+ *           → rejected
+ *           → withdrawn
+ */
+const PROPOSAL_GRAPH = {
+  kind: "proposal",
+  initialState: "drafted",
+  terminalStates: ["ratified", "rejected", "withdrawn"],
+  defaultReviewDays: 90,
+  transitions: [
+    { from: "drafted", to: "deliberating", trigger: "agent-action" },
+    { from: "deliberating", to: "consent-round", trigger: "agent-action" },
+    { from: "consent-round", to: "ratified", trigger: "consent-achieved" },
+    { from: "consent-round", to: "deliberating", trigger: "objection-raised" },
+    { from: "consent-round", to: "rejected", trigger: "agent-action" },
+    { from: "drafted", to: "withdrawn", trigger: "agent-action" },
+    { from: "deliberating", to: "withdrawn", trigger: "agent-action" },
+    // Timeout: deliberation stuck for 7 days escalates
+    { from: "deliberating", to: "deliberating", trigger: "timeout", timeoutMs: 7 * 86_400_000 },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// S3 Plugin implementation
+// ---------------------------------------------------------------------------
+
+/** @type {import('@murmurations-ai/core').GovernancePlugin} */
+const S3GovernancePlugin = {
+  name: "self-organizing",
+  version: "0.1.0",
+
+  terminology: {
+    group: "circle",
+    groupPlural: "circles",
+    governanceItem: "proposal",
+    governanceEvent: "tension",
+  },
+
+  stateGraphs() {
+    return [TENSION_GRAPH, PROPOSAL_GRAPH];
+  },
+
+  async onEventsEmitted(batch, _reader) {
+    const decisions = [];
+
+    for (const event of batch.events) {
+      switch (event.kind) {
+        case "agent-governance-event":
+        case S3_TENSION: {
+          // Route to Source for visibility + to any targeted agent.
+          /** @type {import('@murmurations-ai/core').GovernanceRouteTarget[]} */
+          const routes = [{ target: "source" }];
+          if (event.targetAgentId) {
+            routes.push({ target: "agent", agentId: event.targetAgentId });
+          }
+          decisions.push({
+            event,
+            routes,
+            create: { kind: "tension", payload: event.payload },
+          });
+          break;
+        }
+
+        case S3_PROPOSAL: {
+          // Proposals route to Source for consent round initiation.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+            create: { kind: "proposal", payload: event.payload },
+          });
+          break;
+        }
+
+        case S3_NOTIFY: {
+          // Notify events go to the targeted agent (or Source if no target).
+          if (event.targetAgentId) {
+            decisions.push({
+              event,
+              routes: [{ target: "agent", agentId: event.targetAgentId }],
+            });
+          } else {
+            decisions.push({
+              event,
+              routes: [{ target: "source" }],
+            });
+          }
+          break;
+        }
+
+        case S3_AUTONOMOUS_ACTION: {
+          // Autonomous actions are logged for Source audit trail.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+          });
+          break;
+        }
+
+        case S3_HELD: {
+          // Held items escalate to Source immediately.
+          decisions.push({
+            event,
+            routes: [{ target: "source" }],
+          });
+          break;
+        }
+
+        default: {
+          // Unknown governance event kind — discard silently.
+          // The harness is extensible; other plugins may handle this kind.
+          decisions.push({ event, routes: [{ target: "discard" }] });
+        }
+      }
+    }
+
+    return decisions;
+  },
+
+  async evaluateAction(agentId, action, context, store /* GovernanceStateReader */) {
+    // S3 authorization: check whether a ratified governance item
+    // covers the requested action.
+    //
+    // The `context` object may carry a `tier` field ("autonomous",
+    // "notify", "consent", "source") from the agent's role.md
+    // decision-tiers section. The plugin uses this to decide whether
+    // the store needs a ratified item or the agent can proceed.
+    //
+    // Flow:
+    //   tier "autonomous" → always allow
+    //   tier "notify"     → allow + (caller logs)
+    //   tier "consent"    → check store for ratified proposal
+    //                       covering this action → allow if found,
+    //                       deny if not
+    //   tier "source"     → deny (requires explicit Source approval)
+    //   no tier specified → allow (backward compat / NoOp fallback)
+
+    const ctx = typeof context === "object" && context !== null ? context : {};
+    const tier = /** @type {string|undefined} */ (/** @type {any} */ (ctx).tier);
+
+    if (!tier || tier === "autonomous" || tier === "notify") {
+      return { allow: true };
+    }
+
+    if (tier === "source") {
+      return {
+        allow: false,
+        reason: `action "${action}" requires explicit Source approval (tier: source)`,
+      };
+    }
+
+    if (tier === "consent") {
+      // Look for a ratified proposal that covers this action.
+      // We match on `payload.action` in the governance item.
+      const ratified = store.query({ kind: "proposal", state: "ratified" });
+      const covering = ratified.find((item) => {
+        const payload =
+          typeof item.payload === "object" && item.payload !== null ? item.payload : {};
+        return /** @type {any} */ (payload).action === action;
+      });
+
+      if (covering) {
+        return { allow: true };
+      }
+
+      return {
+        allow: false,
+        reason: `action "${action}" requires a ratified consent-round proposal (tier: consent). Open a [CONSENT] issue to start the round.`,
+      };
+    }
+
+    // Unknown tier — allow with a warning (forward compatibility).
+    return { allow: true };
+  },
+
+  async onDaemonStart(store) {
+    // Log how many governance items survived from a previous session
+    // (will be zero until the durable store is implemented).
+    const existing = store.query();
+    if (existing.length > 0) {
+      console.log(`[s3-governance] restored ${String(existing.length)} governance items`);
+    }
+
+    // Check for items due for review.
+    const due = store.query({ reviewDue: true });
+    if (due.length > 0) {
+      console.warn(
+        `[s3-governance] ${String(due.length)} governance items are past their review date`,
+      );
+    }
+  },
+};
+
+export default S3GovernancePlugin;

--- a/packages/cli/src/init-example.test.ts
+++ b/packages/cli/src/init-example.test.ts
@@ -60,6 +60,17 @@ describe("init --example (v0.5.0 Milestone 4)", () => {
     );
   });
 
+  it("ships the S3 governance plugin and wires it in harness.yaml (Milestone 4.6)", async () => {
+    const target = join(parent, "hello-s3");
+    await runInitFromExample("hello-circle", target);
+
+    expect(existsSync(join(target, "murmuration", "governance-s3", "index.mjs"))).toBe(true);
+
+    const harnessYaml = await readFile(join(target, "murmuration", "harness.yaml"), "utf8");
+    expect(harnessYaml).toContain("model: self-organizing");
+    expect(harnessYaml).toContain("./murmuration/governance-s3/index.mjs");
+  });
+
   it("materializes .env from .env.example at 0600 (Milestone 4.5)", async () => {
     const target = join(parent, "hello-env");
     await runInitFromExample("hello-circle", target);

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -85,6 +85,20 @@ const resolveExamplesDir = (): string => {
   return join(here, "..", "src", "examples");
 };
 
+/**
+ * Resolve the bundled S3 governance plugin shipped with the CLI.
+ * v0.5.0 Milestone 4.6: S3 (and any future governance plugins we
+ * author) ship with the CLI so operators don't need to install or
+ * author them from scratch. Copied into the scaffolded murmuration
+ * at init time so the repo is self-contained.
+ */
+const resolveBundledS3Plugin = (): string => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const shipped = join(here, "governance-plugins", "s3", "index.mjs");
+  if (existsSync(shipped)) return shipped;
+  return join(here, "..", "src", "governance-plugins", "s3", "index.mjs");
+};
+
 /** List the example names bundled with this CLI. */
 export const listExamples = (): readonly string[] => {
   const dir = resolveExamplesDir();
@@ -540,10 +554,14 @@ export const runInit = async (optionsOrTargetArg?: RunInitOptions | string): Pro
   }
 
   // 5. Governance model
+  // Default: self-organizing (Sociocracy 3.0). The S3 plugin ships with
+  // the CLI and is copied into the scaffolded repo below, so this works
+  // out of the box. Operators who want something else can pick from
+  // the menu; those plugins still need to be authored separately.
   const govInput = await ask(
-    "\nGovernance model (self-organizing / chain-of-command / meritocratic / consensus / parliamentary / none) [none]: ",
+    "\nGovernance model (self-organizing / chain-of-command / meritocratic / consensus / parliamentary / none) [self-organizing]: ",
   );
-  const governance = govInput.trim().toLowerCase() || "none";
+  const governance = govInput.trim().toLowerCase() || "self-organizing";
 
   rl?.close();
 
@@ -611,17 +629,32 @@ _What does this murmuration optimize for?_
   );
 
   // murmuration/harness.yaml
-  const governancePluginMap: Record<string, string> = {
-    "self-organizing": "@murmurations-ai/governance-s3",
-    "chain-of-command": "@murmurations-ai/governance-command",
-    meritocratic: "@murmurations-ai/governance-meritocratic",
-    consensus: "@murmurations-ai/governance-consensus",
-    parliamentary: "@murmurations-ai/governance-parliamentary",
-  };
-  const governancePlugin = governancePluginMap[governance];
+  // v0.5.0 Milestone 4.6: the S3 plugin ships bundled with the CLI and
+  // is copied into murmuration/governance-s3/ on init. The plugin path
+  // in harness.yaml is relative so the scaffolded repo is self-contained
+  // (no npm install of an external plugin package needed).
+  let governancePluginPath = "";
+  if (governance === "self-organizing") {
+    governancePluginPath = "./murmuration/governance-s3/index.mjs";
+    await mkdir(join(targetDir, "murmuration", "governance-s3"), { recursive: true });
+    await copyFile(
+      resolveBundledS3Plugin(),
+      join(targetDir, "murmuration", "governance-s3", "index.mjs"),
+    );
+  } else if (governance !== "none") {
+    // Other models don't ship a bundled plugin yet — leave a reference
+    // to a conventional npm package name the operator can install.
+    const placeholders: Record<string, string> = {
+      "chain-of-command": "@murmurations-ai/governance-command",
+      meritocratic: "@murmurations-ai/governance-meritocratic",
+      consensus: "@murmurations-ai/governance-consensus",
+      parliamentary: "@murmurations-ai/governance-parliamentary",
+    };
+    governancePluginPath = placeholders[governance] ?? governance;
+  }
   const governanceBlock =
     governance !== "none"
-      ? `governance:\n  model: "${governance}"\n  plugin: "${governancePlugin ?? governance}"`
+      ? `governance:\n  model: "${governance}"\n  plugin: "${governancePluginPath}"`
       : `governance:\n  model: none`;
 
   const collabBlock =
@@ -845,7 +878,7 @@ ${members.map((m) => `- ${m}`).join("\n")}
 
   const governanceNote =
     governance !== "none"
-      ? `\n  Governance plugin: ${governancePlugin ?? governance} (configured in murmuration/harness.yaml)`
+      ? `\n  Governance plugin: ${governancePluginPath || governance} (configured in murmuration/harness.yaml)`
       : "";
 
   console.log(`


### PR DESCRIPTION
## Summary

v0.5.0 now ships the Sociocracy 3.0 plugin bundled with the CLI, copies it into every scaffolded murmuration, and defaults governance to `self-organizing`. Operators get real governance out of the box; no authoring or npm-installing a plugin.

Directly addresses Nori's test-hello output:
> `ℹ Governance: No governance plugin configured`

After this PR, a fresh `murmuration init --example hello` produces a scaffolded repo where doctor reports 0 errors and 0 info-level governance notices.

## What changes

- **Bundled plugin** — `packages/cli/src/governance-plugins/s3/index.mjs` (copy of `examples/governance-s3/`). Build step copies to `dist/`.
- **Interactive `init`** — default governance question flipped `none` → `self-organizing`. When picked, init creates `murmuration/governance-s3/` in the scaffolded repo and copies the plugin in. `harness.yaml` uses a relative path (`"./murmuration/governance-s3/index.mjs"`) so the scaffold is self-contained.
- **`hello-circle` example** — ships the plugin under `murmuration/governance-s3/` and sets harness.yaml to self-organizing.
- **`murmuration doctor`** — now verifies relative-path plugins actually exist. Missing file → error (was silent before). npm-package plugin paths still deferred to boot.ts to avoid a slow `require.resolve` on every doctor run.
- **Other governance models** (chain-of-command, meritocratic, consensus, parliamentary) still reference placeholder npm package names with a comment. Those plugins aren't authored yet — ship them over time, same bundled-CLI pattern.

## Tests

+2 tests (**633 total**):
- hello-circle ships S3 plugin + harness.yaml references it
- Doctor flags missing relative-path plugins as error

## Manual verification

```sh
# From a fresh directory
murmuration init --example hello test-s3
cd test-s3
murmuration doctor
# Expected: all ✓, no info-level governance notice
ls murmuration/governance-s3/
# Expected: index.mjs
grep "governance" murmuration/harness.yaml
# Expected: "model: self-organizing" + plugin path
```

## Milestone status

- ✅ M1–M4 (merged)
- ✅ M4.5 — init --example env capture (merged)
- ✅ **M4.6 — default to S3 (this PR)**
- ✅ M5 — docs (merged)
- ⏸ Release — waiting for Nori's sign-off after local testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)