### PR TITLE
feat: agent.maxSteps configurable, default 256, + step tracking + exhaustion warning

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1175,7 +1175,10 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               return createDefaultRunner(
                 capturedAgentDir,
                 [],
-                agentTools.length > 0 ? { extensionTools: agentTools } : {},
+                {
+                  maxSteps: config.agent.maxSteps,
+                  ...(agentTools.length > 0 ? { extensionTools: agentTools } : {}),
+                },
                 exampleRoot,
               ) as unknown as AgentRunner<InProcessRunnerClients>;
             }

--- a/packages/cli/src/harness-config.test.ts
+++ b/packages/cli/src/harness-config.test.ts
@@ -28,7 +28,8 @@ describe("loadHarnessConfig", () => {
     expect(config.collaboration.repo).toBeUndefined();
     expect(config.products).toEqual([]);
     expect(config.logging.level).toBe("info");
-    expect(config.spirit.maxSteps).toBe(32);
+    expect(config.spirit.maxSteps).toBe(256);
+    expect(config.agent.maxSteps).toBe(256);
   });
 
   it("reads spirit.maxSteps override from harness.yaml", async () => {
@@ -50,7 +51,7 @@ describe("loadHarnessConfig", () => {
 `,
     );
     const config = await loadHarnessConfig(rootDir);
-    expect(config.spirit.maxSteps).toBe(32);
+    expect(config.spirit.maxSteps).toBe(256);
   });
 
   it("loads all fields from a complete harness.yaml", async () => {
@@ -163,7 +164,8 @@ describe("mergeWithCliFlags", () => {
       collaboration: { provider: "github" as const, repo: "org/repo" },
       products: [],
       logging: { level: "info" as const },
-      spirit: { maxSteps: 32 },
+      spirit: { maxSteps: 256 },
+      agent: { maxSteps: 256 },
     };
 
     const merged = mergeWithCliFlags(config, {
@@ -184,7 +186,8 @@ describe("mergeWithCliFlags", () => {
       collaboration: { provider: "local" as const, repo: "org/repo" },
       products: [],
       logging: { level: "warn" as const },
-      spirit: { maxSteps: 32 },
+      spirit: { maxSteps: 256 },
+      agent: { maxSteps: 256 },
     };
 
     const merged = mergeWithCliFlags(config, {});
@@ -201,7 +204,8 @@ describe("mergeWithCliFlags", () => {
       collaboration: { provider: "github" as const, repo: "my/repo" },
       products: [{ name: "p", repo: "o/r" }],
       logging: { level: "info" as const },
-      spirit: { maxSteps: 32 },
+      spirit: { maxSteps: 256 },
+      agent: { maxSteps: 256 },
     };
 
     const merged = mergeWithCliFlags(config, { logLevel: "debug" });

--- a/packages/cli/src/harness-config.ts
+++ b/packages/cli/src/harness-config.ts
@@ -47,9 +47,19 @@ export interface HarnessConfig {
   readonly spirit: {
     /**
      * Maximum tool-use steps in a single Spirit turn. Each step is one
-     * round-trip to the LLM + any tool calls it emits. Larger
-     * murmurations (many agents) need a bigger budget or the Spirit
-     * runs out of steps before producing a final answer. Default 32.
+     * round-trip to the LLM + any tool calls it emits. Default 256
+     * (effectively unlimited; raised from earlier tighter values after
+     * tester work showed truncation mid-workflow).
+     */
+    readonly maxSteps: number;
+  };
+  /** Agent runtime knobs. Applied to every agent's wake unless overridden
+   *  per-agent in role.md. */
+  readonly agent: {
+    /**
+     * Maximum tool-use steps in a single agent wake. Default 256
+     * (effectively unlimited). Wall-clock and cost budgets are the
+     * real circuit-breakers; step-count is belt-and-suspenders.
      */
     readonly maxSteps: number;
   };
@@ -61,7 +71,8 @@ const DEFAULTS: HarnessConfig = {
   collaboration: { provider: "github", repo: undefined },
   products: [],
   logging: { level: "info" },
-  spirit: { maxSteps: 32 },
+  spirit: { maxSteps: 256 },
+  agent: { maxSteps: 256 },
 };
 
 const isLLMProvider = (v: unknown): v is LLMProvider =>
@@ -95,14 +106,24 @@ export async function loadHarnessConfig(rootDir: string): Promise<HarnessConfig>
   const products = raw.products as { name: string; repo: string }[] | undefined;
   const logging = raw.logging as Record<string, unknown> | undefined;
   const spirit = raw.spirit as Record<string, unknown> | undefined;
+  const agent = raw.agent as Record<string, unknown> | undefined;
 
   const collabProvider = collab?.provider;
   const logLevel = logging?.level;
-  const rawMaxSteps = spirit?.maxSteps;
-  const maxSteps =
-    typeof rawMaxSteps === "number" && Number.isFinite(rawMaxSteps) && rawMaxSteps >= 1
-      ? Math.floor(rawMaxSteps)
+  const rawSpiritMaxSteps = spirit?.maxSteps;
+  const spiritMaxSteps =
+    typeof rawSpiritMaxSteps === "number" &&
+    Number.isFinite(rawSpiritMaxSteps) &&
+    rawSpiritMaxSteps >= 1
+      ? Math.floor(rawSpiritMaxSteps)
       : DEFAULTS.spirit.maxSteps;
+  const rawAgentMaxSteps = agent?.maxSteps;
+  const agentMaxSteps =
+    typeof rawAgentMaxSteps === "number" &&
+    Number.isFinite(rawAgentMaxSteps) &&
+    rawAgentMaxSteps >= 1
+      ? Math.floor(rawAgentMaxSteps)
+      : DEFAULTS.agent.maxSteps;
 
   return {
     llm: {
@@ -135,7 +156,8 @@ export async function loadHarnessConfig(rootDir: string): Promise<HarnessConfig>
           ? logLevel
           : DEFAULTS.logging.level,
     },
-    spirit: { maxSteps },
+    spirit: { maxSteps: spiritMaxSteps },
+    agent: { maxSteps: agentMaxSteps },
   };
 }
 
@@ -165,5 +187,6 @@ export function mergeWithCliFlags(
       level: flags.logLevel ?? config.logging.level,
     },
     spirit: config.spirit,
+    agent: config.agent,
   };
 }

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -41,6 +41,11 @@ export interface DefaultRunnerOptions {
    *  prompt as a "Recent work" block (ADR-0029 §2). Default 3. Set to
    *  0 to disable the self-digest tail entirely. */
   readonly selfDigestTail?: number;
+  /** Max tool-use steps per wake. Each step is one LLM round-trip plus
+   *  its tool calls. Too low truncates multi-step workflows mid-action;
+   *  too high wastes tokens. Default 256 (effectively unlimited for
+   *  normal agent work). Configurable via harness.yaml `agent.maxSteps`. */
+  readonly maxSteps?: number;
 }
 
 /** Tool definition compatible with LLM tool calling (ADR-0020 Phase 2). */
@@ -76,7 +81,16 @@ export interface DefaultRunnerClients {
     ): Promise<
       | {
           ok: true;
-          value: { content: string; inputTokens: number; outputTokens: number; modelUsed: string };
+          value: {
+            content: string;
+            inputTokens: number;
+            outputTokens: number;
+            modelUsed: string;
+            /** Number of LLM→tool round-trips. */
+            steps?: number;
+            /** Tool invocations across all steps. */
+            toolCalls?: readonly unknown[];
+          };
         }
       | {
           ok: false;
@@ -433,7 +447,7 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
           systemPromptOverride: systemPrompt,
           maxOutputTokens: 16000,
           temperature: 0.3,
-          ...(tools && tools.length > 0 ? { tools, maxSteps: 5 } : {}),
+          ...(tools && tools.length > 0 ? { tools, maxSteps: options.maxSteps ?? 256 } : {}),
         },
         ...(signal ? [{ signal }] : []),
       );
@@ -449,6 +463,10 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
     }
 
     const content = result.value.content.trim();
+    const stepCount = result.value.steps ?? 1;
+    const toolCallCount = result.value.toolCalls?.length ?? 0;
+    const stepBudget = options.maxSteps ?? 256;
+    const exhaustedBudget = stepCount >= stepBudget;
 
     // 10. Parse self-reflection
     const reflection = parseSelfReflection(content);
@@ -457,10 +475,21 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
       `  model: ${result.value.modelUsed}`,
       `  input_tokens: ${String(result.value.inputTokens)}`,
       `  output_tokens: ${String(result.value.outputTokens)}`,
+      `  steps: ${String(stepCount)} / ${String(stepBudget)}`,
+      `  tool_calls: ${String(toolCallCount)}`,
       `  signal_count: ${String(spawn.signals.signals.length)}`,
       `  effectiveness: ${reflection.effectiveness}`,
       ...(reflection.governanceEvent
         ? [`  governance_event: ${reflection.governanceEvent.slice(0, 80)}`]
+        : []),
+      ...(exhaustedBudget
+        ? [
+            "",
+            `  ⚠ BUDGET EXHAUSTED: ran through all ${String(stepBudget)} tool-use`,
+            `    steps without finishing. Next wake should note this and`,
+            `    either narrow scope, raise agent.maxSteps in harness.yaml,`,
+            `    or surface a tension suggesting the step budget is too low.`,
+          ]
         : []),
     ];
 

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -190,7 +190,7 @@ describe("createDefaultRunner", () => {
     expect(llmCalls).toHaveLength(1);
     expect(llmCalls[0]?.tools).toBeDefined();
     expect(llmCalls[0]?.tools).toHaveLength(1);
-    expect(llmCalls[0]?.maxSteps).toBe(5);
+    expect(llmCalls[0]?.maxSteps).toBe(256);
   });
 
   it("does not load tools when no mcpServerConfigs", async () => {


### PR DESCRIPTION
Three-part rollup. See commit message.