### PR TITLE
fix(init): accept --example hello as alias for hello-circle (tester feedback)

### DIFF
--- a/packages/cli/src/init-example.test.ts
+++ b/packages/cli/src/init-example.test.ts
@@ -53,6 +53,13 @@ describe("init --example (v0.5.0 Milestone 4)", () => {
     );
   });
 
+  it("accepts the `hello` short-name alias for hello-circle", async () => {
+    const target = join(parent, "hello-alias");
+    await runInitFromExample("hello", target);
+    expect(existsSync(join(target, "murmuration", "harness.yaml"))).toBe(true);
+    expect(existsSync(join(target, "agents", "host-agent", "role.md"))).toBe(true);
+  });
+
   it("rejects unknown example names", async () => {
     const target = join(parent, "fresh");
     await expect(runInitFromExample("not-a-real-example", target)).rejects.toThrow(

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -99,6 +99,30 @@ const resolveBundledS3Plugin = (): string => {
   return join(here, "..", "src", "governance-plugins", "s3", "index.mjs");
 };
 
+/**
+ * Short-name → canonical-directory aliases for `--example`. Lets the
+ * operator type the docs-friendly name (`hello`) and get the full
+ * bundled directory (`hello-circle`). Safe to extend as new examples
+ * ship.
+ */
+const EXAMPLE_ALIASES: Readonly<Record<string, string>> = {
+  hello: "hello-circle",
+};
+
+/**
+ * Resolve a user-supplied `--example <name>` to the canonical example
+ * directory. Accepts both aliases (`hello`) and exact directory names
+ * (`hello-circle`). Returns null if neither resolves to a bundled
+ * example.
+ */
+export const resolveExampleName = (name: string): string | null => {
+  const examples = listExamples();
+  if (examples.includes(name)) return name;
+  const aliased = EXAMPLE_ALIASES[name];
+  if (aliased && examples.includes(aliased)) return aliased;
+  return null;
+};
+
 /** List the example names bundled with this CLI. */
 export const listExamples = (): readonly string[] => {
   const dir = resolveExamplesDir();
@@ -346,13 +370,16 @@ export const runInitFromExample = async (
   example: string,
   targetArg: string | undefined,
 ): Promise<void> => {
-  const examples = listExamples();
-  if (!examples.includes(example)) {
+  const resolvedExample = resolveExampleName(example);
+  if (!resolvedExample) {
+    const available = [...new Set([...listExamples(), ...Object.keys(EXAMPLE_ALIASES)])].sort();
     console.error(
-      `murmuration init: no example named "${example}". Available: ${examples.join(", ") || "(none)"}`,
+      `murmuration init: no example named "${example}". Available: ${available.join(", ") || "(none)"}`,
     );
     throw new Error(`unknown example: ${example}`);
   }
+  // From here on, use the canonical directory name.
+  example = resolvedExample;
 
   const target = targetArg ?? `my-${example}-murmuration`;
   const targetDir = resolve(target);


### PR DESCRIPTION
## Summary

Docs say `murmuration init --example hello`; the bundled directory is `hello-circle`. Tester (Nori) hit this immediately:

```
murmuration init: no example named "hello". Available: hello-circle
murmuration: fatal: unknown example: hello
```

## Fix

Adds `EXAMPLE_ALIASES` map (`hello` → `hello-circle`) and `resolveExampleName()` that accepts either the short name or the canonical directory. Non-breaking; both work.

## Test

+1 test: `runInitFromExample("hello", target)` succeeds and produces the same tree as `hello-circle`.

634 pass, CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)