### PR TITLE
fix: SIGTERM actually exits + REPL surfaces wake-timeout reason

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -923,6 +923,28 @@ const handleCommand = async (
                         rl.prompt();
                         return;
                       }
+                      // Wall-clock timeout — the agent ran past its
+                      // max_wall_clock_ms (15s default). Event fires
+                      // with duration metadata the operator should see
+                      // alongside the "what to do" hint.
+                      if (evt.event === "daemon.wake.timedOut") {
+                        const ev = evt as unknown as {
+                          durationMs?: number;
+                          budget?: { maxWallClockMs?: number };
+                        };
+                        const dur =
+                          ev.durationMs !== undefined ? `${String(ev.durationMs)}ms` : "?";
+                        const cap =
+                          ev.budget?.maxWallClockMs !== undefined
+                            ? `${String(ev.budget.maxWallClockMs)}ms`
+                            : "?";
+                        console.log(`  Wake timed out (${dur} / ${cap} wall clock).`);
+                        console.log(
+                          `  Raise max_wall_clock_ms in agents/${agentId}/role.md, or switch to a faster model (e.g. model_tier: fast).`,
+                        );
+                        rl.prompt();
+                        return;
+                      }
                       // Circuit-breaker skip — agent hit the consecutive-
                       // failure threshold (default 3) and is now locked
                       // out. The daemon never runs the wake, so there's

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1750,6 +1750,12 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       event: "daemon.exit",
     })}\n`,
   );
+  // Force the process to exit. Without this, open servers (Unix
+  // domain socket, HTTP dashboard) keep the event loop alive and
+  // the daemon logs "exit" but never actually terminates — SIGTERM
+  // appears not to kill it. v0.5.0 tester feedback: "SIGTERM never
+  // completely shuts down a murmuration."
+  process.exit(0);
 };
 
 /**


### PR DESCRIPTION
Two fixes:
1. Daemon logged exit but never terminated because the Unix socket and HTTP servers kept the event loop alive. Force process.exit(0) after the exit log.
2. REPL poller now recognizes daemon.wake.timedOut, surfaces the duration/cap, and points operators at the fix (raise wall clock or switch model).