### PR TITLE
security: phase B hardening (scrubber, identifier validation, dashboard auth + XSS)

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1613,10 +1613,23 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     daemonSocket.start();
   }
 
-  // Start HTTP server for web dashboard (SSE events + REST API)
+  // Start HTTP server for web dashboard (SSE events + REST API).
+  // Mint a per-daemon auth token and persist to .murmuration/dashboard.token
+  // (0600) so only the operator account can read it. API clients present
+  // it via `?token=<value>` or `X-Murmuration-Token` header.
   const httpPort = parseInt(process.env.MURMURATION_HTTP_PORT ?? "0", 10);
+  let dashboardToken: string | undefined;
+  if (httpPort > 0 && !once) {
+    const { randomBytes, writeFileSync } = await import("node:fs").then(async (fs) => ({
+      randomBytes: (await import("node:crypto")).randomBytes,
+      writeFileSync: fs.writeFileSync,
+    }));
+    dashboardToken = randomBytes(24).toString("base64url");
+    const tokenPath = resolve(exampleRoot, ".murmuration", "dashboard.token");
+    writeFileSync(tokenPath, dashboardToken + "\n", { mode: 0o600 });
+  }
   const daemonHttp =
-    httpPort > 0 && !once
+    httpPort > 0 && !once && dashboardToken !== undefined
       ? new DaemonHttp({
           port: httpPort,
           statusHandler: () => executor.buildStatus(),
@@ -1624,9 +1637,9 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
           groupDetailHandler: (groupId) => executor.groupDetail(groupId),
           commandHandler: (method, params) => executor.execute(method, params),
           eventBus,
+          authToken: dashboardToken,
         })
       : null;
-  // All handlers are now in DaemonCommandExecutor (command-executor.ts).
   if (daemonHttp) {
     daemonHttp.start();
     process.stdout.write(
@@ -1635,6 +1648,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         level: "info",
         event: "daemon.http.started",
         port: httpPort,
+        dashboard_url: `http://127.0.0.1:${String(httpPort)}/dashboard?token=${dashboardToken ?? ""}`,
       })}\n`,
     );
   }

--- a/packages/core/src/daemon/dashboard.html
+++ b/packages/core/src/daemon/dashboard.html
@@ -172,20 +172,83 @@
 </div>
 
 <script>
+// ---------------------------------------------------------------------------
+// Auth + security helpers (Phase B: v0.5.0 security review C1)
+// ---------------------------------------------------------------------------
+
+// Read the per-daemon auth token from the URL on first load and persist it
+// for subsequent fetches. The operator opens `/dashboard?token=<value>` once;
+// the token survives navigation within the SPA. Without a token every API
+// call gets a 401 from the server.
+(function () {
+  var urlParams = new URLSearchParams(window.location.search);
+  var t = urlParams.get('token');
+  if (t) {
+    try { sessionStorage.setItem('murmurationToken', t); } catch (_) { /* storage disabled */ }
+  }
+})();
+
+function getToken() {
+  try { return sessionStorage.getItem('murmurationToken') || ''; }
+  catch (_) { return ''; }
+}
+
+// Escape an untrusted string for safe interpolation inside HTML text content
+// or double-quoted attribute values. Use for anything coming from GitHub
+// (topic, title, labels, body), LLM output (digest content), or user input.
+function esc(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Only permit http:, https:, and mailto: schemes in user-supplied URLs.
+// Rejects javascript:, data:, file:, etc. If the URL is invalid or uses a
+// non-allowlisted scheme, returns '#'.
+function safeUrl(u) {
+  if (typeof u !== 'string') return '#';
+  try {
+    var parsed = new URL(u, window.location.origin);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'mailto:') {
+      return parsed.href;
+    }
+  } catch (_) { /* fallthrough */ }
+  return '#';
+}
+
+// All data-fetching routes through this so the auth token is always included.
+function apiFetch(path, init) {
+  var opts = init || {};
+  var headers = Object.assign({}, opts.headers || {});
+  var tok = getToken();
+  if (tok) headers['X-Murmuration-Token'] = tok;
+  return fetch(path, Object.assign({}, opts, { headers: headers }));
+}
+
+// SSE needs the token in the query string since EventSource can't set headers.
+function apiEventSource(path) {
+  var tok = getToken();
+  var sep = path.indexOf('?') >= 0 ? '&' : '?';
+  return new EventSource(tok ? path + sep + 'token=' + encodeURIComponent(tok) : path);
+}
+
 var lastStatusData = null;
 async function refresh() {
   try {
-    const r = await fetch('/api/status');
+    const r = await apiFetch('/api/status');
     const d = await r.json();
     lastStatusData = d;
     const m = d.murmuration || {};
     document.getElementById('title').textContent = (d.name || 'Murmuration') + ' Dashboard';
     document.title = (d.name || 'Murmuration') + ' Dashboard';
-    const ghLink = d.githubUrl ? ' | <a href="' + d.githubUrl + '/issues" style="color:#58a6ff" target="_blank">GitHub Issues</a>' : '';
+    const ghLink = d.githubUrl ? ' | <a href="' + esc(safeUrl(d.githubUrl + '/issues')) + '" style="color:#58a6ff" target="_blank" rel="noopener">GitHub Issues</a>' : '';
     const g = d.governance || {};
     const govName = g.model || 'none';
     const govMeta = govName !== 'none' ? ' | Governance: ' + govName : '';
-    document.getElementById('meta').innerHTML = 'v' + d.version + ' | PID ' + d.pid + govMeta + ' | ' + new Date().toLocaleTimeString() + ghLink;
+    document.getElementById('meta').innerHTML = 'v' + esc(d.version) + ' | PID ' + esc(d.pid) + esc(govMeta) + ' | ' + new Date().toLocaleTimeString() + ghLink;
 
     // 1. Overview
     const idleRate = m.totalWakes > 0 ? Math.round((m.idleWakes / m.totalWakes) * 100) : 0;
@@ -200,18 +263,18 @@ async function refresh() {
     // 2. Groups
     document.getElementById('groups').innerHTML = (d.groups || []).map(g => {
       const gIdle = g.totalWakes > 0 ? Math.round((g.idleWakes / g.totalWakes) * 100) : 0;
-      return '<div class="group-card"><h3><a href="#" onclick="showGroup(\'' + g.groupId + '\');return false" style="color:#58a6ff;text-decoration:none">' + g.groupId + '</a></h3>' +
+      return '<div class="group-card"><h3><a href="#" data-group-id="' + esc(g.groupId) + '" onclick="showGroup(this.dataset.groupId);return false" style="color:#58a6ff;text-decoration:none">' + esc(g.groupId) + '</a></h3>' +
         '<div class="group-stats">' +
-        g.memberCount + ' members | ' +
-        '<span>' + g.totalWakes + '</span> wakes | ' +
-        '<span>' + g.totalArtifacts + '</span> artifacts | ' +
-        gIdle + '% idle' +
+        esc(g.memberCount) + ' members | ' +
+        '<span>' + esc(g.totalWakes) + '</span> wakes | ' +
+        '<span>' + esc(g.totalArtifacts) + '</span> artifacts | ' +
+        esc(gIdle) + '% idle' +
         '</div>' +
         '<div class="group-members">' +
         g.members.map(id => {
           const a = d.agents.find(x => x.agentId === id);
           const cls = a && a.totalArtifacts > 0 ? 'active' : a && a.totalWakes > 0 ? 'idle' : '';
-          return '<span class="member-tag ' + cls + '">' + id + '</span>';
+          return '<span class="member-tag ' + esc(cls) + '">' + esc(id) + '</span>';
         }).join('') +
         '</div></div>';
     }).join('');
@@ -229,46 +292,46 @@ async function refresh() {
     if (pending.length > 0) {
       govHtml += '<div class="group-card"><h3>Pending ' + itemLabel + 's (' + pending.length + ')</h3>';
       govHtml += pending.map(i => {
-        var label = '[' + i.kind + '] ' + (i.topic || '(no topic)').slice(0, 60);
+        var label = '[' + esc(i.kind) + '] ' + esc((i.topic || '(no topic)').slice(0, 60));
         var topicSearch = (i.topic || '').slice(0, 40).replace(/[^\w\s]/g, '').trim().split(/\s+/).slice(0, 4).join('+');
-        var itemUrl = i.githubIssueUrl || (ghIssuesUrl ? ghIssuesUrl + '?q=is:issue+%5B' + i.kind.toUpperCase() + '%5D+' + topicSearch : '');
-        var link = itemUrl ? '<a href="' + itemUrl + '" style="color:#8b949e" target="_blank">' + label + '</a>' : label;
+        var itemUrl = i.githubIssueUrl || (ghIssuesUrl ? ghIssuesUrl + '?q=is:issue+%5B' + encodeURIComponent(String(i.kind).toUpperCase()) + '%5D+' + encodeURIComponent(topicSearch) : '');
+        var link = itemUrl ? '<a href="' + esc(safeUrl(itemUrl)) + '" style="color:#8b949e" target="_blank" rel="noopener">' + label + '</a>' : label;
 
         // Only show meeting state for items that were specifically convened
         var cState = convenedItems[i.id];
         var stateText, stateColor, btnHtml;
         if (cState === 'done') {
           var mUrl = meetingMinutesUrl[Object.keys(meetingMinutesUrl)[0] || ''] || (ghIssuesUrl ? ghIssuesUrl + '?q=is:issue+%5BGOVERNANCE+MEETING%5D+in:title+sort:created-desc' : '');
-          stateText = mUrl ? '<a href="' + mUrl + '" target="_blank" style="color:#3fb950">meeting complete — view minutes</a>' : '<span style="color:#3fb950">meeting complete</span>';
+          stateText = mUrl ? '<a href="' + esc(safeUrl(mUrl)) + '" target="_blank" rel="noopener" style="color:#3fb950">meeting complete — view minutes</a>' : '<span style="color:#3fb950">meeting complete</span>';
           stateColor = '#3fb950';
           btnHtml = '';
         } else if (cState) {
-          stateText = convenedLabel(cState);
+          stateText = esc(convenedLabel(cState));
           stateColor = '#d29922';
           btnHtml = '';
         } else {
-          stateText = i.state;
+          stateText = esc(i.state);
           stateColor = '';
-          btnHtml = '<button data-convene="' + i.id + '" data-kind="' + i.kind + '" data-topic="' + (i.topic||'').replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;') + '" data-createdby="' + (i.createdBy || '') + '" onclick="conveneGovernance(this)" style="font-size:0.65rem;padding:2px 6px;background:#238636;color:#c9d1d9;border:1px solid #238636;border-radius:4px;cursor:pointer">Convene</button>';
+          btnHtml = '<button data-convene="' + esc(i.id) + '" data-kind="' + esc(i.kind) + '" data-topic="' + esc(i.topic || '') + '" data-createdby="' + esc(i.createdBy || '') + '" onclick="conveneGovernance(this)" style="font-size:0.65rem;padding:2px 6px;background:#238636;color:#c9d1d9;border:1px solid #238636;border-radius:4px;cursor:pointer">Convene</button>';
         }
-        return '<div class="stat" style="align-items:center"><span class="label">' + link + '</span><span style="display:flex;gap:6px;align-items:center"><span class="value" id="gov-state-' + i.id + '"' + (stateColor ? ' style="color:' + stateColor + '"' : '') + '>' + stateText + '</span>' + btnHtml + '</span></div>';
+        return '<div class="stat" style="align-items:center"><span class="label">' + link + '</span><span style="display:flex;gap:6px;align-items:center"><span class="value" id="gov-state-' + esc(i.id) + '"' + (stateColor ? ' style="color:' + stateColor + '"' : '') + '>' + stateText + '</span>' + btnHtml + '</span></div>';
       }).join('');
       govHtml += '</div>';
     }
     if (recent.length > 0) {
       govHtml += '<div class="group-card"><h3>Recent Decisions</h3>';
       govHtml += recent.map(i => {
-        var label = '[' + i.kind + '] ' + (i.topic || '(no topic)').slice(0, 60);
+        var label = '[' + esc(i.kind) + '] ' + esc((i.topic || '(no topic)').slice(0, 60));
         var topicSearch = (i.topic || '').slice(0, 40).replace(/[^\w\s]/g, '').trim().split(/\s+/).slice(0, 4).join('+');
-        var issueUrl = i.githubIssueUrl || (ghIssuesUrl ? ghIssuesUrl + '?q=is:issue+%5B' + i.kind.toUpperCase() + '%5D+' + topicSearch : '');
-        var labelLink = issueUrl ? '<a href="' + issueUrl + '" style="color:#8b949e" target="_blank">' + label + '</a>' : label;
-        var stateLink = issueUrl ? '<a href="' + issueUrl + '" style="color:#3fb950" target="_blank">' + i.state + '</a>' : i.state;
+        var issueUrl = i.githubIssueUrl || (ghIssuesUrl ? ghIssuesUrl + '?q=is:issue+%5B' + encodeURIComponent(String(i.kind).toUpperCase()) + '%5D+' + encodeURIComponent(topicSearch) : '');
+        var labelLink = issueUrl ? '<a href="' + esc(safeUrl(issueUrl)) + '" style="color:#8b949e" target="_blank" rel="noopener">' + label + '</a>' : label;
+        var stateLink = issueUrl ? '<a href="' + esc(safeUrl(issueUrl)) + '" style="color:#3fb950" target="_blank" rel="noopener">' + esc(i.state) + '</a>' : esc(i.state);
         return '<div class="stat"><span class="label">' + labelLink + '</span><span class="value state-idle">' + stateLink + '</span></div>';
       }).join('');
       govHtml += '</div>';
     }
     if (govHtml === '') {
-      govHtml = '<div class="group-card"><h3>No governance items</h3><div class="stat"><span class="label">File a ' + eventLabel + ' to start governance</span><span class="value">—</span></div></div>';
+      govHtml = '<div class="group-card"><h3>No governance items</h3><div class="stat"><span class="label">File a ' + esc(eventLabel) + ' to start governance</span><span class="value">—</span></div></div>';
     }
     document.getElementById('governance').innerHTML = govHtml;
 
@@ -281,9 +344,10 @@ async function refresh() {
       meetingsHtml += meetingsData.map(function(m) {
         var kindColors = { governance: '#d29922', retrospective: '#f85149', operational: '#3fb950' };
         var kc = kindColors[m.kind] || '#8b949e';
-        var label = m.title ? m.title.replace(/</g, '&lt;').replace(/^\[.*?\]\s*/, '').slice(0, 70) : m.groupId;
+        var rawLabel = m.title ? String(m.title).replace(/^\[.*?\]\s*/, '').slice(0, 70) : m.groupId;
+        var label = esc(rawLabel);
         var titleHtml = m.minutesUrl
-          ? '<a href="' + m.minutesUrl + '" target="_blank" style="color:#c9d1d9;text-decoration:none">' + label + '</a>'
+          ? '<a href="' + esc(safeUrl(m.minutesUrl)) + '" target="_blank" rel="noopener" style="color:#c9d1d9;text-decoration:none">' + label + '</a>'
           : '<span style="color:#c9d1d9">' + label + '</span>';
         var statusHtml = m.status === 'running'
           ? '<span style="color:#d29922">in progress</span>'
@@ -291,16 +355,16 @@ async function refresh() {
         return '<div style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;border-bottom:1px solid #21262d;font-size:0.8rem">' +
           '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + titleHtml + '</span>' +
           '<span style="display:flex;gap:8px;align-items:center;flex-shrink:0;margin-left:12px">' +
-          '<span style="color:' + kc + ';font-size:0.7rem">' + m.kind + '</span>' +
-          '<span style="color:#8b949e;font-size:0.7rem">' + m.date + '</span>' +
+          '<span style="color:' + kc + ';font-size:0.7rem">' + esc(m.kind) + '</span>' +
+          '<span style="color:#8b949e;font-size:0.7rem">' + esc(m.date) + '</span>' +
           statusHtml + '</span></div>';
       }).join('');
       if (allMeetingsUrl) {
-        meetingsHtml += '<div style="text-align:right;padding-top:6px"><a href="' + allMeetingsUrl + '" target="_blank" style="color:#58a6ff;font-size:0.7rem">all meetings in GitHub &rarr;</a></div>';
+        meetingsHtml += '<div style="text-align:right;padding-top:6px"><a href="' + esc(safeUrl(allMeetingsUrl)) + '" target="_blank" rel="noopener" style="color:#58a6ff;font-size:0.7rem">all meetings in GitHub &rarr;</a></div>';
       }
       meetingsHtml += '</div>';
     } else if (allMeetingsUrl) {
-      meetingsHtml = '<div class="group-card" style="padding:10px 14px"><div style="display:flex;justify-content:space-between;align-items:center;font-size:0.8rem"><span style="color:#8b949e">No meetings this session</span><a href="' + allMeetingsUrl + '" target="_blank" style="color:#58a6ff;font-size:0.7rem">view in GitHub &rarr;</a></div></div>';
+      meetingsHtml = '<div class="group-card" style="padding:10px 14px"><div style="display:flex;justify-content:space-between;align-items:center;font-size:0.8rem"><span style="color:#8b949e">No meetings this session</span><a href="' + esc(safeUrl(allMeetingsUrl)) + '" target="_blank" rel="noopener" style="color:#58a6ff;font-size:0.7rem">view in GitHub &rarr;</a></div></div>';
     }
     document.getElementById('meetings').innerHTML = meetingsHtml;
 
@@ -342,13 +406,14 @@ async function refresh() {
       var ir = a.totalWakes > 0 ? Math.round((a.idleWakes / a.totalWakes) * 100) : 0;
       var ar = a.totalWakes > 0 ? (a.totalArtifacts / a.totalWakes).toFixed(1) : '0';
       var sc2 = a.state === 'idle' ? 'state-idle' : a.state === 'running' ? 'state-running' : 'state-failed';
-      return '<div class="card"><h3><a href="#" onclick="showAgent(\'' + a.agentId + '\');return false" style="color:#58a6ff;text-decoration:none">' + a.agentId + '</a></h3>' +
-        st('State', '<span class="' + sc2 + '">' + a.state + '</span>') +
+      var agentIdE = esc(a.agentId);
+      return '<div class="card"><h3><a href="#" data-agent-id="' + agentIdE + '" onclick="showAgent(this.dataset.agentId);return false" style="color:#58a6ff;text-decoration:none">' + agentIdE + '</a></h3>' +
+        st('State', '<span class="' + sc2 + '">' + esc(a.state) + '</span>') +
         st('Wakes', a.totalWakes) + st('Artifacts', a.totalArtifacts) +
         st('Art/Wake', ar) + st('Idle', ir + '%') + st('Failures', a.consecutiveFailures) +
         '<div class="bar"><div class="bar-fill' + (ir > 50 ? ' warn' : '') +
         '" style="width:' + Math.max(5, (a.totalArtifacts / Math.max(a.totalWakes, 1)) * 100) + '%"></div></div>' +
-        '<div style="margin-top:8px"><button data-wake="' + a.agentId + '" onclick="wakeNow(\'' + a.agentId + '\')" style="font-size:0.75rem;padding:3px 8px;background:#21262d;color:#58a6ff;border:1px solid #30363d;border-radius:4px;cursor:pointer">Wake Now</button></div></div>';
+        '<div style="margin-top:8px"><button data-wake="' + agentIdE + '" onclick="wakeNow(this.dataset.wake)" style="font-size:0.75rem;padding:3px 8px;background:#21262d;color:#58a6ff;border:1px solid #30363d;border-radius:4px;cursor:pointer">Wake Now</button></div></div>';
     }).join('');
   } catch (e) {
     document.getElementById('meta').textContent = 'Disconnected: ' + e.message;
@@ -358,7 +423,7 @@ async function refresh() {
 function sc(n, l) { return '<div class="stat-card"><div class="num">' + n + '</div><div class="lbl">' + l + '</div></div>'; }
 function st(l, v) { return '<div class="stat"><span class="label">' + l + '</span><span class="value">' + v + '</span></div>'; }
 
-const sse = new EventSource('/api/events');
+const sse = apiEventSource('/api/events');
 sse.onmessage = function(e) {
   var div = document.createElement('div');
   div.textContent = new Date().toLocaleTimeString() + ' ' + e.data;
@@ -422,7 +487,7 @@ function renderLog() {
   if (!viewer) return;
   viewer.innerHTML = filtered.slice(0, 50).map(function(e) {
     var c = LOG_COLORS[e.level] || '#8b949e';
-    return '<div style="padding:1px 0;border-bottom:1px solid #21262d"><span style="color:#8b949e">' + e.ts + '</span> <span style="color:' + c + ';font-weight:600">' + e.level + '</span> ' + e.text + '</div>';
+    return '<div style="padding:1px 0;border-bottom:1px solid #21262d"><span style="color:#8b949e">' + esc(e.ts) + '</span> <span style="color:' + c + ';font-weight:600">' + esc(e.level) + '</span> ' + esc(e.text) + '</div>';
   }).join('');
 }
 
@@ -455,7 +520,7 @@ function closeModal(id) { document.getElementById(id).classList.remove('show'); 
 
 async function sendCmd(method, params) {
   try {
-    const r = await fetch('/api/command', {
+    const r = await apiFetch('/api/command', {
       method: 'POST', headers: {'Content-Type':'application/json'},
       body: JSON.stringify({ method, params })
     });
@@ -489,14 +554,15 @@ function sendGroupWake() {
 
 async function showAgent(agentId) {
   try {
-    const r = await fetch('/api/agent/' + agentId);
+    if (!/^[a-z0-9][a-z0-9._-]*$/i.test(String(agentId))) return;
+    const r = await apiFetch('/api/agent/' + encodeURIComponent(agentId));
     const d = await r.json();
     document.getElementById('agent-detail-title').textContent = d.agentId;
     document.getElementById('agent-detail-stats').innerHTML =
-      st('State', d.state) + st('Wakes', d.totalWakes) + st('Artifacts', d.totalArtifacts) +
+      st('State', esc(d.state)) + st('Wakes', d.totalWakes) + st('Artifacts', d.totalArtifacts) +
       st('Idle Wakes', d.idleWakes) + st('Failures', d.consecutiveFailures);
     const digests = (d.recentDigests || []).map(function(dig) {
-      return '<div style="margin:8px 0;padding:8px;background:#0d1117;border:1px solid #21262d;border-radius:6px"><strong>' + dig.date + '</strong><pre style="white-space:pre-wrap;margin:4px 0 0;font-size:0.75rem;color:#c9d1d9">' + linkify(dig.summary.replace(/</g,'&lt;')) + '</pre></div>';
+      return '<div style="margin:8px 0;padding:8px;background:#0d1117;border:1px solid #21262d;border-radius:6px"><strong>' + esc(dig.date) + '</strong><pre style="white-space:pre-wrap;margin:4px 0 0;font-size:0.75rem;color:#c9d1d9">' + linkify(esc(dig.summary)) + '</pre></div>';
     }).join('');
     document.getElementById('agent-detail-digests').innerHTML = digests || '<div style="color:#8b949e">No digests yet</div>';
     document.getElementById('agent-detail-wake').onclick = function() { closeModal('agent-modal'); wakeNow(agentId); };
@@ -516,11 +582,11 @@ function wakeNow(agentId) {
 function updateDropdowns(d) {
   const gs = document.getElementById('group-select');
   gs.innerHTML = '<option value="">Convene Group...</option>' +
-    (d.groups || []).map(g => '<option value="' + g.groupId + '">' + g.groupId + '</option>').join('');
+    (d.groups || []).map(g => '<option value="' + esc(g.groupId) + '">' + esc(g.groupId) + '</option>').join('');
   const ds = document.getElementById('dir-scope');
   ds.innerHTML = '<option data-scope="--all">All Agents</option>' +
-    (d.groups || []).map(g => '<option data-scope="--group" data-target="' + g.groupId + '">Group: ' + g.groupId + '</option>').join('') +
-    d.agents.map(a => '<option data-scope="--agent" data-target="' + a.agentId + '">Agent: ' + a.agentId + '</option>').join('');
+    (d.groups || []).map(g => '<option data-scope="--group" data-target="' + esc(g.groupId) + '">Group: ' + esc(g.groupId) + '</option>').join('') +
+    d.agents.map(a => '<option data-scope="--agent" data-target="' + esc(a.agentId) + '">Agent: ' + esc(a.agentId) + '</option>').join('');
 }
 
 // Track convened governance items so refresh doesn't reset their visual state
@@ -529,17 +595,25 @@ var convenedItems = {};
 var meetingState = {};
 var meetingMinutesUrl = {};
 
-// Linkify URLs in text (GitHub issues, PRs, commits, general URLs)
+// Linkify URLs in already-escaped text. Input must be HTML-escaped before
+// this is called — we match the escaped form (e.g. `&lt;` won't break out).
+// Output href is re-validated through safeUrl to reject anything that isn't
+// http/https, even though the match already only accepts http(s) prefixes.
 function linkify(text) {
-  return text.replace(/(https?:\/\/[^\s<)]+)/g, '<a href="$1" target="_blank" style="color:#58a6ff">$1</a>');
+  return text.replace(/(https?:\/\/[^\s<)"']+)/g, function(match) {
+    var href = safeUrl(match);
+    if (href === '#') return match;
+    return '<a href="' + esc(href) + '" target="_blank" rel="noopener" style="color:#58a6ff">' + match + '</a>';
+  });
 }
 
 // Group detail modal
 let currentGroupId = '';
 async function showGroup(groupId) {
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(String(groupId))) return;
   currentGroupId = groupId;
   try {
-    const r = await fetch('/api/group/' + encodeURIComponent(groupId));
+    const r = await apiFetch('/api/group/' + encodeURIComponent(groupId));
     const d = await r.json();
     document.getElementById('group-detail-title').textContent = d.groupId;
     document.getElementById('group-detail-stats').innerHTML =
@@ -547,12 +621,12 @@ async function showGroup(groupId) {
     document.getElementById('group-detail-members').innerHTML =
       (d.members || []).map(function(m) {
         const cls = m.totalArtifacts > 0 ? 'active' : m.totalWakes > 0 ? 'idle' : '';
-        return '<span class="member-tag ' + cls + '">' + m.agentId + '</span>';
+        return '<span class="member-tag ' + esc(cls) + '">' + esc(m.agentId) + '</span>';
       }).join('');
     const meetings = (d.recentMeetings || []).map(function(mtg) {
       return '<div style="margin:8px 0;padding:8px;background:#0d1117;border:1px solid #21262d;border-radius:6px">' +
-        '<strong>' + mtg.date + '</strong> <span style="color:#8b949e;font-size:0.7rem">' + mtg.kind + '</span>' +
-        '<pre style="white-space:pre-wrap;margin:4px 0 0;font-size:0.75rem;color:#c9d1d9">' + linkify(mtg.summary.replace(/</g,'&lt;')) + '</pre></div>';
+        '<strong>' + esc(mtg.date) + '</strong> <span style="color:#8b949e;font-size:0.7rem">' + esc(mtg.kind) + '</span>' +
+        '<pre style="white-space:pre-wrap;margin:4px 0 0;font-size:0.75rem;color:#c9d1d9">' + linkify(esc(mtg.summary)) + '</pre></div>';
     }).join('');
     document.getElementById('group-detail-meetings').innerHTML = meetings || '<div style="color:#8b949e">No meetings yet</div>';
     document.getElementById('group-detail-modal').classList.add('show');

--- a/packages/core/src/daemon/http.ts
+++ b/packages/core/src/daemon/http.ts
@@ -7,6 +7,21 @@
  *   GET  /api/events      — SSE stream of daemon events
  *   POST /api/command      — send a command (same as socket protocol)
  *   GET  /                 — health check
+ *
+ * Security model:
+ *   - Bound to 127.0.0.1 only
+ *   - Host header must be `127.0.0.1:<port>` or `localhost:<port>`
+ *     (defeats DNS rebinding attacks)
+ *   - Every endpoint except `/dashboard` requires a random per-daemon
+ *     auth token, either via `?token=` query param or `x-murmuration-token`
+ *     header. The token is minted at daemon start and written to
+ *     `<root>/.murmuration/dashboard.token` with 0600 permissions so
+ *     only the operator account can read it. The boot log echoes the
+ *     full URL including the token so the operator can open the
+ *     dashboard with one click.
+ *   - `/dashboard` serves static HTML with a strict Content-Security-Policy
+ *     and `default-src 'self'` so any injected content can't reach
+ *     third-party origins.
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
@@ -23,6 +38,26 @@ import type { DaemonEventBus } from "./events.js";
 const __dirname_compat = dirname(fileURLToPath(import.meta.url));
 const DASHBOARD_HTML = readFileSync(resolve(__dirname_compat, "dashboard.html"), "utf8");
 
+/**
+ * Content-Security-Policy for /dashboard. Strict enough to contain an
+ * XSS injection if one slips past the escape helper in dashboard.html:
+ * - no third-party script sources
+ * - no inline event handlers (inline <script> is allowed because the
+ *   dashboard is a single static file with its behavior inline; a
+ *   future milestone extracts it)
+ * - no plugins, no base rewrites, no mixed content
+ */
+const DASHBOARD_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
 // ---------------------------------------------------------------------------
 // HTTP server
 // ---------------------------------------------------------------------------
@@ -34,6 +69,13 @@ export interface DaemonHttpConfig {
   readonly agentDetailHandler?: (agentId: string) => Promise<unknown>;
   readonly groupDetailHandler?: (groupId: string) => Promise<unknown>;
   readonly eventBus?: DaemonEventBus;
+  /**
+   * Shared secret required on every API request. Minted at daemon
+   * start; persisted to disk (0600) for the local dashboard to read.
+   * Clients present it as `?token=<value>` or the
+   * `x-murmuration-token` header.
+   */
+  readonly authToken: string;
 }
 
 export class DaemonHttp {
@@ -45,6 +87,7 @@ export class DaemonHttp {
   readonly #commandHandler: DaemonHttpConfig["commandHandler"];
   readonly #agentDetailHandler: DaemonHttpConfig["agentDetailHandler"];
   readonly #groupDetailHandler: DaemonHttpConfig["groupDetailHandler"];
+  readonly #authToken: string;
   #unsubscribeEventBus: (() => void) | null = null;
 
   public constructor(config: DaemonHttpConfig) {
@@ -53,6 +96,7 @@ export class DaemonHttp {
     this.#commandHandler = config.commandHandler;
     this.#agentDetailHandler = config.agentDetailHandler;
     this.#groupDetailHandler = config.groupDetailHandler;
+    this.#authToken = config.authToken;
 
     // Forward daemon events to all SSE clients
     if (config.eventBus) {
@@ -92,11 +136,65 @@ export class DaemonHttp {
     }
   }
 
+  /**
+   * Verify the Host header points at our expected localhost binding.
+   * A mismatch usually means DNS rebinding or a misconfigured reverse
+   * proxy — either way, refuse. The daemon only ever listens on
+   * 127.0.0.1, so legitimate requests have `127.0.0.1:<port>` or
+   * `localhost:<port>` in the Host header.
+   */
+  #hostHeaderOk(req: IncomingMessage): boolean {
+    const host = req.headers.host;
+    if (typeof host !== "string") return false;
+    const port = String(this.#port);
+    return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+  }
+
+  /**
+   * Constant-time equality check for the auth token. Avoids timing
+   * leaks across the network (same-origin browser-dashboard use case
+   * isn't really exposed to this attack, but it's cheap insurance).
+   */
+  #constantTimeEq(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) {
+      diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return diff === 0;
+  }
+
+  /**
+   * Accept a token from `x-murmuration-token` header or `?token=` query.
+   * Header is preferred (doesn't leak into server logs or `Referer`).
+   */
+  #tokenOk(req: IncomingMessage, url: string): boolean {
+    const header = req.headers["x-murmuration-token"];
+    if (typeof header === "string" && this.#constantTimeEq(header, this.#authToken)) {
+      return true;
+    }
+    const qIdx = url.indexOf("?");
+    if (qIdx >= 0) {
+      const search = new URLSearchParams(url.slice(qIdx + 1));
+      const q = search.get("token");
+      if (q !== null && this.#constantTimeEq(q, this.#authToken)) return true;
+    }
+    return false;
+  }
+
   async #handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    // CORS headers for local development
+    // Host header + DNS rebinding defense
+    if (!this.#hostHeaderOk(req)) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "invalid Host header" }));
+      return;
+    }
+
+    // CORS headers for local development (same-origin only)
     res.setHeader("Access-Control-Allow-Origin", `http://localhost:${String(this.#port)}`);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, X-Murmuration-Token");
+    res.setHeader("Vary", "Origin");
 
     if (req.method === "OPTIONS") {
       res.writeHead(204);
@@ -105,20 +203,36 @@ export class DaemonHttp {
     }
 
     const url = req.url ?? "/";
+    const urlPath = url.split("?")[0] ?? "/";
 
-    if (url === "/" && req.method === "GET") {
+    if (urlPath === "/" && req.method === "GET") {
       res.writeHead(302, { Location: "/dashboard" });
       res.end();
       return;
     }
 
-    if (url === "/dashboard" && req.method === "GET") {
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    if (urlPath === "/dashboard" && req.method === "GET") {
+      // The dashboard itself is public (no token) so the operator can
+      // land on it and see the login form; all data endpoints require
+      // the token. CSP keeps any injected script boxed in.
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Security-Policy": DASHBOARD_CSP,
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
+      });
       res.end(DASHBOARD_HTML);
       return;
     }
 
-    if (url === "/api/status" && req.method === "GET") {
+    // All /api/* endpoints require the auth token.
+    if (urlPath.startsWith("/api/") && !this.#tokenOk(req, url)) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "missing or invalid token" }));
+      return;
+    }
+
+    if (urlPath === "/api/status" && req.method === "GET") {
       try {
         const status = await this.#statusHandler();
         res.writeHead(200, { "Content-Type": "application/json" });
@@ -130,9 +244,8 @@ export class DaemonHttp {
       return;
     }
 
-    if (url.startsWith("/api/agent/") && req.method === "GET" && this.#agentDetailHandler) {
-      const agentId = url.slice("/api/agent/".length);
-      // Validate ID at boundary (#85) — prevent path traversal
+    if (urlPath.startsWith("/api/agent/") && req.method === "GET" && this.#agentDetailHandler) {
+      const agentId = urlPath.slice("/api/agent/".length);
       if (!/^[a-z0-9][a-z0-9._-]*$/i.test(agentId)) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "invalid agent ID" }));
@@ -149,9 +262,8 @@ export class DaemonHttp {
       return;
     }
 
-    if (url.startsWith("/api/group/") && req.method === "GET" && this.#groupDetailHandler) {
-      const groupId = decodeURIComponent(url.slice("/api/group/".length));
-      // Validate ID at boundary (#85)
+    if (urlPath.startsWith("/api/group/") && req.method === "GET" && this.#groupDetailHandler) {
+      const groupId = decodeURIComponent(urlPath.slice("/api/group/".length));
       if (!/^[a-z0-9][a-z0-9._-]*$/i.test(groupId)) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "invalid group ID" }));
@@ -168,7 +280,7 @@ export class DaemonHttp {
       return;
     }
 
-    if (url === "/api/events" && req.method === "GET") {
+    if (urlPath === "/api/events" && req.method === "GET") {
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -182,7 +294,7 @@ export class DaemonHttp {
       return;
     }
 
-    if (url === "/api/command" && req.method === "POST") {
+    if (urlPath === "/api/command" && req.method === "POST") {
       const MAX_BODY = 65536; // 64KB limit
       let body = "";
       let oversized = false;
@@ -199,7 +311,6 @@ export class DaemonHttp {
         if (oversized) return;
         try {
           const raw: unknown = JSON.parse(body);
-          // Runtime type validation (#86)
           if (typeof raw !== "object" || raw === null) {
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ error: "request must be an object" }));

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -241,6 +241,63 @@ model_tier: balanced
       expect(loaded.frontmatter.agent_id).toBe("22");
     });
 
+    it("rejects agent_id containing path traversal sequences (H2)", async () => {
+      // A role.md with agent_id like "../../tmp/x" would otherwise
+      // escape the murmuration root when the daemon joins it into
+      // runs/, logs/, governance persist dirs.
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/evil/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/evil/role.md",
+        `---
+agent_id: "../../../tmp/pwned"
+name: "Evil"
+model_tier: balanced
+---
+
+# Evil
+`,
+      );
+      const loader = new IdentityLoader({ rootDir });
+      await expect(loader.load("evil")).rejects.toBeInstanceOf(FrontmatterInvalidError);
+    });
+
+    it("rejects agent_id containing slashes", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/slashy/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/slashy/role.md",
+        `---
+agent_id: "research/editorial"
+name: "Slashy"
+model_tier: balanced
+---
+
+# Slashy
+`,
+      );
+      const loader = new IdentityLoader({ rootDir });
+      await expect(loader.load("slashy")).rejects.toBeInstanceOf(FrontmatterInvalidError);
+    });
+
+    it("rejects agent_id longer than 64 chars", async () => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/long/soul.md", "# Soul\n");
+      await writeFixture(
+        "agents/long/role.md",
+        `---
+agent_id: "${"a".repeat(65)}"
+name: "Long"
+model_tier: balanced
+---
+
+# Long
+`,
+      );
+      const loader = new IdentityLoader({ rootDir });
+      await expect(loader.load("long")).rejects.toBeInstanceOf(FrontmatterInvalidError);
+    });
+
     it("wrong model_tier: issue names the valid enum values", async () => {
       await writeFixture("murmuration/soul.md", "# Soul\n");
       await writeFixture("agents/badtier/soul.md", "# Soul\n");

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -197,6 +197,26 @@ export class FrontmatterInvalidError extends IdentityLoaderError {
 const modelTierSchema = z.enum(["fast", "balanced", "deep"]);
 
 /**
+ * Valid shape for an agent or group identifier. Must not contain
+ * path-separators or traversal sequences — these values are joined
+ * into filesystem paths (`runs/<id>/`, `.murmuration/logs/wake-<id>.log`,
+ * governance persist dirs) and would otherwise enable an attacker-
+ * controlled `role.md` to escape the murmuration root. Matches the
+ * regex the HTTP handler already uses at its boundary (http.ts:136).
+ *
+ * Rules:
+ *   - Must start with a letter or digit
+ *   - Subsequent chars: letters, digits, `.`, `_`, `-`
+ *   - Length 1..64
+ */
+export const IDENTIFIER_RE = /^[a-z0-9][a-z0-9._-]*$/i;
+const IDENTIFIER_MAX_LENGTH = 64;
+const identifierSchema = z.string().min(1).max(IDENTIFIER_MAX_LENGTH).regex(IDENTIFIER_RE, {
+  message:
+    "identifier must start with a letter or digit and contain only letters, digits, `.`, `_`, or `-` (max 64 chars)",
+});
+
+/**
  * LLM provider enum — kept in sync with `@murmurations-ai/llm`'s
  * `ProviderId`. Extended in ADR-0016 (Phase 2C role template).
  */
@@ -359,14 +379,14 @@ const pluginsSchema = z
 
 /** Shape expected from `role.md` YAML frontmatter. Spec §5.3 + ADR-0016. */
 export const roleFrontmatterSchema = z.object({
-  agent_id: z.string().min(1),
+  agent_id: identifierSchema,
   name: z.string().min(1),
   soul_file: z.string().min(1).optional(),
 
   // legacy compat (Phase 1B)
   model_tier: modelTierSchema,
   wake_schedule: wakeScheduleSchema.optional(),
-  group_memberships: z.array(z.string().min(1)).default([]),
+  group_memberships: z.array(identifierSchema).default([]),
   max_wall_clock_ms: z.number().int().positive().default(15_000),
 
   // new in ADR-0016 (Phase 2C)

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -241,40 +241,103 @@ export const SENSITIVE_FIELD_NAME_RE =
 export const SCRUB_MIN_LENGTH = 8;
 
 /**
- * Walk a logger record and return a shallow copy with sensitive values
- * replaced by redaction sentinels. The walker is intentionally
- * non-recursive on arrays/objects to keep logger overhead low; nested
- * sensitive data should go under the {@link REDACT} symbol.
+ * Value-level secret patterns. Match known vendor key formats in any
+ * string value regardless of the enclosing field name. This catches
+ * leaks that bypass the name-based scrub — most commonly: keys
+ * embedded in provider error messages, HTTP response bodies echoed
+ * into stack traces, subprocess stderr tails, and agent-authored
+ * strings that inadvertently quote tool output.
+ *
+ * Named groups so the replacement can identify which pattern hit,
+ * which helps operators tell whether a leak is from a human-visible
+ * identifier (harmless false positive) or an actual credential.
+ *
+ * Priority order: longer/more-specific patterns first so overlapping
+ * matches resolve to the most informative label.
+ */
+export const VALUE_SECRET_PATTERNS: readonly { readonly name: string; readonly re: RegExp }[] = [
+  // PEM keys
+  { name: "pem", re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g },
+  // Google (Gemini) API keys
+  { name: "gemini", re: /AIza[0-9A-Za-z_-]{30,}/g },
+  // Anthropic API keys
+  { name: "anthropic", re: /sk-ant-[a-zA-Z0-9_-]{30,}/g },
+  // GitHub Personal Access Tokens (classic)
+  { name: "github-pat", re: /ghp_[A-Za-z0-9]{30,}/g },
+  // GitHub OAuth tokens
+  { name: "github-oauth", re: /gho_[A-Za-z0-9]{30,}/g },
+  // GitHub fine-grained PATs
+  { name: "github-fg-pat", re: /github_pat_[A-Za-z0-9_]{30,}/g },
+  // GitHub server-to-server
+  { name: "github-s2s", re: /ghs_[A-Za-z0-9]{30,}/g },
+  // GitHub refresh + user tokens
+  { name: "github-refresh", re: /ghr_[A-Za-z0-9]{30,}/g },
+  { name: "github-user", re: /ghu_[A-Za-z0-9]{30,}/g },
+  // Slack bot/app/user/refresh tokens
+  { name: "slack", re: /xox[baprs]-[A-Za-z0-9-]{20,}/g },
+  // OpenAI-style "sk-" keys (kept last; least specific — 'sk-ant-' already handled above)
+  { name: "openai", re: /sk-[a-zA-Z0-9]{30,}/g },
+];
+
+/**
+ * Apply every {@link VALUE_SECRET_PATTERNS} entry to a string and
+ * replace each match with `[REDACTED:<name>]`. Non-destructive if the
+ * string has no matches.
+ */
+export const scrubValuePatterns = (value: string): string => {
+  let out = value;
+  for (const { name, re } of VALUE_SECRET_PATTERNS) {
+    out = out.replace(re, `[REDACTED:${name}]`);
+  }
+  return out;
+};
+
+/**
+ * Walk a logger record and return a deep copy with sensitive values
+ * replaced by redaction sentinels.
  *
  * Rules:
  *
  *  1. Any field under the {@link REDACT} symbol is removed entirely.
- *  2. Any string-valued field whose **key name** matches
- *     {@link SENSITIVE_FIELD_NAME_RE} and whose value length is at least
- *     {@link SCRUB_MIN_LENGTH} is replaced with
- *     `"[REDACTED:scrubbed-by-name]"`.
- *  3. Any {@link SecretValue} already serializes to its own sentinel
- *     via `toJSON`, so the scrubber need not special-case it.
+ *  2. Any string whose **key name** matches {@link SENSITIVE_FIELD_NAME_RE}
+ *     and whose length is at least {@link SCRUB_MIN_LENGTH} is replaced
+ *     with `"[REDACTED:scrubbed-by-name]"`.
+ *  3. Any remaining string is passed through {@link scrubValuePatterns}
+ *     so vendor-format secrets embedded in error messages, stderr
+ *     tails, or agent output are caught even when the enclosing key
+ *     is benign (`error`, `message`, `stderr`, `output`).
+ *  4. Arrays are walked; each element is scrubbed in place.
+ *  5. {@link SecretValue} already serializes to its own sentinel via
+ *     `toJSON`, so the scrubber need not special-case it.
  */
 export const scrubLogRecord = (data: Record<string, unknown>): Record<string, unknown> => {
-  const scrub = (obj: Record<string, unknown>): Record<string, unknown> => {
-    const out: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj)) {
+  const scrubValue = (value: unknown, keyForNameMatch?: string): unknown => {
+    if (typeof value === "string") {
       if (
-        typeof value === "string" &&
-        SENSITIVE_FIELD_NAME_RE.test(key) &&
+        keyForNameMatch !== undefined &&
+        SENSITIVE_FIELD_NAME_RE.test(keyForNameMatch) &&
         value.length >= SCRUB_MIN_LENGTH
       ) {
-        out[key] = "[REDACTED:scrubbed-by-name]";
-        continue;
+        return "[REDACTED:scrubbed-by-name]";
       }
-      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-        out[key] = scrub(value as Record<string, unknown>);
-        continue;
-      }
-      out[key] = value;
+      return scrubValuePatterns(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map((v) => scrubValue(v));
+    }
+    if (value !== null && typeof value === "object") {
+      return scrubObject(value as Record<string, unknown>);
+    }
+    return value;
+  };
+
+  const scrubObject = (obj: Record<string, unknown>): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      out[key] = scrubValue(value, key);
     }
     return out;
   };
-  return scrub(data);
+
+  return scrubObject(data);
 };

--- a/packages/core/src/secrets/secrets.test.ts
+++ b/packages/core/src/secrets/secrets.test.ts
@@ -136,6 +136,64 @@ describe("scrubLogRecord", () => {
     const out = scrubLogRecord({ token: secret });
     expect(JSON.stringify(out.token)).toBe('"[REDACTED:length=14]"');
   });
+
+  it("scrubs value-pattern secrets regardless of key name (H1)", () => {
+    // Each bucket is a real incident class: keys echoed in error messages,
+    // stderr tails, or agent-authored strings. Every one must be caught
+    // even when the enclosing key is benign (error, message, output, stderr).
+    const inputs = [
+      { key: "error", value: "401: AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8", pat: "gemini" },
+      {
+        key: "message",
+        value: "invalid api key sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789",
+        pat: "anthropic",
+      },
+      {
+        key: "stderr",
+        value: "git failed with token ghp_abcdefghijklmnopqrstuvwxyz0123456",
+        pat: "github-pat",
+      },
+      {
+        key: "output",
+        value: "OpenAI: sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEF",
+        pat: "openai",
+      },
+      {
+        key: "body",
+        value: "github_pat_11ABCDEFG0abcdefghijkl_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ",
+        pat: "github-fg-pat",
+      },
+    ];
+    for (const { key, value, pat } of inputs) {
+      const out = scrubLogRecord({ [key]: value });
+      expect(out[key]).toContain(`[REDACTED:${pat}]`);
+      expect(out[key]).not.toContain(value);
+    }
+  });
+
+  it("scrubs value-pattern secrets inside nested objects and arrays", () => {
+    const out = scrubLogRecord({
+      stderrChunks: [
+        "first line ok",
+        "found AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8 in response",
+      ],
+      nested: {
+        detail: { cause: "ghp_abcdefghijklmnopqrstuvwxyz0123456" },
+      },
+    });
+    const chunks = out.stderrChunks as string[];
+    expect(chunks[0]).toBe("first line ok");
+    expect(chunks[1]).toContain("[REDACTED:gemini]");
+    const nested = out.nested as { detail: { cause: string } };
+    expect(nested.detail.cause).toContain("[REDACTED:github-pat]");
+  });
+
+  it("passes through strings that happen to look key-ish but do not match any pattern", () => {
+    const out = scrubLogRecord({
+      message: "wake completed in 1234ms across 5 agents",
+    });
+    expect(out.message).toBe("wake completed in 1234ms across 5 agents");
+  });
 });
 
 describe("SENSITIVE_FIELD_NAME_RE", () => {


### PR DESCRIPTION
Addresses v0.5.0 security review publish-blockers: **C1** (dashboard XSS + unauth /api/command = local RCE), **H1+H3** (scrubLogRecord matches key names not values), **H2** (agent_id path traversal).

## Changes

- `scrubLogRecord`: value-pattern sweep for Gemini/Anthropic/OpenAI/GitHub/Slack/PEM secrets in every string field. Catches leaks embedded in error messages, stderr tails, agent output — not just sensitively-named keys. Recurses into arrays.
- Identity schema: `IDENTIFIER_RE = /^[a-z0-9][a-z0-9._-]*$/i`, max 64 chars, applied to `agent_id` + `group_memberships`. Blocks `../../../tmp/x` traversal at load time.
- Dashboard auth: random token minted at daemon start, written to `.murmuration/dashboard.token` (0600). Every `/api/*` requires it. Boot log emits full URL with token.
- Host header validation: rejects DNS-rebinding-style requests.
- Dashboard XSS: `esc()` on every untrusted interpolation (topics, titles, kinds, dates, IDs, summaries, linkified URLs). Strict CSP header.

## Tests

650 pass (+6 new). Typecheck + lint clean.

## Still gating v0.5.0

Architecture phase C: circle hardcoded in core prompts, governance terminology in core runner, multi-writer state stores.