### PR TITLE
docs(plans): v0.5.1 — unified event-first logging plan (#139)

### DIFF
--- a/docs/plans/v0.5.1-unified-logging.md
+++ b/docs/plans/v0.5.1-unified-logging.md
@@ -1,0 +1,272 @@
+# v0.5.1 — Unified Event-First Logging
+
+**Status:** Draft plan (2026-04-21)
+**Author:** Nori (via Claude pairing session)
+**Addresses:** [#139](https://github.com/murmurations-ai/murmurations-harness/issues/139) — CLI output mixes JSON-lines and plaintext inconsistently
+**Target release:** v0.5.1 — first patch after tester validation of v0.5.0
+**Likely outputs:** ADR-0030 (unified event-first logging), plus a refactor PR that migrates every current `console.log` in library code behind the event bus and adds a single CLI-side formatter.
+
+This plan responds to tester feedback during v0.5.0 validation: when a meeting convenes in the attached REPL, the daemon's JSON-lines logs interleave with pretty plaintext meeting output, and the visual jump breaks the operator's mental model of what the harness is doing. The root cause isn't cosmetic — it's that the harness doesn't have a single logging contract. Library code sometimes emits structured events, sometimes `console.log`s directly. The CLI has no formatter layer. This plan closes the gap.
+
+---
+
+## 1. Problem
+
+Three output surfaces, three different styles, no unified contract.
+
+### 1.1 Surface inventory
+
+| Surface                                                                    | Current style                                                                                                                           | Who produces it                                                     |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Daemon stdout** (log files, `murmuration start` foreground)              | JSON-lines, one event per line                                                                                                          | `DaemonLoggerImpl` writes structured events; operators pipe or tail |
+| **CLI command output** (`init`, `doctor`, `list`, standalone `group-wake`) | Colored plaintext with ✓/✗/⚠ icons, aligned columns                                                                                     | `console.log` directly from command implementations                 |
+| **Attached REPL streaming** (`:convene`, `:wake`, directive responses)     | **Mixed** — agent dialogue in plaintext, daemon structured events leaking through the socket, REPL's own prompt output, all interleaved | No transform layer; whatever the daemon sends, the REPL prints      |
+
+### 1.2 Why this is a real problem
+
+- **Operators can't visually parse a meeting.** Daemon JSON lines (agent spawned, cost updated, heartbeat) interrupt the narrative of what the agents are saying.
+- **Machine consumers can't reliably parse the output either.** Pretty-printed meeting text in the same stream as JSON means JSON parsers fail on plaintext lines.
+- **Engineering Standard #2 is quietly violated** across library code. Several library functions call `console.log` directly instead of returning typed results, making them untestable and tangling the output contract.
+- **No way to silence non-error output** for scripted invocations. A CI job running `murmuration group-wake` can't easily isolate "did it succeed" from "what did the agents say."
+
+### 1.3 What already works
+
+The bones of a good logger exist:
+
+- **`packages/core/src/daemon/events.ts`** — `DaemonEventBus` is the right shape. Typed events with a stable `event` name and a `data` payload.
+- **`packages/core/src/daemon/logger.ts`** — `DaemonLoggerImpl` wraps the event bus + writes JSON to stdout. Already supports levels (`debug`/`info`/`warn`/`error`) and per-event redaction via the `REDACT` symbol.
+- **ADR-0017** — GitHub-client logs already go through this path.
+
+The gap is that **not every surface uses this infrastructure**. Library code outside the daemon (`group-wake.ts`, `doctor.ts`, `init.ts`) uses `console.log` directly. The CLI has no event-consumer/formatter layer.
+
+---
+
+## 2. Proposed design — four layers
+
+### 2.1 Layer 1: Everything internal emits structured events
+
+Every library function that today produces user-visible output migrates to:
+
+```ts
+// Before
+console.log(`Creating murmuration at ${targetDir}...`);
+
+// After
+logger.info("init.scaffold.start", { targetDir });
+```
+
+Rules:
+
+- **No `console.log` in `packages/core/`** — enforced via ESLint rule (`no-console` with `allow: ["warn", "error"]` only, or stricter).
+- **No `console.log` in library-shaped `packages/cli/src/*.ts`** — the CLI's internal logic (e.g. `doctor.ts`'s check runner, `init.ts`'s scaffold engine) emits events. Only the top-level CLI entry point (`bin.ts`) is allowed to write to the terminal.
+- **Event names are stable.** Use dotted hierarchy: `init.scaffold.start`, `doctor.check.layout.pass`, `group-wake.meeting.action.create-issue.ok`. Event names become a public contract for scripting.
+
+This is a big migration. Rough count: ~80 `console.log` sites across `packages/cli/src/`, ~5 in `packages/core/src/` (mostly already-shielded paths). See §4.1 for the checklist.
+
+### 2.2 Layer 2: A single CLI formatter
+
+New module: `packages/cli/src/cli-formatter.ts`.
+
+Subscribes to the event bus (or receives events pushed by command implementations), renders to the terminal in one of three modes:
+
+```ts
+export type FormatterMode = "human" | "json" | "quiet";
+
+export class CliFormatter {
+  constructor(opts: { mode: FormatterMode; tty: boolean });
+  render(event: LogEvent): void;
+}
+```
+
+Mode selection:
+
+1. `--json` flag or non-TTY stdout → `json`
+2. `--quiet` flag → `quiet` (errors only)
+3. Default, TTY stdout → `human`
+
+### 2.3 Layer 3: Human-mode rendering conventions
+
+A small style guide, implemented once in the formatter and used everywhere:
+
+| Level                 | Prefix | Color          | Example                                     |
+| --------------------- | ------ | -------------- | ------------------------------------------- |
+| `error`               | `✗`    | red            | `✗ Secrets: GEMINI_API_KEY not set in .env` |
+| `warn`                | `⚠`    | yellow         | `⚠ Layout: .env is mode 644 (expected 600)` |
+| `info`                | `ℹ`    | dim cyan       | `ℹ Starting group meeting "example"`        |
+| `success`             | `✓`    | green          | `✓ Copied example "hello-circle"`           |
+| `meeting` (new level) | `•`    | bright white   | `• host-agent: Welcome...` (agent dialogue) |
+| `action-ok`           | `✓`    | green + indent | `  ✓ create-issue #466: ...`                |
+| `action-fail`         | `✗`    | red + indent   | `  ✗ comment-issue #123: UNAUTHORIZED`      |
+
+Rendering is deterministic and testable. The formatter is pure — given the same event, always produces the same string.
+
+### 2.4 Layer 4: Daemon log sink unifies with formatter
+
+The daemon's own stdout writer becomes an instance of the same formatter in `json` mode when non-TTY, `human` mode when TTY. `DaemonLoggerImpl` becomes a thin adapter that routes events through the formatter, so `murmuration start` with a terminal looks like any other CLI command, and `murmuration start > daemon.log` still produces JSON-lines for parsing.
+
+### 2.5 REPL event streaming
+
+The attached REPL already receives events from the daemon over the socket. Instead of `console.log`-ing them raw, it routes each event through the CLI formatter (always in `human` mode, because the REPL is by definition interactive TTY). The visual jump Nori observed disappears: agent dialogue renders with the `•` prefix, daemon events render with their appropriate level icon, all in the same style.
+
+---
+
+## 3. Event taxonomy (first pass)
+
+A non-exhaustive list of event names, grouped by namespace. Final list grows during the migration.
+
+### 3.1 Init
+
+- `init.scaffold.start` — `{ targetDir, example? }`
+- `init.scaffold.file-written` — `{ path, role: "soul"|"role"|"harness"|"env"|... }`
+- `init.scaffold.complete` — `{ targetDir, sessionName, capturedSecrets }`
+- `init.secret.captured` — `{ envVar, lastFour }` (never the full key)
+- `init.secret.skipped` — `{ envVar }`
+
+### 3.2 Doctor
+
+- `doctor.check.layout.pass` / `.fail` — `{ checkId, detail? }`
+- `doctor.check.schema.pass` / `.fail`
+- `doctor.check.secrets.pass` / `.fail`
+- `doctor.check.governance.pass` / `.fail`
+- `doctor.check.live.pass` / `.fail`
+- `doctor.check.drift.observation`
+- `doctor.fix.applied` / `.skipped`
+- `doctor.summary` — `{ errors, warnings, infos }`
+
+### 3.3 Group wake
+
+- `group-wake.meeting.start` — `{ groupId, facilitator, directive, members }`
+- `group-wake.llm.resolved` — `{ provider, model }`
+- `group-wake.agent.contribution` — `{ agentId, text }` (the human-visible agent dialogue)
+- `group-wake.facilitator.synthesis` — `{ text }`
+- `group-wake.actions.parsed` — `{ count }`
+- `group-wake.action.ok` — `{ kind, identifier, detail? }`
+- `group-wake.action.failed` — `{ kind, identifier?, code, message }`
+- `group-wake.meeting.complete` — `{ minutesUrl, actionSummary }`
+
+### 3.4 Daemon lifecycle (mostly already exist)
+
+- `daemon.start` / `daemon.stop`
+- `daemon.agent.fallback`
+- `daemon.wake.scheduled` / `.fired` / `.completed`
+- `daemon.cost.update`
+
+---
+
+## 4. Phasing
+
+Each phase is independently mergeable.
+
+### Phase 1 — CLI formatter module (2 days)
+
+- New `packages/cli/src/cli-formatter.ts` with the three modes and rendering conventions from §2.3.
+- Unit tests: deterministic output for each event × mode matrix.
+- Wire into `bin.ts`: construct one formatter at CLI start, pass down to command handlers.
+- No migration yet — new commands can opt in; old ones keep their `console.log`.
+
+### Phase 2 — Migrate `doctor` (1 day)
+
+- Easiest first migration; `doctor` already has a structured `DoctorFinding` type.
+- Replace `formatReport` with an event stream routed through the formatter.
+- `--json` flag becomes a thin wrapper around `CliFormatter` in `json` mode.
+- Delete the hand-rolled pretty-print code.
+
+### Phase 3 — Migrate `init` (1-2 days)
+
+- Interactive prompts stay as `readline` (operator input is input, not event).
+- Every scaffold step emits an event. Final "next steps" hero output becomes events.
+
+### Phase 4 — Migrate `group-wake` standalone (2-3 days)
+
+- Largest migration. The meeting's full narrative becomes events.
+- Agent dialogue arrives via the LLM client stream — wrap in `group-wake.agent.contribution` events.
+- Action execution already returns receipts; just emit them as events.
+
+### Phase 5 — REPL event routing (1 day)
+
+- `attach.ts` changes its event-handler: instead of `console.log`, route through the formatter.
+- Closes the visual-jump gap Nori observed.
+
+### Phase 6 — Daemon log sink unification (half-day)
+
+- `DaemonLoggerImpl` becomes an adapter over `CliFormatter`.
+- TTY detection on daemon start determines mode.
+
+### Phase 7 — Enforcement (half-day)
+
+- ESLint rule: `no-console` with `allow: []` in `packages/core/src/` and `packages/cli/src/` (except `bin.ts` + test files).
+- Existing `console.log` sites without an event-emission alternative become typed errors at lint time.
+
+**Total estimated effort:** 8-12 days focused work.
+
+---
+
+## 4.1 Migration checklist
+
+Rough inventory of `console.log` sites to migrate. Each bullet becomes an event emission.
+
+- [ ] `packages/cli/src/bin.ts` — ~15 sites (top-level CLI output, allowed but formalize)
+- [ ] `packages/cli/src/init.ts` — ~20 sites (scaffold output, prompts, next-steps block)
+- [ ] `packages/cli/src/doctor.ts` — ~8 sites (mostly in `formatReport` + `runDoctorCli`)
+- [ ] `packages/cli/src/group-wake.ts` — ~30 sites (meeting narrative, action receipts, resolver failures)
+- [ ] `packages/cli/src/backlog.ts`, `directive.ts`, `attach.ts` — ~20 sites combined
+- [ ] `packages/cli/src/sessions.ts`, `running-sessions.ts` — ~5 sites (list rendering)
+- [ ] `packages/core/src/` — audit; most already route through logger, but spot-check
+
+---
+
+## 5. Open questions
+
+### Q1. Event emission from inside core library functions
+
+Core library functions don't take a `logger` as a parameter — they return typed results, and the caller logs. Should we keep that purity and only emit events from the CLI/daemon layer? Or should core accept an optional `logger` arg (as the daemon does) for the cases where structured events enrich the result?
+
+**Recommendation:** keep core pure. Events are a presentation concern. Core returns results; the CLI decides what to emit.
+
+### Q2. Colors in non-TTY output when `--json` is explicitly set
+
+Should `--json` on a TTY still emit pure JSON (no ANSI codes)? Or should it respect the TTY and colorize?
+
+**Recommendation:** `--json` always strips ANSI, even on TTY. Consistency wins; operators who want colored JSON can pipe through `jq -C`.
+
+### Q3. Event versioning
+
+As we add events, some will be renamed or restructured. Do we need a schema version?
+
+**Recommendation:** yes, but not yet. Add `schema: "murmuration-log-v1"` to every JSON-lines event in Phase 6. Bumping is a future-v0.6 concern.
+
+### Q4. Live streaming during agent dialogue
+
+Agent dialogue is streamed token-by-token from the LLM provider. Do we emit one event per token, per line, per complete message?
+
+**Recommendation:** per line. One `group-wake.agent.contribution.chunk` per newline (or periodically), one `.complete` per full message. Human mode renders chunks as they arrive; JSON mode emits each chunk as a separate line.
+
+---
+
+## 6. Risks
+
+- **Large PR.** 80+ `console.log` sites; bundle-size of the changes could be intimidating. Phase it explicitly as in §4.
+- **Breaking scripts.** Any operator piping `murmuration group-wake` into `grep` will see different output. Mitigation: ship `--json` mode in Phase 1 so scripts have a stable target before the pretty format changes.
+- **Test flakiness.** Formatter tests depend on ANSI code handling; use a stripping helper in test assertions.
+- **Lint rule backlash.** Some CLI commands genuinely need `console.log` for prompts and direct terminal I/O. Allowlist `bin.ts` + `spirit/repl.ts` + test files; fail everywhere else.
+
+---
+
+## 7. Success criteria
+
+- [ ] Every `pnpm run lint` run is clean with the new `no-console` rule enforced
+- [ ] `murmuration group-wake --group example` produces either **entirely** colored plaintext (TTY) or **entirely** JSON-lines (piped)
+- [ ] Attached REPL `:convene` renders agent dialogue and daemon events in the same visual style, no format jumps
+- [ ] `murmuration doctor --json` emits parseable JSON that passes `jq .` without error
+- [ ] No tester reports "the output suddenly changes format" for v0.5.1
+- [ ] Manual smoke: run the full v0.5.0 tester walkthrough (`docs/GETTING-STARTED.md`) and confirm visual coherence at every step
+
+---
+
+## 8. Related
+
+- [ADR-0017](../adr/0017-github-mutations.md) — original structured logging introduction
+- Engineering Standard #2 (typed results) in [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- Engineering Standard #9 (no silent swallowing) in [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- Engineering Standard #11 (reasonable defaults) — the output format should have a reasonable default too
+- Issue [#139](https://github.com/murmurations-ai/murmurations-harness/issues/139) — the tracking issue for this work


### PR DESCRIPTION
Draft plan for the v0.5.1 logging refactor per tester feedback.\n\nNo code changes — this is the design doc. Scope, phasing, event taxonomy, risks, open questions.\n\nRelated: #139 (tracking issue).