### PR TITLE
debug: MURMURATION_DEBUG_GITHUB=1 traces updateIssueState

### DIFF
--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -510,7 +510,20 @@ class GithubClientImpl implements GithubClient {
     if (denial) return denial;
 
     const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/issues/${String(issueNumber.value)}`;
+    // MURMURATION_DEBUG_GITHUB=1 turns on request tracing so the
+    // operator can see exactly what's going out when a write 404s
+    // unexpectedly.
+    if (process.env.MURMURATION_DEBUG_GITHUB === "1") {
+      process.stderr.write(
+        `[github] PATCH ${url} state=${state} tokenPrefix=${this.#token.reveal().slice(0, 10)}\n`,
+      );
+    }
     const raw = await this.#requestMutation(url, "PATCH", { state }, options);
+    if (process.env.MURMURATION_DEBUG_GITHUB === "1") {
+      process.stderr.write(
+        `[github] PATCH result: ${raw.ok ? "ok" : `err ${raw.error.code}: ${raw.error.message}`}\n`,
+      );
+    }
     if (!raw.ok) return raw;
     return { ok: true, value: undefined };
   }


### PR DESCRIPTION
Add a gated stderr trace to `updateIssueState` so we can see exactly what the daemon sends when `:directive close` 404s while `gh issue close` with the same token succeeds. Off by default.