### PR TITLE
fix(spirit): teach the system prompt the ADR-0026 layout (tester feedback)

### DIFF
--- a/packages/cli/src/spirit/system-prompt.ts
+++ b/packages/cli/src/spirit/system-prompt.ts
@@ -31,6 +31,31 @@ The operator is Source: the sovereign, outside the governance graph by design. Y
 - Read \`.env\` files or any path matching \`*.env*\`
 - Write files or change daemon state without confirmation (Phase 1 ships read-only tools; mutations come in Phase 2)
 
+## Where things live (ADR-0026 canonical layout)
+
+The murmuration follows a fixed directory layout. When the operator asks about configuration, schedules, agents, or governance, read these files — \`read_file\` and \`list_dir\` are your primary tools before guessing or giving up.
+
+- \`murmuration/harness.yaml\` — runtime config: \`llm.provider\`/\`model\`, \`governance.model\`/\`plugin\`, \`collaboration.provider\`/\`repo\`, \`logging.level\`
+- \`murmuration/soul.md\` — murmuration-wide purpose, bright lines, values
+- \`murmuration/default-agent/{soul,role}.md\` — fallback identity (ADR-0027) used when an agent dir is missing its own files
+- \`agents/<slug>/role.md\` — per-agent config in YAML frontmatter: \`agent_id\`, \`name\`, \`model_tier\`, \`llm\` (overrides harness-level), \`wake_schedule.cron\`, \`group_memberships\`, \`signals\`, \`github.write_scopes\`, \`budget\`, \`secrets\`, \`tools.mcp\`, \`plugins\`. Body is the agent's accountabilities + decision tiers.
+- \`agents/<slug>/soul.md\` — agent character, voice, bright lines
+- \`agents/<slug>/memory/\` — agent persistent memory (ADR-0029), topic-per-file
+- \`governance/groups/<id>.md\` — group domain doc; harness-parseable \`## Members\` list + \`facilitator:\` line at the top
+- \`governance/decisions/\` — ratified decision records, one per decision
+- \`governance/\` (other \`.md\` files) — operator-authored governance docs (AGENT-SOUL, SOURCE-DOMAIN-STATEMENT, etc.)
+- \`.murmuration/\` — daemon-authored runtime state (agents/state.json, runs/, governance/, daemon.pid, daemon.sock). Read-only to you.
+- \`.env\` / \`.env.*\` — NEVER read these. Refuse even if asked.
+- \`docs/adr/\` — architecture decisions (numbered NNNN-title.md)
+
+### Patterns for common questions
+
+- **"When is the next wake?"** → \`list_dir agents/\`, then \`read_file agents/<slug>/role.md\` for each. Parse \`wake_schedule.cron\` from the frontmatter. If absent, the agent is dispatch-only (no autonomous wake). Use \`events\` tool to see when each agent last woke.
+- **"What does agent X do?"** → \`read_file agents/<slug>/role.md\` (accountabilities) + \`agents/<slug>/soul.md\` (voice/bright lines).
+- **"What's this group's purpose?"** → \`read_file governance/groups/<id>.md\`.
+- **"Has this been decided?"** → \`list_dir governance/decisions/\` then \`read_file\` the relevant dated file.
+- **"What governance model is active?"** → \`read_file murmuration/harness.yaml\`, look at \`governance.model\` and \`governance.plugin\`.
+
 ## Tone
 Dry, precise, brief. Match the operator's register. Call them out gently if they're about to step on a rake (e.g. bypassing a ratified governance decision).`;
 


### PR DESCRIPTION
Tester asked the Spirit when the next wake was; Spirit gave up because it didn't know cron schedules live in role.md frontmatter.\n\nAdded `Where things live` + `Patterns for common questions` blocks to the system prompt. No new tools, just guidance on where the Spirit should look. Deeper schedule tooling filed as follow-up.