### PR TITLE
feat: :status digests show file path

### DIFF
--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -828,7 +828,7 @@ const handleCommand = async (
             totalArtifacts: number;
             idleWakes: number;
             consecutiveFailures: number;
-            recentDigests: { date: string; summary: string }[];
+            recentDigests: { date: string; summary: string; file: string }[];
           };
           console.log(
             `  ${d.agentId} — ${d.state} · wakes: ${String(d.totalWakes)} · artifacts: ${String(d.totalArtifacts)} · idle: ${String(d.idleWakes)} · failures: ${String(d.consecutiveFailures)}`,
@@ -847,6 +847,7 @@ const handleCommand = async (
                 .find((s) => s.length > 0 && !s.startsWith("#"));
               const preview = meaningfulLine ?? "(empty digest)";
               console.log(`    ${entry.date}  ${preview.slice(0, 80)}`);
+              console.log(`                ${entry.file}`);
             }
           }
         }

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -259,7 +259,7 @@ export class DaemonCommandExecutor {
     });
     const runsDir = join(rootDir, ".murmuration", "runs", agentId);
     const agent = agentStateStore.getAgent(agentId);
-    const recentDigests: { date: string; summary: string }[] = [];
+    const recentDigests: { date: string; summary: string; file: string }[] = [];
     try {
       const dates = (await readdir(runsDir))
         .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
@@ -286,7 +286,7 @@ export class DaemonCommandExecutor {
         if (!latest) continue;
         const content = await readFile(latest.file, "utf8");
         const body = content.replace(/^---[\s\S]*?---\n*/, "").trim();
-        recentDigests.push({ date, summary: body.slice(0, 500) });
+        recentDigests.push({ date, summary: body.slice(0, 500), file: latest.file });
       }
     } catch {
       /* no runs yet */


### PR DESCRIPTION
Tester: 'showing recent digests, it would be useful to have the full path for a local file'. agentDetail now includes 'file' on each digest entry; REPL prints the absolute path on the line below the preview so operators can cat/open it directly. (GitHub-URL rendering is N/A for digests — those are always local. Separate track for artifact URLs if needed.)