### PR TITLE
fix: classify 'API key expired' as unauthorized, not validation

### DIFF
--- a/packages/llm/src/adapters/vercel-adapter.ts
+++ b/packages/llm/src/adapters/vercel-adapter.ts
@@ -74,6 +74,25 @@ const mapError = (err: unknown, provider: ProviderId, model: string): LLMClientE
   if (status === 403) {
     return new LLMForbiddenError(provider, message, opts);
   }
+
+  // Message-based auth detection. Gemini returns HTTP 400 INVALID_ARGUMENT
+  // for expired / bad API keys rather than 401 — without this we'd
+  // classify "API key expired. Please renew the API key." as a
+  // generic validation error, which hides the real fix (.env edit +
+  // daemon restart). Run before the 400/422 validation branch below.
+  const lower = message.toLowerCase();
+  const looksLikeAuth =
+    lower.includes("api key expired") ||
+    lower.includes("api key not valid") ||
+    lower.includes("api_key_invalid") ||
+    lower.includes("invalid api key") ||
+    lower.includes("invalid_api_key") ||
+    lower.includes("unauthenticated") ||
+    lower.includes("authentication") ||
+    (lower.includes("api key") && (lower.includes("invalid") || lower.includes("expired")));
+  if (looksLikeAuth) {
+    return new LLMUnauthorizedError(provider, message, opts);
+  }
   if (status === 429) {
     return new LLMRateLimitError(provider, message, {
       ...opts,

--- a/packages/llm/src/errors.ts
+++ b/packages/llm/src/errors.ts
@@ -228,9 +228,10 @@ const remediationHints = (err: LLMClientError): readonly string[] => {
   switch (err.code) {
     case "unauthorized":
       return [
-        `Your ${envVarForProvider(err.provider)} is missing or wrong. Check \`.env\` and confirm the key starts with the expected prefix.`,
+        `Your ${envVarForProvider(err.provider)} is missing, wrong, or expired.`,
+        "Confirm you edited the `.env` inside the murmuration's own root (e.g. `<murmuration>/.env`), not a different directory. If running `group-wake` from another folder, it still reads the target murmuration's .env — not your current one.",
+        "After updating .env, restart the daemon so the new value is loaded: `murmuration restart --name <name>`.",
         "Rotate the key at the provider console if it may be compromised.",
-        "After editing .env, restart the daemon so the new value is loaded.",
       ];
     case "forbidden":
       return providerForbiddenHints(err.provider);


### PR DESCRIPTION
## Problem
Tester rotated a leaked Gemini key, updated .env, re-ran group-wake:

\`\`\`
code:     validation
message:  API key expired. Please renew the API key.

Next steps:
  - Unexpected client error. Include the message: line above when filing a bug.
\`\`\`

Useless remediation. The real fix is ".env + daemon restart," but we classified it as \`validation\`.

## Root cause
Gemini returns HTTP 400 INVALID_ARGUMENT for expired / bad API keys rather than 401, so \`mapError\` fell through past the 401 branch and hit the 400-means-validation branch without ever noticing the auth signal in the message.

## Fix
- \`mapError\`: add message-based auth detection before the 400/422 validation branch. Matches "api key expired", "api key not valid", "api_key_invalid", "invalid api key", "unauthenticated", etc. Returns \`LLMUnauthorizedError\`.
- Beef up the \`unauthorized\` remediation with the "running from a different directory than the murmuration root" case — exactly the hazard the tester hit (updating the wrong .env).

## Test plan
- [x] \`pnpm run check\` passes
- [ ] Reproduce with an expired Gemini key — now classified as unauthorized, remediation mentions .env root + daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)