### PR TITLE
debug: unconditional PATCH trace

### DIFF
--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -910,8 +910,11 @@ export class DaemonCommandExecutor {
           // instead of 403 for unauthorized writes. Annotate so the
           // operator knows where to look.
           if (result.error.code === "NOT_FOUND") {
+            const repoHint = this.#deps.repoCoordinate
+              ? `${this.#deps.repoCoordinate.owner}/${this.#deps.repoCoordinate.repo}`
+              : "(unknown)";
             throw new Error(
-              `could not close directive ${id}: GitHub returned "not found". If :directive list showed this item, the token likely lacks write access. Regenerate a PAT with \`repo\` scope (classic) or Issues: Read and write (fine-grained) and update .env.`,
+              `could not close directive ${id}: GitHub returned "not found" for ${repoHint}#${id}.\n  If :directive list showed this item, check two things:\n  1. Does the issue actually live in ${repoHint}? (The daemon is hitting that repo; if the directive was posted elsewhere, adjust harness.yaml collaboration.repo or the first agent's github_scopes.)\n  2. Does your GITHUB_TOKEN have Issues: Read and write on that repo? (GitHub returns 404 instead of 403 for unauthorized writes.)`,
             );
           }
           throw new Error(result.error.message);

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -510,20 +510,15 @@ class GithubClientImpl implements GithubClient {
     if (denial) return denial;
 
     const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/issues/${String(issueNumber.value)}`;
-    // MURMURATION_DEBUG_GITHUB=1 turns on request tracing so the
-    // operator can see exactly what's going out when a write 404s
-    // unexpectedly.
-    if (process.env.MURMURATION_DEBUG_GITHUB === "1") {
-      process.stderr.write(
-        `[github] PATCH ${url} state=${state} tokenPrefix=${this.#token.reveal().slice(0, 10)}\n`,
-      );
-    }
+    // Temporary: always trace updateIssueState so we can diagnose the
+    // 404-on-write bug EP is hitting. Remove once root cause is known.
+    process.stderr.write(
+      `[github] PATCH ${url} state=${state} tokenPrefix=${this.#token.reveal().slice(0, 12)}\n`,
+    );
     const raw = await this.#requestMutation(url, "PATCH", { state }, options);
-    if (process.env.MURMURATION_DEBUG_GITHUB === "1") {
-      process.stderr.write(
-        `[github] PATCH result: ${raw.ok ? "ok" : `err ${raw.error.code}: ${raw.error.message}`}\n`,
-      );
-    }
+    process.stderr.write(
+      `[github] PATCH result: ${raw.ok ? "ok" : `err ${raw.error.code}: ${raw.error.message}`}\n`,
+    );
     if (!raw.ok) return raw;
     return { ok: true, value: undefined };
   }


### PR DESCRIPTION
Make the PATCH trace always-on (temp) and apply the repo-aware hint to :directive delete too. Revert once the 404-write bug is diagnosed.