### PR TITLE
fix: daemon repo-coord fallback (harness.yaml + all agents)

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1456,8 +1456,32 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   // Command executor — owns command dispatch, status building, and detail handlers
   // (extracted from boot.ts per Engineering Standard #8)
   const { DaemonCommandExecutor } = await import("./command-executor.js");
+
+  // Resolve the repo coordinate for both GitHub collaboration and the
+  // command-executor's status/issue-listing path. Try harness.yaml's
+  // `collaboration.repo` first (explicit operator config), then fall
+  // back to searching ALL registered agents for github_scopes (not
+  // just the first — agents are loaded alphabetically and the first
+  // one may not have scopes declared).
   const firstScope = allRegistered[0]?.signalScopes?.githubScopes?.[0];
-  const repoCoord = firstScope ? { owner: firstScope.owner, repo: firstScope.repo } : undefined;
+  let repoCoord: { owner: string; repo: string } | undefined = firstScope
+    ? { owner: firstScope.owner, repo: firstScope.repo }
+    : undefined;
+  if (!repoCoord && config.collaboration.repo) {
+    const parts = config.collaboration.repo.split("/");
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      repoCoord = { owner: parts[0], repo: parts[1] };
+    }
+  }
+  if (!repoCoord) {
+    for (const agent of allRegistered) {
+      const scope = agent.signalScopes?.githubScopes?.[0];
+      if (scope) {
+        repoCoord = { owner: scope.owner, repo: scope.repo };
+        break;
+      }
+    }
+  }
 
   // Wire a CollaborationProvider for the daemon's command-executor
   // paths (:directive list, directive.close, etc.). Local mode already
@@ -1477,6 +1501,18 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     logger.info("daemon.collaboration.provider", {
       provider: "github",
       repo: `${repoCoord.owner}/${repoCoord.repo}`,
+    });
+  } else if (collaborationMode === "github") {
+    // Diagnostic: explain why the GitHub collaboration provider didn't
+    // wire up so operators aren't staring at "No collaboration provider
+    // configured" with no hint of what to fix.
+    logger.warn("daemon.collaboration.provider.skipped", {
+      reason: !githubClient
+        ? "no GITHUB_TOKEN in .env"
+        : !repoCoord
+          ? "no collaboration.repo in harness.yaml and no agent github_scopes"
+          : "unknown",
+      collaborationMode,
     });
   }
   const commandCollaborationProvider = localCollaborationProvider ?? githubCollaborationProvider;


### PR DESCRIPTION
## Problem
After PR #162 merged, tester restarted daemon and ran \`:directive list\` → still "No collaboration provider configured".

## Root cause
PR #162's repoCoord resolution only checked the FIRST registered agent's github_scopes. In murmurations with a mix of agent types, the first (alphabetically) may not declare scopes. Result: \`repoCoord\` stays undefined, new github-provider block is skipped.

## Fix
Three-level fallback for \`repoCoord\`, matching what \`collaboration-factory.ts\` already does for the CLI commands:

1. First agent's \`github_scopes\` (fastest path)
2. \`harness.yaml\` \`collaboration.repo\` (explicit operator config)
3. Search ALL registered agents for any \`github_scopes\`

Plus a diagnostic \`warn\` log when the github provider is skipped in github mode, so operators know *why* (no token vs. no repo vs. other).

## Test plan
- [x] \`pnpm run check\` passes
- [ ] Restart EP daemon, \`:directive list\` succeeds
- [ ] Daemon logs show \`daemon.collaboration.provider\` with the resolved repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)