### PR TITLE
fix: :status <agent> reloads state + meaningful digest preview

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -657,8 +657,15 @@ const handleCommand = async (
           } else {
             console.log("  Recent digests:");
             for (const entry of d.recentDigests) {
-              const firstLine = entry.summary.split("\n")[0] ?? "";
-              console.log(`    ${entry.date}  ${firstLine.slice(0, 80)}`);
+              // Skip blank lines and markdown headers that have no prose.
+              // Some digests are frontmatter-only with an empty body —
+              // fall back to "(empty digest)" instead of a lonely date.
+              const meaningfulLine = entry.summary
+                .split("\n")
+                .map((s) => s.trim())
+                .find((s) => s.length > 0 && !s.startsWith("#"));
+              const preview = meaningfulLine ?? "(empty digest)";
+              console.log(`    ${entry.date}  ${preview.slice(0, 80)}`);
             }
           }
         }

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -250,6 +250,13 @@ export class DaemonCommandExecutor {
 
   public async agentDetail(agentId: string): Promise<unknown> {
     const { rootDir, agentStateStore } = this.#deps;
+    // Reload from disk so wake-now child-process writes are visible.
+    // Without this, :status <agent> shows stale wake counts right
+    // after a :wake — the daemon's in-memory state doesn't know the
+    // child already updated the JSONL. buildStatus() does the same.
+    await agentStateStore.load().catch(() => {
+      /* best effort */
+    });
     const runsDir = join(rootDir, ".murmuration", "runs", agentId);
     const agent = agentStateStore.getAgent(agentId);
     const recentDigests: { date: string; summary: string }[] = [];


### PR DESCRIPTION
Two fixes on :status <agent>:

1. agentDetail now reloads agentStateStore from disk before reading, matching buildStatus behavior. Previously wake-now child process writes to the JSONL were invisible — :status <agent> showed stale counts right after :wake.

2. Recent digest preview: extract the first non-blank, non-heading line instead of raw entry.summary.split, so frontmatter-only digests show '(empty digest)' instead of a lonely date.