### PR TITLE
fix: revert spinner above-mode (broke prompt leader)

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -73,49 +73,23 @@ interface SocketEvent {
  *
  * Skipped when stderr is not a TTY (CI, piped output).
  */
-const startThinkingIndicator = (label: string, rl?: Interface): (() => void) => {
+const startThinkingIndicator = (label: string): (() => void) => {
   if (!process.stderr.isTTY) return () => undefined;
   const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   const start = Date.now();
   let frameIdx = 0;
-
-  // "Above mode": when a readline is passed, reserve a line above the
-  // prompt for the spinner so the operator can still see the prompt
-  // while work is in flight. Without rl, fall back to the original
-  // in-place spinner.
-  let aboveMode = false;
-  if (rl !== undefined) {
-    process.stderr.write("\n");
-    aboveMode = true;
-    rl.prompt(true);
-  }
-
   const render = (): void => {
     const elapsed = Math.floor((Date.now() - start) / 1000);
     const frame = frames[frameIdx % frames.length] ?? "";
     frameIdx++;
-    if (aboveMode) {
-      // Save cursor → up 1 line → col 0 → clear line → spinner → restore.
-      process.stderr.write(
-        `\x1b7\x1b[1A\r\x1b[2K\x1b[2m${frame} ${label} (${String(elapsed)}s)\x1b[0m\x1b8`,
-      );
-    } else {
-      process.stderr.write(`\r\x1b[2m${frame} ${label} (${String(elapsed)}s)\x1b[0m`);
-    }
+    process.stderr.write(`\r\x1b[2m${frame} ${label} (${String(elapsed)}s)\x1b[0m`);
   };
   render();
   const timer = setInterval(render, 100);
   return () => {
     clearInterval(timer);
-    if (aboveMode) {
-      // Up 1 (spinner line) → col 0 → clear to end of screen (removes
-      // spinner line + prompt line). Caller continues with console.log
-      // of the result, then rl.prompt() for a fresh prompt.
-      process.stderr.write("\x1b[1A\r\x1b[J");
-    } else {
-      // Clear the line and reset to column 0.
-      process.stderr.write("\r\x1b[K");
-    }
+    // Clear the line and reset to column 0.
+    process.stderr.write("\r\x1b[K");
   };
 };
 
@@ -474,7 +448,7 @@ export const runAttach = async (rootDir: string, name: string): Promise<void> =>
       return;
     }
     spiritBusy = true;
-    const stop = startThinkingIndicator("Spirit thinking", rl);
+    const stop = startThinkingIndicator("Spirit thinking");
     try {
       const result = await session.turn(message);
       stop();


### PR DESCRIPTION
## Summary
- Cursor manipulation in the spinner (save/restore + up-1) desynced readline's \`prevRows\` tracking, causing \`spirit>\` to disappear on the second and later turns
- Revert to the original in-place spinner
- Busy guard stays — concurrent Spirit turns still prevented
- Visible-prompt-while-thinking moves to issue #147 for a proper implementation alongside the type-ahead queue

## Test plan
- [x] \`pnpm run check\` passes
- [ ] Multiple Spirit turns in a row — prompt leader stays visible after each response

🤖 Generated with [Claude Code](https://claude.com/claude-code)