### PR TITLE
feat: unify CLI group-wake + REPL :convene → 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The v0.5.0 work started from a lived failure: on 2026-04-20, a motivated operato
 
 ### Changed
 
+- **`murmuration convene` replaces `murmuration group-wake`** — unified with the REPL's `:convene` so the operator has one verb for "start a group meeting" regardless of surface. `group-wake` still works as a deprecated alias (prints a deprecation notice) and will be removed in a future release.
 - **Generated `role.md` is ~15 lines shorter.** Init emits minimum-viable frontmatter; Engineering Standard #11 fills in the rest at load time.
 - **`murmuration/default-agent/` fallback role.md** now uses Engineering Standard #11 shape (no duplicated agent_id/name/model_tier when defaults are correct).
 - **README quickstart** leads with the 6-command tester flow instead of the developer-from-source install. Developer install moved to its own section below.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ murmuration cost   [--root|--name] [--json]
 
 # Actions
 murmuration directive --root <path> --agent <id> "message"
-murmuration group-wake --root <path> --group <id> [--governance] [--directive "msg"]
+murmuration convene --root <path> --group <id> [--governance] [--directive "msg"]
 murmuration backlog --root <path> --group <id> [--repo owner/repo] [--refresh]
 murmuration init [dir]
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ chmod 600 .env
 murmuration doctor
 
 # 5. Run your first meeting
-murmuration group-wake --group example --directive "what should we scout next?"
+murmuration convene --group example --directive "what should we scout next?"
 ```
 
 You'll see the facilitator invite the scout, the scout contribute, and the facilitator synthesize a next step. Meeting minutes land in `.murmuration/items/` locally.
@@ -238,7 +238,7 @@ murmuration cost   [--json]
 
 # Actions
 murmuration directive [flags] "message"     # Send a Source directive
-murmuration group-wake [flags]              # Convene a group meeting
+murmuration convene [flags]              # Convene a group meeting
 
 # Help
 murmuration help protocol                   # Show daemon protocol + parity matrix

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -634,7 +634,7 @@ Everything else inherits, cascades, or has a sensible built-in:
 **Anti-pattern:** Require `agent_id` in the frontmatter even though the loader already knows the directory name.
 **Fix:** Loader fills `agent_id` from the directory slug before Zod validation runs; explicit operator value still wins.
 
-This principle is what makes `murmuration init` → `murmuration group-wake` a 4-command experience instead of a 40-minute tour of every YAML field.
+This principle is what makes `murmuration init` → `murmuration convene` a 4-command experience instead of a 40-minute tour of every YAML field.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -48,7 +48,7 @@ Next:
   # edit .env and paste your GEMINI_API_KEY
 
   murmuration doctor --name my-first-murm
-  murmuration group-wake --name my-first-murm --group example --directive "what should we scout next?"
+  murmuration convene --name my-first-murm --group example --directive "what should we scout next?"
 ```
 
 ### 3. Paste your Gemini API key
@@ -97,7 +97,7 @@ murmuration doctor --live
 ### 5. Run your first meeting
 
 ```sh
-murmuration group-wake --group example --directive "what should we scout next?"
+murmuration convene --group example --directive "what should we scout next?"
 ```
 
 The facilitator (`host-agent`) invites the scout (`scout-agent`) to contribute. The scout offers observations. The facilitator synthesizes a summary and names a next step. You'll see a streaming transcript in your terminal.
@@ -126,7 +126,7 @@ The interactive interview will ask:
 
 Every question has a reasonable default you can ENTER through. API keys are validated for shape before confirmation (the init rejects an obviously wrong paste and lets you try again).
 
-After init, run `murmuration doctor` to validate, edit the scaffolded `role.md` / `soul.md` / `governance/groups/*.md` to flesh out your agents and groups, then `murmuration start` to boot the daemon (or `murmuration group-wake` for on-demand meetings).
+After init, run `murmuration doctor` to validate, edit the scaffolded `role.md` / `soul.md` / `governance/groups/*.md` to flesh out your agents and groups, then `murmuration start` to boot the daemon (or `murmuration convene` for on-demand meetings).
 
 ---
 
@@ -154,18 +154,18 @@ When in doubt, `murmuration doctor` is the first thing to run. It validates agai
 
 ## Key commands reference
 
-| Command                                                 | What it does                                  |
-| ------------------------------------------------------- | --------------------------------------------- |
-| `murmuration init [dir]`                                | Interactive scaffold of a new murmuration     |
-| `murmuration init --example hello [dir]`                | Scaffold the bundled hello-circle example     |
-| `murmuration doctor [--live] [--fix] [--json]`          | Diagnose a murmuration's setup                |
-| `murmuration start [--root\|--name]`                    | Boot the daemon                               |
-| `murmuration group-wake --group <id> --directive "..."` | Convene a group meeting on demand             |
-| `murmuration directive --agent <id> "..."`              | Send a directive to a specific agent          |
-| `murmuration agents`                                    | List registered agents and their state        |
-| `murmuration attach <name>`                             | Interactive REPL attached to a running daemon |
-| `murmuration status`                                    | Show daemon + agent state summary             |
-| `murmuration stop`                                      | Graceful shutdown                             |
+| Command                                              | What it does                                  |
+| ---------------------------------------------------- | --------------------------------------------- |
+| `murmuration init [dir]`                             | Interactive scaffold of a new murmuration     |
+| `murmuration init --example hello [dir]`             | Scaffold the bundled hello-circle example     |
+| `murmuration doctor [--live] [--fix] [--json]`       | Diagnose a murmuration's setup                |
+| `murmuration start [--root\|--name]`                 | Boot the daemon                               |
+| `murmuration convene --group <id> --directive "..."` | Convene a group meeting on demand             |
+| `murmuration directive --agent <id> "..."`           | Send a directive to a specific agent          |
+| `murmuration agents`                                 | List registered agents and their state        |
+| `murmuration attach <name>`                          | Interactive REPL attached to a running daemon |
+| `murmuration status`                                 | Show daemon + agent state summary             |
+| `murmuration stop`                                   | Graceful shutdown                             |
 
 Pass `--help` to any command for full flag documentation.
 

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -130,7 +130,7 @@ Honest path:
 
 5. **Validate end-to-end** with a group-wake once doctor is clean:
    ```sh
-   murmuration group-wake --group <your-group> --directive "test"
+   murmuration convene --group <your-group> --directive "test"
    ```
 
 The Emergent Praxis migration is the reference case study for this path. See [`xeeban/emergent-praxis` PRs #463–#465](https://github.com/xeeban/emergent-praxis/pulls?q=is%3Apr+adr-0026) for what it looked like in practice (with all the missteps we fixed in v0.5.0 by making them impossible to reproduce).

--- a/docs/plans/v0.5.1-unified-logging.md
+++ b/docs/plans/v0.5.1-unified-logging.md
@@ -27,7 +27,7 @@ Three output surfaces, three different styles, no unified contract.
 - **Operators can't visually parse a meeting.** Daemon JSON lines (agent spawned, cost updated, heartbeat) interrupt the narrative of what the agents are saying.
 - **Machine consumers can't reliably parse the output either.** Pretty-printed meeting text in the same stream as JSON means JSON parsers fail on plaintext lines.
 - **Engineering Standard #2 is quietly violated** across library code. Several library functions call `console.log` directly instead of returning typed results, making them untestable and tangling the output contract.
-- **No way to silence non-error output** for scripted invocations. A CI job running `murmuration group-wake` can't easily isolate "did it succeed" from "what did the agents say."
+- **No way to silence non-error output** for scripted invocations. A CI job running `murmuration convene` can't easily isolate "did it succeed" from "what did the agents say."
 
 ### 1.3 What already works
 
@@ -246,7 +246,7 @@ Agent dialogue is streamed token-by-token from the LLM provider. Do we emit one 
 ## 6. Risks
 
 - **Large PR.** 80+ `console.log` sites; bundle-size of the changes could be intimidating. Phase it explicitly as in §4.
-- **Breaking scripts.** Any operator piping `murmuration group-wake` into `grep` will see different output. Mitigation: ship `--json` mode in Phase 1 so scripts have a stable target before the pretty format changes.
+- **Breaking scripts.** Any operator piping `murmuration convene` into `grep` will see different output. Mitigation: ship `--json` mode in Phase 1 so scripts have a stable target before the pretty format changes.
 - **Test flakiness.** Formatter tests depend on ANSI code handling; use a stripping helper in test assertions.
 - **Lint rule backlash.** Some CLI commands genuinely need `console.log` for prompts and direct terminal I/O. Allowlist `bin.ts` + `spirit/repl.ts` + test files; fail everywhere else.
 
@@ -255,7 +255,7 @@ Agent dialogue is streamed token-by-token from the LLM provider. Do we emit one 
 ## 7. Success criteria
 
 - [ ] Every `pnpm run lint` run is clean with the new `no-console` rule enforced
-- [ ] `murmuration group-wake --group example` produces either **entirely** colored plaintext (TTY) or **entirely** JSON-lines (piped)
+- [ ] `murmuration convene --group example` produces either **entirely** colored plaintext (TTY) or **entirely** JSON-lines (piped)
 - [ ] Attached REPL `:convene` renders agent dialogue and daemon events in the same visual style, no format jumps
 - [ ] `murmuration doctor --json` emits parseable JSON that passes `jq .` without error
 - [ ] No tester reports "the output suddenly changes format" for v0.5.1

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -266,7 +266,7 @@ Usage:
   murmuration doctor [--live] [--fix] [--json]  Diagnose a murmuration's setup
   murmuration directive [options] "msg" Send a directive to agents/groups
   murmuration directive --list          Show all directives and responses
-  murmuration group-wake [options]     Convene a group meeting (on demand)
+  murmuration convene [options]        Convene a group meeting (on demand)
   murmuration backlog [options]         View/refresh a group's GitHub work queue
   murmuration providers list [--json]   List registered LLM providers
   murmuration status [--root|--name]     Show daemon status and agent summary
@@ -473,7 +473,16 @@ const main = async (): Promise<void> => {
       await runBacklog(argv.slice(1), resolveRoot(argv.slice(1)));
       break;
     }
+    case "convene": {
+      await runGroupWakeCommand(argv.slice(1), resolveRoot(argv.slice(1)));
+      break;
+    }
     case "group-wake": {
+      // Deprecated alias — unified with the REPL's `:convene` in v0.5.x.
+      // Remove after one release cycle.
+      process.stderr.write(
+        "murmuration: `group-wake` is deprecated and will be removed in a future release. Use `convene` instead.\n",
+      );
       await runGroupWakeCommand(argv.slice(1), resolveRoot(argv.slice(1)));
       break;
     }

--- a/packages/cli/src/examples/hello-circle/README.md
+++ b/packages/cli/src/examples/hello-circle/README.md
@@ -37,7 +37,7 @@ chmod 600 .env
 murmuration doctor --root .
 
 # 3. Wake the group with a directive
-murmuration group-wake --root . --group example --directive "what should we scout next?"
+murmuration convene --root . --group example --directive "what should we scout next?"
 ```
 
 The host invites scout's observation, synthesizes a summary, names a next step. Meeting minutes land in `.murmuration/items/` locally (no GitHub needed).

--- a/packages/cli/src/examples/hello-circle/agents/host-agent/role.md
+++ b/packages/cli/src/examples/hello-circle/agents/host-agent/role.md
@@ -8,7 +8,7 @@ group_memberships:
   - "example"
 
 # Dispatch-only — the operator triggers meetings with
-# `murmuration group-wake --group example --directive "..."`. No cron.
+# `murmuration convene --group example --directive "..."`. No cron.
 
 signals:
   sources:

--- a/packages/cli/src/examples/hello-circle/governance/groups/example.md
+++ b/packages/cli/src/examples/hello-circle/governance/groups/example.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `example` group is the one group in the hello-circle murmuration. Its only purpose is to hold a meeting when the operator runs `murmuration group-wake`. Production murmurations have domain-specific groups; this one exists only to demonstrate the mechanics.
+The `example` group is the one group in the hello-circle murmuration. Its only purpose is to hold a meeting when the operator runs `murmuration convene`. Production murmurations have domain-specific groups; this one exists only to demonstrate the mechanics.
 
 <!-- Harness-parseable metadata per ADR-0026 / group-wake.ts parser. -->
 
@@ -18,7 +18,7 @@ facilitator: host-agent
 Run:
 
 ```sh
-murmuration group-wake --group example --directive "what should we scout next?"
+murmuration convene --group example --directive "what should we scout next?"
 ```
 
 The host invites scout's observation, synthesizes a summary, proposes a next step. The meeting minutes land in `.murmuration/items/` (local collaboration).

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -1,10 +1,10 @@
 /**
- * `murmuration group-wake` — trigger a group meeting on demand.
+ * `murmuration convene` — trigger a group meeting on demand.
  *
  * Usage:
- *   murmuration group-wake --root ../my-murmuration --group content
- *   murmuration group-wake --root ../my-murmuration --group content --governance
- *   murmuration group-wake --root ../my-murmuration --group content --directive "What's our top priority?"
+ *   murmuration convene --root ../my-murmuration --group content
+ *   murmuration convene --root ../my-murmuration --group content --governance
+ *   murmuration convene --root ../my-murmuration --group content --directive "What's our top priority?"
  */
 
 import { randomUUID } from "node:crypto";
@@ -121,7 +121,7 @@ const printLLMResolveFailure = (
   facilitatorId: string,
   result: Exclude<ResolveLLMResult, { readonly ok: true }>,
 ): void => {
-  const prefix = "murmuration group-wake:";
+  const prefix = "murmuration convene:";
   switch (result.reason) {
     case "no-llm-block":
       console.error(`${prefix} facilitator "${facilitatorId}" role.md has no llm: block`);
@@ -130,7 +130,7 @@ const printLLMResolveFailure = (
       console.error(`          llm:`);
       console.error(`            provider: "gemini"   # or anthropic, openai, ollama`);
       console.error(`  Alternative: the harness default in murmuration/harness.yaml applies`);
-      console.error(`               only when the daemon spawns agents — group-wake needs`);
+      console.error(`               only when the daemon spawns agents — convene needs`);
       console.error(`               the facilitator's role.md to set the llm explicitly.`);
       break;
     case "file-not-found":
@@ -388,10 +388,7 @@ export const runGroupWakeCommand = async (
   const groupIdx = args.indexOf("--group");
   const groupId = groupIdx >= 0 ? args[groupIdx + 1] : undefined;
   if (!groupId) {
-    throw new GroupWakeError(
-      "MISSING_GROUP_ID",
-      "murmuration group-wake: --group <id> is required",
-    );
+    throw new GroupWakeError("MISSING_GROUP_ID", "murmuration convene: --group <id> is required");
   }
 
   const isGovernance = args.includes("--governance");
@@ -411,7 +408,7 @@ export const runGroupWakeCommand = async (
   if (!existsSync(groupDocPath)) {
     throw new GroupWakeError(
       "GROUP_NOT_FOUND",
-      `murmuration group-wake: group doc not found at ${groupDocPath}`,
+      `murmuration convene: group doc not found at ${groupDocPath}`,
     );
   }
   const groupContent = await readFile(groupDocPath, "utf8");
@@ -468,7 +465,7 @@ export const runGroupWakeCommand = async (
   if (!llmClient) {
     throw new GroupWakeError(
       "MISSING_LLM_TOKEN",
-      `murmuration group-wake: ${secretKeyName ?? "LLM token"} not found in .env`,
+      `murmuration convene: ${secretKeyName ?? "LLM token"} not found in .env`,
     );
   }
 

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -488,7 +488,7 @@ export const runInitFromExample = async (
   }
 
   const capturedNote = capturedKey
-    ? `\n  ✓ ${llmSpec?.envVar ?? "API key"} captured into .env (0600). You can run doctor and group-wake immediately.\n`
+    ? `\n  ✓ ${llmSpec?.envVar ?? "API key"} captured into .env (0600). You can run doctor and convene immediately.\n`
     : `\n  ⚠ No key captured. Edit .env before running any command.\n`;
 
   const editStep = capturedKey
@@ -503,7 +503,7 @@ Try it now:
 
   cd ${target}
 ${editStep}  murmuration doctor --name ${sessionName}
-  murmuration group-wake --name ${sessionName} --group example --directive "what should we scout next?"
+  murmuration convene --name ${sessionName} --group example --directive "what should we scout next?"
 `);
 };
 
@@ -981,7 +981,7 @@ ${members.map((m) => `- ${m}`).join("\n")}
   // Optional per-agent tuning hints follow; no step-by-step chore list.
   const firstGroup = groups[0];
   const heroCommand = firstGroup
-    ? `  murmuration group-wake --name ${sessionName} --group ${firstGroup}\n`
+    ? `  murmuration convene --name ${sessionName} --group ${firstGroup}\n`
     : `  murmuration start --name ${sessionName}\n`;
 
   const capturedSecretsSummary = [...capturedSecrets.keys()].sort();

--- a/packages/cli/src/spirit/skills/governance-models.md
+++ b/packages/cli/src/spirit/skills/governance-models.md
@@ -43,7 +43,7 @@ In code, always use `group` / `item`. In CLI output and meeting minutes, the plu
 
 ## Group meetings
 
-`murmuration group-wake --group <id>` convenes a meeting:
+`murmuration convene --group <id>` convenes a meeting:
 
 - **Operational** (default) — the circle works through its backlog
 - **`--governance`** — pending governance items only; emits consent tallies


### PR DESCRIPTION
## Summary
Tester feedback: CLI had \`group-wake\`, REPL had \`:convene\`, same action. Unified under **\`convene\`** (more natural language, matches the REPL).

- New CLI verb: \`murmuration convene --group <id>\`
- \`murmuration group-wake\` still works but prints: \`murmuration: \`group-wake\` is deprecated and will be removed in a future release. Use \`convene\` instead.\`
- Scheduled for removal after one release cycle

## Swept
- \`bin.ts\` help text + command switch
- \`init.ts\` hero command lines (init post-completion "Try it now:" block)
- \`group-wake.ts\` internal docs + error message prefixes
- hello-circle example (README, group doc, host-agent role)
- Spirit skills (governance-models.md)
- README, CHANGELOG, GETTING-STARTED, MIGRATION-GUIDE, CONFIGURATION
- CLAUDE.md, ARCHITECTURE.md, plans/v0.5.1

## Left alone
- ADRs (describe the verb at time of authorship; rewriting is revisionist)
- \`packages/cli/src/group-wake.ts\` file name (rename is bigger scope; follow-up)
- \`collaboration-factory.ts\` internal comment

## Test plan
- [x] \`pnpm run check\` passes (649 tests)
- [ ] \`murmuration convene --name <name> --group <id>\` works
- [ ] \`murmuration group-wake --name <name> --group <id>\` works, prints deprecation

🤖 Generated with [Claude Code](https://claude.com/claude-code)