### PR TITLE
fix: surface Spirit tool-budget exhaustion (no more silent empty output)

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -452,7 +452,15 @@ export const runAttach = async (rootDir: string, name: string): Promise<void> =>
     try {
       const result = await session.turn(message);
       stop();
-      console.log(result.content);
+      if (result.truncated) {
+        console.log(
+          "(Spirit ran out of tool-use budget before producing an answer. Try narrowing the question, or ask for a shorter summary.)",
+        );
+      } else if (result.content.trim().length === 0) {
+        console.log("(Spirit returned no text. Try rephrasing the question.)");
+      } else {
+        console.log(result.content);
+      }
       const tokens = `${String(result.inputTokens)} in / ${String(result.outputTokens)} out`;
       const cost = `$${result.estimatedCostUsd.toFixed(4)}`;
       const tools = result.toolCallCount > 0 ? `, ${String(result.toolCallCount)} tool calls` : "";

--- a/packages/cli/src/spirit/client.ts
+++ b/packages/cli/src/spirit/client.ts
@@ -48,6 +48,12 @@ export interface SpiritTurnResult {
   readonly outputTokens: number;
   readonly toolCallCount: number;
   readonly estimatedCostUsd: number;
+  /**
+   * True when the tool loop exhausted maxSteps before the model
+   * produced a final text message. When this is set the operator
+   * sees an empty response; the REPL should surface a hint.
+   */
+  readonly truncated: boolean;
 }
 
 export interface SpiritInitOptions {
@@ -172,6 +178,7 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
   const turn = async (message: string): Promise<SpiritTurnResult> => {
     history.push({ role: "user", content: message });
 
+    const maxSteps = 16;
     const result = await client.complete({
       model,
       messages: history,
@@ -179,7 +186,7 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
       maxOutputTokens: 4096,
       temperature: 0.2,
       tools,
-      maxSteps: 8,
+      maxSteps,
     });
 
     if (!result.ok) {
@@ -193,13 +200,22 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
     const outputTokens = result.value.outputTokens;
     const estimatedCostUsd =
       (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+    const toolCallCount = result.value.toolCalls?.length ?? 0;
+    // Vercel SDK reports finishReason="tool-calls" (→ "tool_use") when
+    // stepCountIs fires while the model was mid-tool-loop. Combined with
+    // empty text, that means the budget ran out before a final answer.
+    const truncated =
+      toolCallCount >= maxSteps &&
+      result.value.stopReason === "tool_use" &&
+      result.value.content.trim().length === 0;
 
     return {
       content: result.value.content,
       inputTokens,
       outputTokens,
-      toolCallCount: result.value.toolCalls?.length ?? 0,
+      toolCallCount,
       estimatedCostUsd,
+      truncated,
     };
   };
 


### PR DESCRIPTION
## Problem
Tester report:

\`\`\`
emergent-praxis> what agent will wake next?

  [101310 in / 1188 out, 8 tool calls · ~\$0.1326]
\`\`\`

No answer text. The Spirit hit the \`maxSteps: 8\` tool-loop budget while reading all 27 EP agent role.md files. Vercel SDK returns \`finishReason: \"tool-calls\"\` with empty text when the budget is exhausted mid-loop; the REPL printed the empty string, so the operator saw only the footer.

## Fix
- Raise \`maxSteps\` 8 → 16
- Add \`truncated: boolean\` on \`SpiritTurnResult\` — set when toolCallCount == maxSteps, stopReason == \"tool_use\", and content is empty
- REPL prints a helpful message when content is empty, distinguishing the truncation case

## Test plan
- [x] \`pnpm run check\` passes
- [ ] Ask EP Spirit a broad question — either answers within budget or shows the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)