### PR TITLE
feat: move runs/ out of .murmuration/ with auto-migration

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -745,14 +745,32 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     ? { provider, declaration }
     : undefined;
 
+  // One-time auto-migration: move legacy `.murmuration/runs/` →
+  // `runs/` at the repo root if it hasn't been done yet. Idempotent;
+  // safe to run every boot.
+  {
+    const { migrateLegacyRunsDir } = await import("@murmurations-ai/core");
+    const migrated = await migrateLegacyRunsDir(exampleRoot);
+    if (migrated) {
+      logger.info("daemon.runs.migrated", {
+        from: ".murmuration/runs",
+        to: "runs",
+        rootDir: exampleRoot,
+      });
+    }
+  }
+
   // Per-agent run artifact writers (2D5). Each agent gets its own
-  // writer at `<rootDir>/.murmuration/runs/<agentId>/`.
+  // writer at `<rootDir>/runs/<agentId>/`. v0.5.x moved out of the
+  // legacy `.murmuration/runs/` dot-dir so agent-authored content is
+  // visible in normal directory browsing. Readers still fall back to
+  // the legacy location for pre-move data (see runs-path.ts).
   const writerMap = new Map<string, RunArtifactWriter>();
   for (const agent of allRegistered) {
     writerMap.set(
       agent.agentId,
       new RunArtifactWriter({
-        rootDir: resolve(exampleRoot, ".murmuration", "runs", agent.agentId),
+        rootDir: resolve(exampleRoot, "runs", agent.agentId),
       }),
     );
   }
@@ -1712,7 +1730,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     // artifact, then stop the daemon and exit. We detect completion by
     // polling each agent's index.jsonl.
     const indexPaths = allRegistered.map((a) =>
-      resolve(exampleRoot, ".murmuration", "runs", a.agentId, "index.jsonl"),
+      resolve(exampleRoot, "runs", a.agentId, "index.jsonl"),
     );
     const pollIntervalMs = 2000;
     const maxWaitMs = 300_000; // 5 minutes hard ceiling

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -745,7 +745,7 @@ export const runGroupWakeCommand = async (
 
   const writeFallback = async (): Promise<void> => {
     const { writeFile: wf, mkdir } = await import("node:fs/promises");
-    const meetingDir = join(root, ".murmuration", "runs", `group-${groupId}`, dayUtc);
+    const meetingDir = join(root, "runs", `group-${groupId}`, dayUtc);
     await mkdir(meetingDir, { recursive: true });
     await wf(
       join(meetingDir, `meeting-${randomUUID().slice(0, 8)}.md`),

--- a/packages/cli/src/spirit/system-prompt.ts
+++ b/packages/cli/src/spirit/system-prompt.ts
@@ -44,7 +44,8 @@ The murmuration follows a fixed directory layout. When the operator asks about c
 - \`governance/groups/<id>.md\` — group domain doc; harness-parseable \`## Members\` list + \`facilitator:\` line at the top
 - \`governance/decisions/\` — ratified decision records, one per decision
 - \`governance/\` (other \`.md\` files) — operator-authored governance docs (AGENT-SOUL, SOURCE-DOMAIN-STATEMENT, etc.)
-- \`.murmuration/\` — daemon-authored runtime state (agents/state.json, runs/, governance/, daemon.pid, daemon.sock). Read-only to you.
+- \`runs/\` — agent-authored wake digests. \`runs/<agent>/<YYYY-MM-DD>/digest-*.md\`. Readable.
+- \`.murmuration/\` — daemon-authored runtime state (agents/state.json, governance/, daemon.pid, daemon.sock, items/). Read-only to you.
 - \`.env\` / \`.env.*\` — NEVER read these. Refuse even if asked.
 - \`docs/adr/\` — architecture decisions (numbered NNNN-title.md)
 

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 
 import { HARNESS_VERSION } from "../index.js";
 import { PROTOCOL_SCHEMA_VERSION } from "./protocol.js";
+import { runsDirForAgent, runsDir as canonicalRunsDir } from "./runs-path.js";
 import { GovernanceStateStore } from "../governance/index.js";
 import type { GovernancePlugin, GovernanceSyncCallbacks } from "../governance/index.js";
 import type { GovernanceTally } from "../groups/index.js";
@@ -269,7 +270,7 @@ export class DaemonCommandExecutor {
     await agentStateStore.load().catch(() => {
       /* best effort */
     });
-    const runsDir = join(rootDir, ".murmuration", "runs", agentId);
+    const runsDir = runsDirForAgent(rootDir, agentId);
     const agent = agentStateStore.getAgent(agentId);
     const recentDigests: { date: string; summary: string; file: string }[] = [];
     try {
@@ -323,7 +324,7 @@ export class DaemonCommandExecutor {
   async #digestList(
     agentId: string,
   ): Promise<{ digests: { name: string; file: string; date: string }[] }> {
-    const runsDir = join(this.#deps.rootDir, ".murmuration", "runs", agentId);
+    const runsDir = runsDirForAgent(this.#deps.rootDir, agentId);
     const rows: { name: string; file: string; date: string; mtimeMs: number }[] = [];
     try {
       const { stat } = await import("node:fs/promises");
@@ -366,7 +367,7 @@ export class DaemonCommandExecutor {
     if (!/^digest-[\w-]+\.md$/.test(file)) {
       throw new Error(`digest.get: bad filename "${file}"`);
     }
-    const runsDir = join(this.#deps.rootDir, ".murmuration", "runs", agentId);
+    const runsDir = runsDirForAgent(this.#deps.rootDir, agentId);
     // Search across day directories for the file.
     const dates = await readdir(runsDir).catch(() => []);
     for (const date of dates) {
@@ -383,7 +384,7 @@ export class DaemonCommandExecutor {
 
   public async groupDetail(groupId: string): Promise<unknown> {
     const { rootDir, agentStateStore, allRegistered } = this.#deps;
-    const runsBase = join(rootDir, ".murmuration", "runs");
+    const runsBase = canonicalRunsDir(rootDir);
 
     // Find the matching group directory
     let groupRunsDir = "";

--- a/packages/core/src/daemon/runs-path.ts
+++ b/packages/core/src/daemon/runs-path.ts
@@ -1,0 +1,60 @@
+/**
+ * Runs directory path resolution.
+ *
+ * Canonical location: `<rootDir>/runs/<agent>/<YYYY-MM-DD>/digest-*.md`
+ *
+ * Legacy location: `<rootDir>/.murmuration/runs/<agent>/<YYYY-MM-DD>/digest-*.md`
+ *
+ * The legacy location hid real content (agent-authored digests) inside
+ * a dot-dir intended for daemon-managed runtime state. v0.5.x moves
+ * runs/ out to the root so operators can see and browse their agents'
+ * work like any other content directory. Readers check both paths
+ * during the transition so existing murmurations keep working without
+ * a manual migration step.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const RUNS_DIR_NAME = "runs";
+
+/** Canonical runs dir — what new writes use. */
+export const runsDir = (rootDir: string): string => join(rootDir, RUNS_DIR_NAME);
+
+/** Legacy runs dir — writes from pre-v0.5.x went here. */
+export const legacyRunsDir = (rootDir: string): string =>
+  join(rootDir, ".murmuration", RUNS_DIR_NAME);
+
+/**
+ * Return the runs dir that exists for this agent, preferring the
+ * canonical location. Falls back to the legacy path only when the
+ * canonical one hasn't been created yet AND legacy exists. Always
+ * returns the canonical path when neither exists (so writers default
+ * to the new layout).
+ */
+export const runsDirForAgent = (rootDir: string, agentId: string): string => {
+  const canonical = join(runsDir(rootDir), agentId);
+  if (existsSync(canonical)) return canonical;
+  const legacy = join(legacyRunsDir(rootDir), agentId);
+  if (existsSync(legacy)) return legacy;
+  return canonical;
+};
+
+/**
+ * One-time auto-migration: if legacy `<root>/.murmuration/runs/`
+ * exists and canonical `<root>/runs/` doesn't, rename legacy → new.
+ * Called at daemon boot so operators don't have to think about the
+ * migration. Safe to call repeatedly — no-op when already migrated.
+ */
+export const migrateLegacyRunsDir = async (rootDir: string): Promise<boolean> => {
+  const legacy = legacyRunsDir(rootDir);
+  const canonical = runsDir(rootDir);
+  if (!existsSync(legacy) || existsSync(canonical)) return false;
+  const { rename } = await import("node:fs/promises");
+  try {
+    await rename(legacy, canonical);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,12 @@ export * from "./daemon/socket.js";
 export * from "./daemon/http.js";
 export * from "./daemon/events.js";
 export * from "./daemon/logger.js";
+export {
+  migrateLegacyRunsDir,
+  runsDir,
+  legacyRunsDir,
+  runsDirForAgent,
+} from "./daemon/runs-path.js";
 export * from "./daemon/protocol.js";
 // directives/index.ts removed — directives are GitHub issues now.
 // The DirectiveStore was a file-based mechanism that has been replaced

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -18,6 +18,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join, resolve, dirname } from "node:path";
 
+import { runsDirForAgent } from "../daemon/runs-path.js";
 import { parseSelfReflection } from "../execution/index.js";
 import type {
   AgentOutputArtifact,
@@ -185,7 +186,7 @@ const readUpstreamDigest = async (
   upstreamAgentId: string,
 ): Promise<string | null> => {
   try {
-    const runsDir = join(rootDir, ".murmuration", "runs", upstreamAgentId);
+    const runsDir = runsDirForAgent(rootDir, upstreamAgentId);
     const dates = await readdir(runsDir);
     const sorted = dates
       .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
@@ -213,7 +214,7 @@ const readSelfDigestTail = async (
   n: number,
 ): Promise<{ day: string; wake: string; content: string }[]> => {
   try {
-    const runsDir = join(rootDir, ".murmuration", "runs", agentId);
+    const runsDir = runsDirForAgent(rootDir, agentId);
     const dates = await readdir(runsDir);
     const sortedDays = dates
       .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -159,7 +159,10 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
   }
 
   const results: AgentStatus[] = [];
-  const runsDir = join(rootDir, ".murmuration", "runs");
+  // v0.5.x moved runs/ out of .murmuration/ so content is visible.
+  // Read from new path; legacy data stays at .murmuration/runs/ until
+  // the boot-time auto-migration picks it up.
+  const runsDir = join(rootDir, "runs");
 
   for (const agentId of agentDirs.sort()) {
     const schedule = await parseCronFromRole(rootDir, agentId);
@@ -486,7 +489,10 @@ export interface CostSummary {
 }
 
 export const readCostSummary = async (rootDir: string): Promise<CostSummary> => {
-  const runsDir = join(rootDir, ".murmuration", "runs");
+  // v0.5.x moved runs/ out of .murmuration/ so content is visible.
+  // Read from new path; legacy data stays at .murmuration/runs/ until
+  // the boot-time auto-migration picks it up.
+  const runsDir = join(rootDir, "runs");
   let agentDirs: string[];
   try {
     agentDirs = await readdir(runsDir);


### PR DESCRIPTION
Agent-authored wake digests are real content; they shouldn't be hidden under the daemon's dot-dir. Moves runs/ to the repo root with a one-time auto-migration at boot.