### PR TITLE
docs: v0.6.0 plan — init as Source Vision Interview

### DIFF
--- a/docs/plans/v0.6.0-init-interview.md
+++ b/docs/plans/v0.6.0-init-interview.md
@@ -1,0 +1,173 @@
+# v0.6.0 — `murmuration init` as a Source Vision Interview
+
+**Status:** Draft / awaiting Source review
+**Reference:** [docs/reference/launch-plans/operator-launch-plan-template.md](../reference/launch-plans/operator-launch-plan-template.md)
+
+## Why
+
+Tester ran `murmuration init` against a fresh directory, accepted defaults, and ran `group-wake`. The lone agent hallucinated everything — because the scaffolded soul/role were placeholders and the "backlog" GitHub repo didn't exist.
+
+Beyond the placeholders (fixed in PR #158), the deeper issue is the init _model_:
+
+- Init asks form-fill questions: directory, purpose, provider, agents-one-by-one, governance model.
+- Source often doesn't know what agents or groups they need before they articulate their vision.
+- The field has two proven reference plans (anonymized in the reference doc) where first-time operators stood up working murmurations in Claude Code by running a **structured interview**, not a form.
+
+This plan pivots `init` from configuration to consultation.
+
+## Shape of the new flow
+
+```
+murmuration init [<dir>] [--example <name>] [--no-interview]
+
+  1. Directory + existing-state detection        (unchanged)
+  2. LLM provider + key capture                  (moved EARLIER)
+  3. Source Vision Interview                     (new — LLM-driven)
+     - one question at a time, 6 questions
+     - follow-ups on vague answers
+     - synthesize → Source Vision Statement
+     - show to Source, accept/edit before write
+  4. Circle Design Proposal                      (new — LLM-driven)
+     - LLM proposes 4–5 circles based on the vision
+     - Source accepts/edits each (name, purpose, outputs, deps)
+  5. Agent Roster Proposal                       (new — LLM-driven)
+     - asks Source for time-budget first
+     - LLM proposes 6–10 agents across circles
+     - Source accepts/edits each (name, circle, job, cadence, deps)
+  6. Scaffold files                              (reuses existing templates)
+     - murmuration/soul.md (from vision statement)
+     - governance/groups/<slug>.md (per circle)
+     - agents/<slug>/role.md + soul.md (per agent)
+     - murmuration/harness.yaml (governance/collab/products)
+  7. Final summary + next-steps hero
+```
+
+`--no-interview` falls back to the current form-fill flow for CI, tests, and offline users.
+
+## Anti-goals
+
+- **Not a Phase 1 governance-doc author.** AGENT-SOUL.md, SOURCE-DOMAIN-STATEMENT.md, DECISION-TIERS.md stay out of init. Post-init Source invokes the Spirit to author each.
+- **Not a consent-round runner.** S3 plugin handles that post-scaffold.
+- **Not a first-cycle driver.** `group-wake` remains the entry point for actual work.
+
+v0.6.0's single goal: vision → scaffolded murmuration with reasonable circles + agents, in one init session.
+
+## Prompts to use
+
+See [operator-launch-plan-template.md § Phase 0](../reference/launch-plans/operator-launch-plan-template.md#phase-0-discovery-week-1) for the battle-tested prompt bodies. Three prompts total:
+
+1. **Source Vision Interview** — 6 questions, one-at-a-time, synthesize at end.
+2. **Circle Design** — 4–5 circles, Phase 0 lean, critical-first flag.
+3. **Agent Roster** — 6–10 agents, time-budget-first, cadence + deps.
+
+Each prompt ends with a structured-output block the harness parses to scaffold files. Proposed shape (YAML inside a fenced code block the LLM produces last):
+
+```yaml
+vision:
+  mission: "..."
+  stakeholders: [...]
+  unique_contribution: "..."
+  constraints: "..."
+  never_do: [...]
+
+circles:
+  - name: "content"
+    purpose: "..."
+    outputs: [...]
+    depends_on: [...]
+    phase: 0
+
+agents:
+  - name: "research"
+    circle: "content"
+    primary_job: "..."
+    outputs: [...]
+    cadence: "weekly"
+    needs_from: [...]
+    provides_to: [...]
+```
+
+The harness validates the YAML (Zod schema), lets Source edit inline, and scaffolds from the accepted version.
+
+## Interview discipline (non-negotiable)
+
+The LLM must follow these rules inside every interview prompt:
+
+- **One question at a time.** Never multiple.
+- **Wait for the answer.** No preemption.
+- **Follow up on vague answers.** Go deeper when needed.
+- **Synthesize only at the end.** Not mid-interview.
+- **Show the draft before writing files.** Source approves before anything is committed.
+
+These are enforced via system prompt. Regressions here (LLM asking 6 questions at once) erode the whole value prop.
+
+## Review-and-edit UI
+
+After each synthesis:
+
+```
+Proposed Source Vision Statement:
+
+  Mission:     Coordinate climate-adaptation research across 6 partners...
+  Stakeholders:
+    - Partner orgs (3 NGOs, 2 universities, 1 policy body)
+    - Funders (2 foundations)
+    - Communities (indirect via partners)
+  ...
+
+Accept as-is? (y/N/e) >
+```
+
+- `y` / ENTER → commit to soul.md
+- `N` → abort, start over
+- `e` → open in `$EDITOR`, re-parse after close
+
+Same pattern for circles and agents, per-item.
+
+## Fallbacks
+
+- **No LLM key** → print "init needs an LLM key to interview; pass --no-interview to use form-fill" and exit.
+- **LLM call fails mid-interview** → offer to retry, or drop into form-fill with whatever was captured so far.
+- **LLM output doesn't parse as expected YAML** → ask LLM to re-emit, max 2 retries, then fall back.
+- **`--no-interview`** → current form-fill flow.
+- **Non-TTY (CI)** → implies `--no-interview`.
+
+## Cost estimate
+
+Three LLM calls per init session:
+
+1. Interview conversation — roughly 2k in / 1k out (6 Q+A turns)
+2. Vision synthesis — ~3k in / 1k out
+3. Circle proposal — ~3k in / 1.5k out
+4. Agent roster — ~4k in / 2.5k out
+
+Total ~12k in / 6k out. At Gemini 2.5 Flash pricing (~$0.15 / $0.60 per million), that's **sub-1¢ per init**. Cheap. At Sonnet 4.5 pricing it'd be ~6¢. Still cheap.
+
+## Implementation phases
+
+1. **v0.6.0-α** — build the interview LLM loop with system prompts + structured-output parsing. Unit-test with fixture responses. No UI polish.
+2. **v0.6.0-β** — review-and-edit UI. `$EDITOR` integration. Retry loops for bad YAML.
+3. **v0.6.0-rc** — fallback flows (no-interview, non-TTY, LLM failure). Polish hero output.
+4. **v0.6.0 ship** — when an operator can go vision → scaffolded murmuration in under 15 minutes.
+
+## Open questions
+
+- **Provider choice before vision?** The launch plans capture the API key early. Current init asks LLM provider _then_ goes into the key capture. We need provider + key captured before step 3, so the flow gets slightly reshuffled (dir → provider + key → vision → circles → agents).
+- **Should the interview remember conversation history across steps?** (i.e. use the same LLM session for vision + circles + agents, so the LLM has the vision context implicitly). Yes — one session, with the vision statement as the grounding context for circles/agents prompts.
+- **Model tier?** Use `model_tier: balanced` per provider. The quality matters more than the cost at init time.
+- **What if Source wants to skip circles?** Allow `0 circles` — scaffolded as a flat murmuration with agents only. Uncommon but valid.
+- **What if Source wants to skip agents?** Same — allow `0 agents`. Produces a vision + circles scaffold, operator runs `init --add-agent` later.
+
+## Out of scope for v0.6.0
+
+- Phase 1 governance-doc authoring inside init (AGENT-SOUL.md, DECISION-TIERS.md, etc.)
+- Consent rounds during init
+- First-cycle content production
+- Multi-language interviews (English only for now)
+
+## Success criteria
+
+- First-time operator with zero prior knowledge can run `npx murmuration init`, answer 6 vision questions, review the proposed circles + agents, and end up with a running murmuration that produces a grounded meeting on `group-wake`.
+- Test fixtures for the interview loop exist and don't require live LLM calls.
+- `--no-interview` still works for CI and offline.
+- Total init time: **under 15 minutes** for a new operator.

--- a/docs/reference/launch-plans/operator-launch-plan-template.md
+++ b/docs/reference/launch-plans/operator-launch-plan-template.md
@@ -1,0 +1,227 @@
+# Operator Launch Plan — Template
+
+Anonymized reference distilled from two proven onboarding plans where first-time operators stood up working murmurations inside Claude Code. Preserves the **interview discipline** and **prompt structure** that worked; strips all PII, domain specifics, and personal attribution.
+
+Use this as the **source material** for redesigning `murmuration init` from a form-fill tool into a guided interview. The prompts below are the behaviors the init LLM interview should reproduce.
+
+---
+
+## What the operator is building
+
+A **murmuration** is a self-organizing team of AI agents that helps coordinate complex work. Each agent has a specific role, a defined domain, and a schedule. Together they research, synthesize, communicate, track, and produce — while the operator (Source) focuses on relationships, judgment, and vision.
+
+---
+
+## The model
+
+In Phase 0, the operator is the harness. They open a Claude conversation, paste in an agent's identity, and run that agent's tasks. It sounds manual because it is — but it's fast (15–30 min per session), and it teaches the operator how the system works before automation. Phase 2 adds the OpenClaw / murmuration-harness daemon for scheduled, autonomous wakes.
+
+---
+
+## Phase 0: Discovery (Week 1)
+
+_Goal: understand vision, stakeholders, and what agents are actually needed._
+
+### Step 1 — Source Vision Interview
+
+The single most important step. Template prompt:
+
+```
+You are a skilled systems design consultant.
+
+I'm building an AI agent team to help me coordinate [DOMAIN].
+
+Please run a structured discovery interview. Ask ONE question at a time.
+Wait for my answer. Ask a follow-up if my answer is vague or could go
+deeper. Don't rush — this is the most important conversation we'll have.
+
+Cover in order:
+1. What is the core mission of this work — what change am I trying to
+   make in the world?
+2. Who are the key stakeholders and what does each need from me?
+3. What am I currently doing that is high-value and shouldn't be delegated?
+4. What is currently falling through the cracks?
+5. What does coordination failure look like? What breaks and why?
+6. What does success look like in 12 months?
+
+After the interview, synthesize into a one-page Source Vision Statement:
+- Mission (specific, not generic)
+- Stakeholders and their needs
+- My unique contribution (what would be lost without me)
+- My constraints (time, capacity, what I do vs. delegate)
+- What I will NOT do (scope boundaries)
+
+Start with question 1.
+```
+
+**Rules for the interview engine:**
+
+- ONE question at a time
+- Wait for answer
+- Follow up on vague answers
+- Don't summarize or propose until the interview is complete
+
+Output is saved to `murmuration/soul.md` (the harness's equivalent of SOURCE-VISION.md).
+
+### Step 2 — Circle/Domain Design
+
+```
+Read the Source Vision Statement.
+
+Help me design the circles (functional domains) for my murmuration.
+Think of circles like departments — each has a clear purpose and owns
+specific work.
+
+Based on my vision:
+1. Propose 4–6 circles suited to Phase 0. For each:
+   - Name (short, functional)
+   - One-sentence purpose
+   - Main outputs it produces
+   - Which circles it feeds into or depends on
+2. Flag any circles that are Phase 2 (don't need them to launch)
+3. Tell me which circle is most critical to get right first
+
+Discuss until we agree on the set. Keep Phase 0 lean: 4–5 circles max.
+```
+
+Output: one `governance/groups/<slug>.md` per circle, each with purpose + members list.
+
+### Step 3 — Agent Roster
+
+```
+Read the Source Vision Statement and the circles.
+
+Help me design the specific agents for my murmuration.
+
+For each agent, define:
+- Agent name and number
+- Which circle they belong to
+- Primary job in one sentence
+- Concrete outputs they produce
+- How often they should run (daily / weekly / monthly / event-triggered)
+- What they need from other agents
+- What other agents need from them
+
+Guidelines:
+- Phase 0 target: 6–10 agents total
+- Phase 2 agents can be named but don't need full design yet
+- Fewer well-defined agents beats more half-baked ones
+- My available time per week for agent sessions: [X hours]
+
+Ask me my time budget before proposing the roster. Discuss and refine.
+```
+
+Output: one `agents/<slug>/` dir per agent with `role.md` + `soul.md` scaffolded from the roster.
+
+---
+
+## Phase 1: Governance Documents (Week 2)
+
+Four foundational documents:
+
+1. **AGENT-SOUL.md** — shared ethical/behavioral foundation every agent inherits. Written first-person plural. Specific bright lines. Never generic corporate values.
+2. **SOURCE-DOMAIN-STATEMENT.md** — what Source keeps vs delegates, availability, "good enough" standard.
+3. **CIRCLE-DOMAINS.md** — all circles with purpose, domain, outputs, decision authority.
+4. **DECISION-TIERS.md** — AUTONOMOUS / NOTIFY / CONSENT with 5–8 concrete examples of each drawn from the operator's specific domain.
+
+Each is produced by an LLM call reading the previous docs, showing the operator the draft for approval, then writing to `governance/` and opening a consent-round GitHub issue.
+
+---
+
+## Phase 2: Agent Identity Documents (Week 2–3)
+
+Per-agent identity document covering:
+
+1. Who I Am — specific role, what makes me distinct
+2. What I Am Accountable For — domain, outputs, success
+3. How I Think — reasoning approach
+4. How I Relate to Other Agents — dependencies, handoffs
+5. My Voice — how I communicate with Source and peers
+6. What I Will Never Do — agent-specific bright lines
+7. How I Grow — Phase 0 / 1 / 2 trajectory
+8. My Schedule — cadence, outputs
+
+Per-agent LLM call, draft shown for approval, written to `agents/<slug>/soul.md` body.
+
+---
+
+## Phase 3: Consent Rounds (Week 3)
+
+Each identity document is ratified through an S3 consent round. LLM roleplays all affected agents, tests objections against the S3 rubric (evidence-based, specific harm, relevant to shared goal), declares consent or proposes amendments.
+
+Output: status `DRAFT` → `RATIFIED` in frontmatter, GitHub issue closed with summary comment.
+
+---
+
+## Phase 4: Weekly Operating Schedule (Week 3)
+
+```
+Read the agent roster and Source Domain Statement.
+
+Ask me two questions first:
+1. How often do I want to publish/deliver? (cadence and day)
+2. How many hours per week can I realistically spend on agent sessions?
+
+Then design a weekly operating schedule. For each agent:
+- Which day(s) they run
+- Realistic session length
+- What triggers them (day, event, output from another agent)
+- What they hand off and in what format
+
+Show the full week as a flow with dependencies. Discuss and refine.
+```
+
+---
+
+## Phase 5: First Cycle (Week 4)
+
+End-to-end session on a real piece of work. Pick one of:
+
+- **Partner/Stakeholder Pulse** — one-page health snapshot, flag attention needs.
+- **Meeting Prep** — brief Source before a call, surface 3 key questions, list open commitments.
+- **Research Synthesis** — summarize recent developments in one area, flag what matters.
+
+Run it, produce the output, archive to GitHub, open a retrospective issue.
+
+---
+
+## The Interview Discipline (most important pattern)
+
+Every interview prompt repeats the same discipline:
+
+- **One question at a time.** Never multiple.
+- **Wait for the answer.** Never preempt.
+- **Follow up on vague answers.** Go deeper when needed.
+- **Synthesize only at the end.** Not mid-interview.
+- **Show the draft before writing files.** Source approves before anything is committed.
+
+This discipline is what makes the difference between "generic scaffold" and "operator's actual vision captured."
+
+---
+
+## What to preserve when adapting to `murmuration init`
+
+1. The **question sequences** above — they're battle-tested.
+2. The **interview rules** — one-at-a-time, wait, follow up, synthesize-last, approve-before-write.
+3. The **Phase 0 → Phase 1 → Phase 2** progression — vision first, then circles, then agents, then governance docs, then schedule.
+4. The **anti-hallucination bright lines** in every agent soul ("no contribution this round is a valid answer").
+5. The **review gate** before every file write — Source edits the LLM's proposal, then the harness commits.
+
+## What the harness must add
+
+1. An **LLM-driven interview loop** inside `init` (not a form-fill).
+2. **Structured output** (YAML or JSON) from the synthesis step so the harness can scaffold files reliably.
+3. A **review-and-edit UI** — show the proposal, let Source accept wholesale or edit per-item.
+4. A **fallback to form-fill** via `--no-interview` for CI / offline / tests.
+
+## What's out of scope for v0.6.0
+
+- Phase 1 governance docs (AGENT-SOUL, DECISION-TIERS, etc.) — can still be authored via Spirit prompts post-init.
+- Phase 3 consent rounds — the S3 plugin handles these once the murmuration is running.
+- Phase 5 first-cycle content — that's live `group-wake` territory.
+
+v0.6.0's goal: get the operator from "I have a vision" to "I have a murmuration with reasonable circles, agents, and a vision statement" in a single `init` session.
+
+---
+
+_Reference material anonymized from two operator launch plans authored by third parties. Structure and prompts preserved; names, domains, and attribution removed._


### PR DESCRIPTION
## Summary
Docs-only PR. Captures the proposed pivot of \`murmuration init\` from form-fill to structured Source interview, based on two proven operator launch plans you shared.

- **docs/reference/launch-plans/operator-launch-plan-template.md** — anonymized distillation of the two launch plans. Interview discipline, phase structure, and the three core prompts (vision / circles / agents) preserved. Names, domains, and third-party attribution removed.
- **docs/plans/v0.6.0-init-interview.md** — adaptation into the harness. Flow shape, structured-output YAML schema, review-and-edit UI, fallback paths, cost estimate, implementation phases, open questions.

## What's in v0.6.0 (per the plan)
1. Vision interview (6 questions, one-at-a-time, follow-ups, synthesize-last)
2. Circle proposal (4–5, Phase 0 lean)
3. Agent roster proposal (6–10, time-budget-first)
4. Scaffold files from the accepted plan
5. \`--no-interview\` fallback for CI / offline

## What's NOT in v0.6.0
- Phase 1 governance-doc authoring inside init (AGENT-SOUL, DECISION-TIERS, etc.) — handled post-init via the Spirit
- Consent rounds during init — S3 plugin handles those post-scaffold
- First-cycle content production — \`group-wake\` stays the entry point

## Review asks
- Does the flow shape match your intent?
- Are there open questions I haven't surfaced?
- Anything in the reference plan template that should be added or removed?

No code changes. Merge only after you've aligned on the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)