### PR TITLE
fix: init secret prompt — no more plaintext echo, masked '*' input

### DIFF
--- a/packages/cli/src/init-secrets.ts
+++ b/packages/cli/src/init-secrets.ts
@@ -1,12 +1,13 @@
 /**
  * Interactive secret capture for `murmuration init` — v0.5.0 Milestone 2.
  *
- * Prompts with stdin in raw mode so characters aren't echoed to the
- * terminal. Provides a provider-specific shape-validation heuristic
- * (catches paste-from-wrong-clipboard; not cryptographic). Shows a
- * masked last-4 confirmation so the operator can verify the paste
- * landed. ENTER-to-skip returns an empty string and the caller writes
- * a placeholder to .env.
+ * Prompts with stdin in raw mode and echoes a '*' per character so
+ * the operator sees typing progress without leaking the secret.
+ * Provides a provider-specific shape-validation heuristic (catches
+ * paste-from-wrong-clipboard; not cryptographic). Shows a masked
+ * last-4 confirmation so the operator can verify the paste landed.
+ * ENTER-to-skip returns an empty string and the caller writes a
+ * placeholder to .env.
  *
  * Exported helpers are pure (no side effects beyond stdio) so init.ts
  * composes them and tests exercise each piece in isolation.
@@ -168,8 +169,12 @@ export const promptSecret = async (options: SecretPromptOptions): Promise<string
           return;
         }
         if (code === 8 || code === 127) {
-          // backspace / delete — pop one character silently
-          if (chars.length > 0) chars.pop();
+          // backspace / delete — pop one char and erase its mask.
+          // \b moves cursor left; ' ' overwrites the '*'; \b moves back.
+          if (chars.length > 0) {
+            chars.pop();
+            stdout.write("\b \b");
+          }
           continue;
         }
         if (code < 32) {
@@ -177,6 +182,10 @@ export const promptSecret = async (options: SecretPromptOptions): Promise<string
           continue;
         }
         chars.push(ch);
+        // Tester feedback: pure invisible input makes it hard to tell
+        // whether typing is registering. Echo a '*' per character so
+        // the operator sees progress without leaking the secret.
+        stdout.write("*");
       }
     };
 
@@ -237,7 +246,7 @@ export const captureSecret = async (options: CaptureSecretOptions): Promise<stri
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const value = await doPrompt({
-      question: `Enter your ${options.spec.envVar} (input hidden, press ENTER to skip): `,
+      question: `Enter your ${options.spec.envVar} (masked, press ENTER to skip): `,
     });
 
     const trimmed = value.trim();

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -49,6 +49,27 @@ const ask = (question: string): Promise<string> =>
     getRL().question(question, r);
   });
 
+/**
+ * Wrap a {@link captureSecret} call so it doesn't fight with the
+ * init-flow readline. An active readline keeps its own stdin data
+ * listener, which echoes raw keystrokes AND steals the ENTER meant
+ * for the echo-off prompt — manifesting as a plaintext-echoed key
+ * and a consumed confirmation ENTER. Tear down the readline before
+ * the capture; lazy `getRL()` re-creates a fresh one on the next
+ * `ask()`.
+ *
+ * Tester report (v0.5.0): `murmuration init` echoed the Gemini API
+ * key in plaintext and then "crashed" (actually: readline consumed
+ * the confirmation ENTER, hanging the prompt).
+ */
+const captureSecretIsolated = async (
+  args: Parameters<typeof captureSecret>[0],
+): Promise<string> => {
+  rl?.close();
+  rl = null;
+  return captureSecret(args);
+};
+
 // ---------------------------------------------------------------------------
 // Default-agent templates
 // ---------------------------------------------------------------------------
@@ -419,9 +440,9 @@ export const runInitFromExample = async (
   // can always edit .env by hand later.
   if (llmSpec && process.stdin.isTTY) {
     console.log(
-      `\nLet's capture your ${llmSpec.displayName} API key now so you can run a meeting right away.\nInput is hidden; press ENTER to skip and paste it into .env later.`,
+      `\nLet's capture your ${llmSpec.displayName} API key now so you can run a meeting right away.\nInput is masked; press ENTER to skip and paste it into .env later.`,
     );
-    capturedKey = await captureSecret({ spec: llmSpec, askYN: ask });
+    capturedKey = await captureSecretIsolated({ spec: llmSpec, askYN: ask });
     if (capturedKey) {
       await writeEnvKey(envPath, llmSpec.envVar, capturedKey);
     }
@@ -534,9 +555,9 @@ export const runInit = async (optionsOrTargetArg?: RunInitOptions | string): Pro
   const llmSpec = getLLMKeySpec(defaultProvider);
   if (llmSpec) {
     console.log(
-      `\nLet's capture your ${llmSpec.displayName} API key. Input is hidden; press ENTER to skip.`,
+      `\nLet's capture your ${llmSpec.displayName} API key. Input is masked; press ENTER to skip.`,
     );
-    const key = await captureSecret({ spec: llmSpec, askYN: ask });
+    const key = await captureSecretIsolated({ spec: llmSpec, askYN: ask });
     if (key) capturedSecrets.set(llmSpec.envVar, key);
   } else {
     console.log(`\nOllama is locally-hosted — no API key needed.`);
@@ -559,9 +580,9 @@ export const runInit = async (optionsOrTargetArg?: RunInitOptions | string): Pro
 
     // 4a. Capture GITHUB_TOKEN (v0.5.0 Milestone 2).
     console.log(
-      `\nLet's capture your GitHub personal access token. It needs "repo" scope. Input is hidden; press ENTER to skip.`,
+      `\nLet's capture your GitHub personal access token. It needs "repo" scope. Input is masked; press ENTER to skip.`,
     );
-    const token = await captureSecret({ spec: GITHUB_TOKEN_SPEC, askYN: ask });
+    const token = await captureSecretIsolated({ spec: GITHUB_TOKEN_SPEC, askYN: ask });
     if (token) capturedSecrets.set(GITHUB_TOKEN_SPEC.envVar, token);
   }
 


### PR DESCRIPTION
## Problem
Tester report:
```
Enter your GEMINI_API_KEY (input hidden, press ENTER to skip): <KEY ECHOED IN PLAINTEXT>
  Captured GEMINI_API_KEY ending in …XXXX (length 39).
  Looks right? (Y/n): %
```

The key was echoed in plaintext, and the confirmation prompt "crashed" (actually hung — zsh's `%` is an EOL marker).

## Root cause
The init flow's module-level readline Interface keeps its own stdin `data` listener. When `captureSecret` → `promptSecret` ran, both listeners fired on each keystroke:
- readline echoed each char (plaintext leak)
- readline consumed the ENTER, emitting a `line` event with no handler
- then `askYN("Looks right? (Y/n): ")` registered `rl.question` — but readline was waiting for a second ENTER that would never come

## Fix
- `captureSecretIsolated` tears down the readline before capture; `getRL()` lazily re-creates a fresh one on the next ask()
- Applied at all three call sites (two LLM-key paths, one GITHUB_TOKEN path)

## Bonus
Tester also asked for masked input instead of invisible:
- `promptSecret` now echoes `*` per character
- Backspace erases the mask (`\b \b`)
- Prompt text: "Input is hidden" → "Input is masked"

## Test plan
- [x] `pnpm run check` passes
- [ ] `murmuration init` — key masked with *, "Looks right?" works, Y/n answered cleanly

---

**Note**: original PR description inadvertently included the leaked key from the tester output. Key has since been rotated; description redacted 2026-04-21.