### PR TITLE
feat: actionable hints for LLM failures (formatLLMError)

### DIFF
--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -29,7 +29,7 @@ import {
   type GovernanceTally,
   GovernanceStateStore,
 } from "@murmurations-ai/core";
-import { createLLMClient, type LLMClient } from "@murmurations-ai/llm";
+import { createLLMClient, formatLLMError, type LLMClient } from "@murmurations-ai/llm";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 
 import { buildBuiltinProviderRegistry } from "./builtin-providers/index.js";
@@ -619,7 +619,7 @@ export const runGroupWakeCommand = async (
         temperature: 0.3,
         ...(extensionTools.length > 0 ? { tools: extensionTools, maxSteps: 5 } : {}),
       });
-      if (!r.ok) throw new Error(`LLM failed for ${agentId}: ${r.error.code}`);
+      if (!r.ok) throw new Error(`\n${formatLLMError(r.error, { agentId, model })}`);
       return {
         content: r.value.content,
         inputTokens: r.value.inputTokens,

--- a/packages/cli/src/spirit/client.ts
+++ b/packages/cli/src/spirit/client.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { makeSecretKey, makeSecretValue, type SecretValue } from "@murmurations-ai/core";
 import {
   createLLMClient,
+  formatLLMError,
   ProviderRegistry,
   type LLMClient,
   type LLMClientConfig,
@@ -191,7 +192,7 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
 
     if (!result.ok) {
       history.pop();
-      throw new Error(`Spirit LLM error: ${result.error.code} — ${result.error.message}`);
+      throw new Error(`\n${formatLLMError(result.error, { agentId: "spirit", model })}`);
     }
 
     history.push({ role: "assistant", content: result.value.content });

--- a/packages/llm/src/errors.test.ts
+++ b/packages/llm/src/errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  formatLLMError,
+  LLMForbiddenError,
+  LLMRateLimitError,
+  LLMUnauthorizedError,
+} from "./errors.js";
+
+describe("formatLLMError", () => {
+  it("renders a forbidden gemini error with provider-specific hints", () => {
+    const err = new LLMForbiddenError("gemini", "Permission denied", {
+      requestUrl: "https://example",
+    });
+    const out = formatLLMError(err, { agentId: "coordinator", model: "gemini-2.5-flash" });
+    expect(out).toContain("LLM call failed for coordinator");
+    expect(out).toContain("provider: gemini");
+    expect(out).toContain("model:    gemini-2.5-flash");
+    expect(out).toContain("code:     forbidden (HTTP 403)");
+    expect(out).toContain("Permission denied");
+    expect(out).toContain("Next steps:");
+    expect(out).toContain("model_tier: economy");
+  });
+
+  it("renders a 401 with env-var remediation", () => {
+    const err = new LLMUnauthorizedError("anthropic", "bad key", {
+      requestUrl: "https://example",
+    });
+    const out = formatLLMError(err);
+    expect(out).toContain("ANTHROPIC_API_KEY");
+    expect(out).toContain("restart the daemon");
+  });
+
+  it("renders rate-limit with cadence hints", () => {
+    const err = new LLMRateLimitError("openai", "slow down", {
+      requestUrl: "https://example",
+      status: 429,
+      retryAfterSeconds: 30,
+      limitScope: "rpm",
+    });
+    const out = formatLLMError(err, { model: "gpt-4o-mini" });
+    expect(out).toContain("rate-limited");
+    expect(out).toContain("HTTP 429");
+    expect(out).toContain("wake_schedule");
+  });
+
+  it("omits agentId header when not provided", () => {
+    const err = new LLMForbiddenError("openai", "nope", { requestUrl: "x" });
+    const out = formatLLMError(err);
+    expect(out).toMatch(/^LLM call failed\n/);
+  });
+});

--- a/packages/llm/src/errors.ts
+++ b/packages/llm/src/errors.ts
@@ -186,6 +186,123 @@ export class LLMInternalError extends LLMClientError {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Human-readable formatting with remediation hints
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an {@link LLMClientError} as a multi-line operator-facing
+ * block. Shows provider, code, HTTP status, model when provided, and
+ * the raw provider message. Appends a short "what to check" list
+ * tailored to the error code + provider so a tester hit with a 403
+ * knows to look at API-key permissions rather than their agent code.
+ *
+ * Never embeds the API key or token. Safe to print to stdout.
+ *
+ * Intentionally generous with whitespace — operators read this in a
+ * terminal, not a log aggregator.
+ */
+export const formatLLMError = (
+  err: LLMClientError,
+  context: { readonly agentId?: string; readonly model?: string } = {},
+): string => {
+  const lines: string[] = [];
+  const who = context.agentId !== undefined ? ` for ${context.agentId}` : "";
+  lines.push(`LLM call failed${who}`);
+  lines.push(`  provider: ${err.provider}`);
+  if (context.model !== undefined) lines.push(`  model:    ${context.model}`);
+  lines.push(
+    `  code:     ${err.code}${err.status !== undefined ? ` (HTTP ${String(err.status)})` : ""}`,
+  );
+  lines.push(`  message:  ${err.message}`);
+  const hints = remediationHints(err);
+  if (hints.length > 0) {
+    lines.push("");
+    lines.push("Next steps:");
+    for (const hint of hints) lines.push(`  - ${hint}`);
+  }
+  return lines.join("\n");
+};
+
+const remediationHints = (err: LLMClientError): readonly string[] => {
+  switch (err.code) {
+    case "unauthorized":
+      return [
+        `Your ${envVarForProvider(err.provider)} is missing or wrong. Check \`.env\` and confirm the key starts with the expected prefix.`,
+        "Rotate the key at the provider console if it may be compromised.",
+        "After editing .env, restart the daemon so the new value is loaded.",
+      ];
+    case "forbidden":
+      return providerForbiddenHints(err.provider);
+    case "rate-limited":
+      return [
+        "You've hit the provider's rate limit. Wait a minute or two and retry.",
+        "If this happens often: lower wake cadence (agent role.md `wake_schedule`), reduce parallelism, or upgrade your provider plan.",
+        "Consider a different model tier — set `model_tier: economy` in role.md for cheaper, higher-limit models.",
+      ];
+    case "content-policy":
+      return [
+        "The provider refused the prompt for safety/policy reasons.",
+        "Check the agent's soul.md and any recent signals for content that could have tripped the filter.",
+      ];
+    case "context-length":
+      return [
+        "The prompt exceeded the model's context window.",
+        "Reduce the number of signals included (agent role.md `signals` caps), shorten agent soul.md, or switch to a larger-context model.",
+      ];
+    case "transport":
+    case "provider-outage":
+      return [
+        "Network or upstream provider issue.",
+        "Check connectivity and https://status.anthropic.com / https://status.openai.com / https://status.cloud.google.com depending on provider.",
+        "Retry in a few minutes.",
+      ];
+    case "validation":
+    case "parse":
+    case "internal":
+      return ["Unexpected client error. Include the `message:` line above when filing a bug."];
+  }
+};
+
+const envVarForProvider = (provider: string): string => {
+  switch (provider) {
+    case "gemini":
+      return "GEMINI_API_KEY";
+    case "anthropic":
+      return "ANTHROPIC_API_KEY";
+    case "openai":
+      return "OPENAI_API_KEY";
+    default:
+      return `${provider.toUpperCase()}_API_KEY`;
+  }
+};
+
+const providerForbiddenHints = (provider: string): readonly string[] => {
+  const common = [
+    "403 usually means the API key is valid but not permitted for this model or region.",
+  ];
+  switch (provider) {
+    case "gemini":
+      return [
+        ...common,
+        "Gemini free tier only supports some models. Try `model_tier: economy` in role.md to pick a free-tier-friendly model, or enable billing at https://aistudio.google.com/app/apikey.",
+        "If you're outside a supported region, use a VPN endpoint in a supported region or switch providers (anthropic / openai).",
+      ];
+    case "anthropic":
+      return [
+        ...common,
+        "Anthropic keys need model access granted per-model. Check https://console.anthropic.com/settings/workspaces.",
+      ];
+    case "openai":
+      return [
+        ...common,
+        "OpenAI keys need billing + model access. Check https://platform.openai.com/settings/organization/limits.",
+      ];
+    default:
+      return common;
+  }
+};
+
 /**
  * Best-effort scrub of the raw token from a cause's message. Primary
  * defense is that the token never enters any error path we construct;

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -64,3 +64,4 @@ export {
   LLMValidationError,
 } from "./errors.js";
 export type { LLMClientErrorCode, RateLimitScope } from "./errors.js";
+export { formatLLMError } from "./errors.js";


### PR DESCRIPTION
## Problem
Tester ran \`murmuration group-wake\` and got:

\`\`\`
murmuration: fatal: LLM failed for coordinator: forbidden
\`\`\`

Useless — no provider, no model, no idea what to fix.

## Fix
New \`formatLLMError()\` helper in \`@murmurations-ai/llm\` renders:

\`\`\`
LLM call failed for coordinator
  provider: gemini
  model:    gemini-2.5-flash
  code:     forbidden (HTTP 403)
  message:  Permission denied

Next steps:
  - 403 usually means the API key is valid but not permitted for this model or region.
  - Gemini free tier only supports some models. Try \`model_tier: economy\` in role.md to pick a free-tier-friendly model, or enable billing at https://aistudio.google.com/app/apikey.
  - If you're outside a supported region, use a VPN endpoint or switch providers (anthropic / openai).
\`\`\`

- Provider-aware hints for every \`LLMClientErrorCode\` (unauthorized, forbidden, rate-limited, content-policy, context-length, transport / outage, validation, parse, internal)
- Gemini/Anthropic/OpenAI-specific guidance for 401/403
- Wired into \`group-wake.ts\` and \`spirit/client.ts\` throw paths
- Never embeds the API key or token
- 4 unit tests (forbidden gemini, unauthorized anthropic, rate-limited openai, no-agent-id)

## Test plan
- [x] \`pnpm run check\` passes (649 tests)
- [ ] Reproduce the 403 locally — new output shows provider-specific remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)