### PR TITLE
docs: CONFIGURATION.md reference for harness.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,22 +160,28 @@ Set `LANGFUSE_SECRET_KEY` and `LANGFUSE_PUBLIC_KEY` in your environment. The har
 
 ### Configuration (`harness.yaml`)
 
-Settings that rarely change live in `murmuration/harness.yaml`:
+Settings that rarely change live in `murmuration/harness.yaml`. Full field reference: [docs/CONFIGURATION.md](./docs/CONFIGURATION.md).
 
 ```yaml
+llm:
+  provider: gemini
+
 governance:
-  plugin: "./governance-s3/index.mjs"
+  plugin: s3 # bundled alias; also accepts a path or npm package
 
 collaboration:
-  provider: "github" # or "local" for offline
-  repo: "my-org/my-murmuration" # governance repo (private)
+  provider: github # or "local" for offline
+  repo: my-org/my-murmuration
 
 products:
   - name: my-product
-    repo: "my-org/my-product" # product repo (separate)
+    repo: my-org/my-product
 
 logging:
-  level: "info"
+  level: info
+
+spirit:
+  maxSteps: 32 # Spirit tool-loop budget per turn
 ```
 
 CLI flags override the config file when set. The murmuration is self-contained — all configuration, identity, and runtime state live in one directory.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,124 @@
+# Configuration reference
+
+Everything an operator can tune via `murmuration/harness.yaml`.
+
+Load order:
+
+```
+defaults (in code) → harness.yaml → CLI flags → environment variables
+```
+
+Anything not set falls back to the default. Anything invalid falls back silently (the loader never throws) so a typo in one field doesn't brick the daemon. Use `murmuration doctor` to validate a setup.
+
+## Example
+
+```yaml
+# murmuration/harness.yaml
+
+llm:
+  provider: gemini # gemini | anthropic | openai | ollama
+  model: gemini-2.5-pro # optional; omit to let the tier resolver pick
+
+governance:
+  plugin: s3 # bundled alias, or ./path/to/plugin.mjs, or npm package
+
+collaboration:
+  provider: github # github | local
+  repo: my-org/my-murmuration # required when provider = github
+
+products:
+  - name: my-product
+    repo: my-org/my-product
+
+logging:
+  level: info # debug | info | warn | error
+
+spirit:
+  maxSteps: 32 # Spirit tool-loop budget per turn
+```
+
+## Fields
+
+### `llm`
+
+Harness-level default LLM. Individual agents override via their `role.md` `llm:` frontmatter.
+
+| Field      | Type   | Default       | Notes                                                                                                                             |
+| ---------- | ------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `provider` | enum   | `gemini`      | One of `gemini`, `anthropic`, `openai`, `ollama`.                                                                                 |
+| `model`    | string | tier-resolved | Explicit model ID. When omitted the tier resolver picks a "balanced" model for the provider; see `packages/llm/src/providers.ts`. |
+
+The Spirit inherits this default unless a future `spirit.md` overrides it.
+
+### `governance`
+
+| Field    | Type   | Default     | Notes                                                                                                                                                         |
+| -------- | ------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plugin` | string | `undefined` | Bundled alias (`s3`, `self-organizing`), a path starting with `.` or `/`, or an installed npm package name. When omitted the harness runs without governance. |
+
+`murmuration doctor` reports the resolution kind (bundled-alias / local-path / npm-package / unresolvable).
+
+### `collaboration`
+
+Where meeting minutes, action items, and signals are written.
+
+| Field      | Type   | Default     | Notes                                                                                                           |
+| ---------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `provider` | enum   | `github`    | `github` (canonical) or `local` (writes to `.murmuration/items/` on disk — useful for testing without a token). |
+| `repo`     | string | `undefined` | `owner/repo`. Required when `provider: github`.                                                                 |
+
+### `products`
+
+Additional repos the harness may open issues/PRs against. Agents reference these by name from `role.md` write scopes.
+
+```yaml
+products:
+  - name: my-product
+    repo: my-org/my-product
+```
+
+Each entry needs both `name` and `repo`. Malformed entries are silently dropped.
+
+### `logging`
+
+| Field   | Type | Default | Notes                                |
+| ------- | ---- | ------- | ------------------------------------ |
+| `level` | enum | `info`  | `debug` / `info` / `warn` / `error`. |
+
+### `spirit`
+
+Spirit-specific knobs. The Spirit is the operator's read-only companion; see [ADR-0024](./adr/0024-spirit-of-the-murmuration.md).
+
+| Field      | Type   | Default | Notes                                                                                                                                                                                                                                                                      |
+| ---------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxSteps` | number | `32`    | Tool-use budget per Spirit turn. Each step is one round-trip to the LLM plus any tool calls. Larger murmurations (many agents) need a bigger budget or the Spirit runs out of steps before producing a final answer. Must be ≥ 1; invalid values fall back to the default. |
+
+When the budget is exhausted the REPL shows:
+
+```
+(Spirit ran out of tool-use budget before producing an answer. Try narrowing the question, or ask for a shorter summary.)
+```
+
+## Precedence
+
+CLI flags override `harness.yaml` for the keys they cover:
+
+| Flag                  | Overrides                |
+| --------------------- | ------------------------ |
+| `--governance <path>` | `governance.plugin`      |
+| `--collaboration <p>` | `collaboration.provider` |
+| `--log-level <lvl>`   | `logging.level`          |
+
+Environment variables are read at runtime by the providers themselves (e.g. `GEMINI_API_KEY`, `GITHUB_TOKEN`) — they never appear in `harness.yaml`. See `.env.example`.
+
+## Not yet configurable
+
+Several tunables are still hardcoded and tracked in [issue #152](https://github.com/murmurations-ai/murmurations-harness/issues/152): daemon circuit-breaker threshold, LLM retry policy, signal aggregator caps, meeting-prompt context caps, and group-meeting LLM params. Each moves to `harness.yaml` in subsequent PRs following the `spirit.maxSteps` pattern.
+
+## What never goes in `harness.yaml`
+
+- **Secrets** — API keys, tokens, passphrases. Use `.env` (see `secrets-dotenv` provider) or a platform secrets manager.
+- **Identity** — agent souls, roles, group membership. These live in `agents/<slug>/` and `governance/groups/` per [ADR-0026](./adr/0026-harness-directory-layout.md).
+- **Per-agent overrides** — model, schedule, budget, write scopes. These go in `agents/<slug>/role.md` frontmatter per [ADR-0016](./adr/0016-role-md-schema.md).
+
+Engineering Standard #11 in [ARCHITECTURE.md](./ARCHITECTURE.md) explains the split: reasonable defaults with config-file overrides for operational knobs; never for identity or secrets.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -177,6 +177,7 @@ Pass `--help` to any command for full flag documentation.
 - **Pick a governance model.** v0.5.0 ships with five: S3 (self-organizing), chain-of-command, meritocratic, consensus, parliamentary. Declare one in `murmuration/harness.yaml`.
 - **Set real wake schedules.** By default, new agents are dispatch-only. Add `wake_schedule.cron` when you're ready for autonomous wakes.
 - **Tune budgets and write scopes** per agent as you observe what they actually need.
+- **Tune the harness.** [docs/CONFIGURATION.md](./CONFIGURATION.md) is the full reference for `murmuration/harness.yaml` — LLM provider, governance plugin, logging level, Spirit tool-loop budget, and more.
 - **Read the architecture docs.** [docs/ARCHITECTURE.md](./ARCHITECTURE.md) covers the engineering standards; ADRs under [docs/adr/](./adr/) cover every load-bearing design decision.
 
 Questions, bugs, feedback: open an issue on [murmurations-ai/murmurations-harness](https://github.com/murmurations-ai/murmurations-harness/issues).


### PR DESCRIPTION
## Summary
- New \`docs/CONFIGURATION.md\` — single source of truth for every \`harness.yaml\` field: \`llm\`, \`governance\`, \`collaboration\`, \`products\`, \`logging\`, \`spirit\`
- Covers defaults, types, CLI-flag precedence, the never-in-yaml list (secrets, identity), and points to #152 for the tunables still pending a lift
- README links to the new doc; the README example now includes \`spirit.maxSteps\`
- GETTING-STARTED \"Next steps\" points to it

## Why
Operators need to know what they can tune without reading source. Now that \`spirit.maxSteps\` is configurable (PR #151), there's a real field set worth documenting — and a growing one as #152 lands.

## Test plan
- [x] \`pnpm run check\` passes
- [ ] Render CONFIGURATION.md on GitHub — tables/links render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)