### PR TITLE
feat: :wake --force + circuit-breaker skip visibility

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -822,11 +822,12 @@ const handleCommand = async (
     }
   } else if (verb === "wake") {
     const agentId = parts[1];
+    const force = parts.includes("--force");
     if (!agentId) {
-      console.log("  Usage: wake <agent-id>");
+      console.log("  Usage: wake <agent-id> [--force]");
     } else {
-      console.log(`  Waking ${agentId}...`);
-      const resp = await send("wake-now", { agentId });
+      console.log(`  Waking ${agentId}${force ? " (--force: bypass circuit breaker)" : ""}...`);
+      const resp = await send("wake-now", { agentId, ...(force ? { force: true } : {}) });
       if (resp.error) {
         console.log(`  Error: ${resp.error}`);
       } else {
@@ -879,6 +880,26 @@ const handleCommand = async (
                       }
                       if (evt.event === "daemon.wake.failed") {
                         console.log(`  Wake failed: ${evt.errorMessage ?? "unknown error"}`);
+                        rl.prompt();
+                        return;
+                      }
+                      // Circuit-breaker skip — agent hit the consecutive-
+                      // failure threshold (default 3) and is now locked
+                      // out. The daemon never runs the wake, so there's
+                      // no completed/failed event — recognize this here
+                      // so the operator isn't left waiting 2min for a
+                      // timeout. Offer the --force escape hatch.
+                      if (evt.event === "daemon.wake.circuitBreaker") {
+                        const ev = evt as unknown as {
+                          consecutiveFailures?: number;
+                          threshold?: number;
+                        };
+                        console.log(
+                          `  Wake skipped: circuit breaker tripped (${String(ev.consecutiveFailures ?? "?")} / ${String(ev.threshold ?? "?")} consecutive failures).`,
+                        );
+                        console.log(
+                          `  Run \`:wake ${agentId} --force\` to reset the failure count and try again.`,
+                        );
                         rl.prompt();
                         return;
                       }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -261,6 +261,19 @@ export class AgentStateStore implements IAgentStateStore {
     return this.#agents.get(agentId);
   }
 
+  /**
+   * Reset consecutive-failure count to 0 for a single agent. Used by
+   * :wake --force to unstick an agent that the circuit breaker has
+   * locked out. No-op if the agent is unknown.
+   */
+  public async resetConsecutiveFailures(agentId: string): Promise<void> {
+    const agent = this.#agents.get(agentId);
+    if (!agent) return;
+    if (agent.consecutiveFailures === 0) return;
+    this.#agents.set(agentId, { ...agent, consecutiveFailures: 0 });
+    await this.#persist();
+  }
+
   /** Get all agent records. */
   public getAllAgents(): readonly AgentRecord[] {
     return [...this.#agents.values()];

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -673,6 +673,16 @@ export class DaemonCommandExecutor {
       throw new Error(`Unknown agent "${agentId}". Available: ${available}`);
     }
 
+    // --force: reset the circuit-breaker by zeroing consecutiveFailures
+    // before spawning the child. Operator escape hatch when an agent
+    // is locked out after 3 consecutive failures.
+    if (params.force === true) {
+      await this.#deps.agentStateStore.load().catch(() => {
+        /* best effort */
+      });
+      await this.#deps.agentStateStore.resetConsecutiveFailures(agentId);
+    }
+
     const result = await this.#deps.onWakeNow(this.#deps.rootDir, agentId);
 
     // Track the process (Engineering Standard #7 — track what you spawn)


### PR DESCRIPTION
Tester wake attempt on editorial-agent hit the circuit breaker (3/3 failures). REPL timed out after 2min because the poller didn't recognize daemon.wake.circuitBreaker.

Now the skip is surfaced immediately with a one-line explanation and the --force escape hatch. --force resets consecutiveFailures=0 on the agent before spawning the child.