### PR TITLE
arch: phase C governance decoupling (blockers #1/#2/#3)

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -151,7 +151,10 @@ const showStatus = async (rootDir: string): Promise<void> => {
 
   // Show agent summary from state store
   const { AgentStateStore } = await import("@murmurations-ai/core");
-  const store = new AgentStateStore({ persistDir: resolve(rootDir, ".murmuration", "agents") });
+  const store = new AgentStateStore({
+    persistDir: resolve(rootDir, ".murmuration", "agents"),
+    readOnly: true,
+  });
   const loaded = await store.load();
   if (loaded > 0) {
     const agents = store.getAllAgents();

--- a/packages/cli/src/governance-plugins/s3/index.mjs
+++ b/packages/cli/src/governance-plugins/s3/index.mjs
@@ -116,12 +116,53 @@ const S3GovernancePlugin = {
     return [TENSION_GRAPH, PROPOSAL_GRAPH];
   },
 
+  /**
+   * S3 treats these verbs in a tally recommendation as resolving a
+   * governance item. Substring match so "we ratify" / "will approve" /
+   * "consent with concern" all trigger. Used by the daemon to decide
+   * whether to advance the item to its terminal state.
+   */
+  isResolvingRecommendation(recommendation) {
+    const verbs = ["resolve", "ratif", "approve", "adopt", "agree", "pass", "consent"];
+    const lower = String(recommendation).toLowerCase();
+    return verbs.some((v) => lower.includes(v));
+  },
+
   async onEventsEmitted(batch, _reader) {
     const decisions = [];
 
     for (const event of batch.events) {
-      switch (event.kind) {
-        case "agent-governance-event":
+      // Generic "agent-governance-event" from core: parse the model-
+      // specific prefix from payload.topic to decide the item kind.
+      // "PROPOSAL:" → proposal-opened, "TENSION:" → tension,
+      // "REPORT:" → report. Unprefixed defaults to tension (the
+      // zero-ceremony path for agents who don't know the taxonomy).
+      let resolvedKind = event.kind;
+      let resolvedPayload = event.payload;
+      if (event.kind === "agent-governance-event") {
+        const topic =
+          typeof event.payload === "object" &&
+          event.payload !== null &&
+          typeof event.payload.topic === "string"
+            ? event.payload.topic
+            : "";
+        let kind = S3_TENSION;
+        let trimmed = topic;
+        if (topic.startsWith("PROPOSAL:")) {
+          kind = S3_PROPOSAL;
+          trimmed = topic.slice("PROPOSAL:".length).trim();
+        } else if (topic.startsWith("TENSION:")) {
+          kind = S3_TENSION;
+          trimmed = topic.slice("TENSION:".length).trim();
+        } else if (topic.startsWith("REPORT:")) {
+          kind = "report";
+          trimmed = topic.slice("REPORT:".length).trim();
+        }
+        resolvedKind = kind;
+        resolvedPayload = { ...event.payload, topic: trimmed };
+      }
+
+      switch (resolvedKind) {
         case S3_TENSION: {
           // Route to Source for visibility + to any targeted agent.
           /** @type {import('@murmurations-ai/core').GovernanceRouteTarget[]} */
@@ -132,7 +173,7 @@ const S3GovernancePlugin = {
           decisions.push({
             event,
             routes,
-            create: { kind: "tension", payload: event.payload },
+            create: { kind: "tension", payload: resolvedPayload },
           });
           break;
         }
@@ -142,7 +183,7 @@ const S3GovernancePlugin = {
           decisions.push({
             event,
             routes: [{ target: "source" }],
-            create: { kind: "proposal", payload: event.payload },
+            create: { kind: "proposal", payload: resolvedPayload },
           });
           break;
         }

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -24,6 +24,7 @@ import {
   type GroupWakeContext,
   type GroupWakeKind,
   type GovernanceItem,
+  type GovernanceTerminology,
   type MeetingAction,
   type ActionReceipt,
   type GovernanceTally,
@@ -469,37 +470,52 @@ export const runGroupWakeCommand = async (
     );
   }
 
+  // Resolve plugin terminology (for meeting prompts) and state graphs
+  // (for governance queue filtering). Both are read once up front from
+  // the --governance-plugin argument, if supplied.
+  let pluginTerminology: GovernanceTerminology | undefined;
+  const govPluginIdx = args.indexOf("--governance-plugin");
+  const govPluginPath = govPluginIdx >= 0 ? args[govPluginIdx + 1] : undefined;
+  let govPluginGraphs:
+    | readonly {
+        kind: string;
+        initialState: string;
+        terminalStates: readonly string[];
+        transitions: readonly { from: string; to: string; trigger: string }[];
+      }[]
+    | undefined;
+  if (govPluginPath) {
+    try {
+      const { pathToFileURL } = await import("node:url");
+      const pluginMod = (await import(pathToFileURL(resolve(govPluginPath)).href)) as {
+        default?: {
+          terminology?: GovernanceTerminology;
+          stateGraphs?: () => {
+            kind: string;
+            initialState: string;
+            terminalStates: readonly string[];
+            transitions: readonly { from: string; to: string; trigger: string }[];
+          }[];
+        };
+      };
+      pluginTerminology = pluginMod.default?.terminology;
+      govPluginGraphs = pluginMod.default?.stateGraphs?.();
+    } catch {
+      /* best effort — fall back to generic terminology + no graph validation */
+    }
+  }
+
   // Load governance queue if governance meeting (read-only — transitions
   // are applied by the daemon after this function returns)
   const governanceQueue: GovernanceItem[] = [];
   if (isGovernance) {
     const govStore = new GovernanceStateStore({
       persistDir: join(root, ".murmuration", "governance"),
+      readOnly: true,
     });
 
-    // Register governance plugin graphs so transitions validate correctly
-    const govPluginIdx = args.indexOf("--governance-plugin");
-    const govPluginPath = govPluginIdx >= 0 ? args[govPluginIdx + 1] : undefined;
-    if (govPluginPath) {
-      try {
-        const { pathToFileURL } = await import("node:url");
-        const pluginMod = (await import(pathToFileURL(resolve(govPluginPath)).href)) as {
-          default?: {
-            stateGraphs?: () => {
-              kind: string;
-              initialState: string;
-              terminalStates: readonly string[];
-              transitions: readonly { from: string; to: string; trigger: string }[];
-            }[];
-          };
-        };
-        const graphs = pluginMod.default?.stateGraphs?.() ?? [];
-        for (const g of graphs) {
-          govStore.registerGraph(g);
-        }
-      } catch {
-        /* best effort — transitions will be skipped if graphs aren't available */
-      }
+    if (govPluginGraphs) {
+      for (const g of govPluginGraphs) govStore.registerGraph(g);
     }
 
     await govStore.load();
@@ -557,6 +573,7 @@ export const runGroupWakeCommand = async (
     const { AgentStateStore } = await import("@murmurations-ai/core");
     const stateStore = new AgentStateStore({
       persistDir: join(root, ".murmuration", "agents"),
+      readOnly: true,
     });
     await stateStore.load();
     const agentMetrics = config.members.map((memberId) => {
@@ -589,6 +606,7 @@ export const runGroupWakeCommand = async (
     ...(directiveBody ? { directiveBody } : {}),
     ...(backlogForAgenda ? { backlogContext: backlogForAgenda } : {}),
     ...(retrospectiveMetrics ? { retrospectiveMetrics } : {}),
+    ...(pluginTerminology ? { terminology: pluginTerminology } : {}),
   };
 
   // Run the group wake

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -102,6 +102,7 @@ export const listSessions = async (): Promise<void> => {
     try {
       const store = new AgentStateStore({
         persistDir: join(session.root, ".murmuration", "agents"),
+        readOnly: true,
       });
       const loaded = await store.load();
       agentCount = loaded > 0 ? String(store.getAllAgents().length) : "0";

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -85,10 +85,32 @@ export class AgentStateStore implements IAgentStateStore {
   readonly #wakesByAgent = new Map<string, string[]>(); // agentId → wakeId[]
   readonly #persistDir: string | undefined;
   readonly #now: () => Date;
+  readonly #readOnly: boolean;
 
-  public constructor(options: { readonly persistDir?: string; readonly now?: () => Date } = {}) {
+  public constructor(
+    options: {
+      readonly persistDir?: string;
+      readonly now?: () => Date;
+      /**
+       * When `true`, mutation methods (`register`, `recordWakeOutcome`,
+       * `flush`) throw. CLI processes that read agent state while the
+       * daemon is running should pass `readOnly: true` — the daemon is
+       * the single writer (Engineering Standard #3). Default: `false`.
+       */
+      readonly readOnly?: boolean;
+    } = {},
+  ) {
     this.#persistDir = options.persistDir;
     this.#now = options.now ?? ((): Date => new Date());
+    this.#readOnly = options.readOnly ?? false;
+  }
+
+  #guardWrite(method: string): void {
+    if (this.#readOnly) {
+      throw new Error(
+        `AgentStateStore: ${method}() called on read-only instance. Only the daemon writes to state.json; CLI processes must RPC the daemon.`,
+      );
+    }
   }
 
   /** Load persisted state from disk. Call once at daemon start. */
@@ -124,6 +146,7 @@ export class AgentStateStore implements IAgentStateStore {
 
   /** Register an agent. Idempotent — re-registering preserves history. */
   public register(agentId: string, maxWallClockMs: number): void {
+    this.#guardWrite("register");
     const existing = this.#agents.get(agentId);
     if (existing) {
       // Update maxWallClockMs but preserve history
@@ -152,6 +175,7 @@ export class AgentStateStore implements IAgentStateStore {
 
   /** Transition an agent to a new state. */
   public transition(agentId: string, to: AgentLifecycleState, wakeId?: string): void {
+    this.#guardWrite("transition");
     const agent = this.#agents.get(agentId);
     if (!agent)
       throw new Error(
@@ -217,6 +241,7 @@ export class AgentStateStore implements IAgentStateStore {
       artifactCount?: number | undefined;
     } = {},
   ): void {
+    this.#guardWrite("recordWakeOutcome");
     const wake = this.#wakes.get(wakeId);
     if (!wake) return;
 

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -805,9 +805,12 @@ export class DaemonCommandExecutor {
     totalOutputTokens: number;
   }): Promise<{ itemId: string; to: string }[]> {
     const { governancePersistDir, governancePlugin } = this.#deps;
-    const resolveKeywords = ["resolve", "ratif", "approve", "adopt", "agree", "pass", "consent"];
+    // Core is governance-model-agnostic: delegate the "does this
+    // recommendation mean resolve?" question to the plugin.
+    // Without a plugin, nothing auto-resolves — operators ratify
+    // by explicit transition, not implicit keyword sniff.
     const shouldResolve = (text: string): boolean =>
-      resolveKeywords.some((kw) => text.toLowerCase().includes(kw));
+      governancePlugin?.isResolvingRecommendation?.(text) ?? false;
 
     try {
       const store = new GovernanceStateStore({

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -241,6 +241,7 @@ export class GovernanceStateStore implements IGovernanceStateStore {
   readonly #now: () => Date;
   readonly #persistDir: string | undefined;
   readonly #onSync: GovernanceSyncCallbacks | undefined;
+  readonly #readOnly: boolean;
   #persistPending: Promise<void> | null = null;
 
   public constructor(
@@ -248,11 +249,19 @@ export class GovernanceStateStore implements IGovernanceStateStore {
       readonly now?: () => Date;
       readonly persistDir?: string | undefined;
       readonly onSync?: GovernanceSyncCallbacks | undefined;
+      /**
+       * When `true`, `create` and `transition` throw instead of mutating
+       * state. Use for CLI processes that share the on-disk `items.jsonl`
+       * with a running daemon — the daemon is the single writer
+       * (Engineering Standard #3). Default: `false`.
+       */
+      readonly readOnly?: boolean;
     } = {},
   ) {
     this.#now = options.now ?? ((): Date => new Date());
     this.#persistDir = options.persistDir;
     this.#onSync = options.onSync;
+    this.#readOnly = options.readOnly ?? false;
   }
 
   /**
@@ -329,6 +338,11 @@ export class GovernanceStateStore implements IGovernanceStateStore {
     payload: unknown,
     options: { readonly reviewAt?: Date } = {},
   ): GovernanceItem {
+    if (this.#readOnly) {
+      throw new Error(
+        "GovernanceStateStore: create() called on read-only instance. Only the daemon writes to items.jsonl; CLI processes must RPC the daemon.",
+      );
+    }
     const graph = this.#graphs.get(kind);
     if (!graph) {
       throw new Error(`governance: no state graph registered for kind "${kind}"`);
@@ -377,6 +391,11 @@ export class GovernanceStateStore implements IGovernanceStateStore {
     triggeredBy: string,
     reason?: string,
   ): GovernanceItem {
+    if (this.#readOnly) {
+      throw new Error(
+        "GovernanceStateStore: transition() called on read-only instance. Only the daemon writes to items.jsonl; CLI processes must RPC the daemon.",
+      );
+    }
     const item = this.#items.get(itemId);
     if (!item) throw new Error(`governance: item "${itemId}" not found`);
 
@@ -645,6 +664,26 @@ export interface GovernancePlugin {
    * its own internal state.
    */
   onTransition?(item: GovernanceItem, transition: GovernanceStateTransition): void;
+
+  /**
+   * After a group meeting produces a tally recommendation, the daemon
+   * calls this hook to decide whether the referenced governance items
+   * should transition to a terminal state. Generic daemon code cannot
+   * know what "resolve" / "ratify" / "approve" mean in every governance
+   * model, so the plugin owns the decision.
+   *
+   * Return `true` when the recommendation implies the item is done;
+   * the daemon will walk the plugin's own state graph to find the
+   * nearest terminal transition. Return `false` (or omit the hook)
+   * to leave items in their current state — the daemon will not
+   * auto-resolve anything it can't attribute to the plugin.
+   *
+   * S3 interprets "ratify" / "approve" / "consent" / "resolve" /
+   * "adopt" as resolving. Chain of Command interprets "approve" /
+   * "execute". Parliamentary interprets "pass" / "adopt". None of
+   * these vocabularies belong in core.
+   */
+  isResolvingRecommendation?(recommendation: string): boolean;
 
   /**
    * Optional hook called once when the daemon starts. Unlike

--- a/packages/core/src/groups/index.ts
+++ b/packages/core/src/groups/index.ts
@@ -15,7 +15,8 @@
  */
 
 import type { Signal } from "../execution/index.js";
-import type { GovernanceItem } from "../governance/index.js";
+import type { GovernanceItem, GovernanceTerminology } from "../governance/index.js";
+import { DEFAULT_TERMINOLOGY } from "../governance/index.js";
 
 // ---------------------------------------------------------------------------
 // Group configuration (parsed from group docs)
@@ -76,9 +77,19 @@ export interface GroupWakeContext {
   readonly backlogContext?: string;
   /** Member identity summaries for peer review meetings. Map of agentId → role excerpt. */
   readonly memberIdentities?: ReadonlyMap<string, string>;
+  /**
+   * Display terms for human-facing prompt text (governance-model agnostic).
+   * Injected by the caller from the active `GovernancePlugin.terminology`.
+   * If absent, `DEFAULT_TERMINOLOGY` applies ("group" / "item" / etc.).
+   *
+   * Why it lives on the context, not hardcoded: core can't know whether the
+   * operator's governance model calls groups "circles" (S3), "departments"
+   * (chain of command), "committees" (parliamentary), or something else.
+   */
+  readonly terminology?: GovernanceTerminology;
 }
 
-/** A single agenda item for a circle meeting. */
+/** A single agenda item for a group meeting. */
 export interface AgendaItem {
   readonly title: string;
   readonly description: string;
@@ -399,6 +410,10 @@ export const runGroupWake = async (
   const contributions: MemberContribution[] = [];
   let totalInput = 0;
   let totalOutput = 0;
+  // Resolve display terms once per wake. The plugin's terminology (when
+  // supplied) overrides generic defaults; e.g. S3 maps `group -> "circle"`.
+  const terminology = context.terminology ?? DEFAULT_TERMINOLOGY;
+  const groupTerm = terminology.group;
 
   // =========================================================================
   // Phase 0: Agenda formation
@@ -462,7 +477,7 @@ ${memberInstructions}
 Keep your contribution focused and concise (3-5 paragraphs). Structure your response by agenda item.`;
 
     const response = await deps.callLLM({
-      systemPrompt: `You are agent ${memberId} participating in a ${context.kind} meeting of the ${context.groupId} circle. Your job is to address the meeting agenda — not to discuss anything outside of it.`,
+      systemPrompt: `You are agent ${memberId} participating in a ${context.kind} meeting of the ${context.groupId} ${groupTerm}. Your job is to address the meeting agenda — not to discuss anything outside of it.`,
       userPrompt,
       agentId: memberId,
       ...(signal ? { signal } : {}),
@@ -497,7 +512,7 @@ ${allContributions}
 
 ---
 
-You are ${context.facilitator}, the facilitator of the ${context.groupId} circle. Synthesize all member contributions into a meeting summary ORGANIZED BY AGENDA ITEM.
+You are ${context.facilitator}, the facilitator of the ${context.groupId} ${groupTerm}. Synthesize all member contributions into a meeting summary ORGANIZED BY AGENDA ITEM.
 
 ${
   context.kind === "governance"
@@ -534,7 +549,7 @@ Each action item MUST become a create-issue action with an "action-item" label a
 Only reference issue numbers that exist. Do not invent issue numbers.`;
 
   const synthesis = await deps.callLLM({
-    systemPrompt: `You are ${context.facilitator}, facilitator of the ${context.groupId} circle. Synthesize member contributions into clear decisions and action items organized by agenda item.`,
+    systemPrompt: `You are ${context.facilitator}, facilitator of the ${context.groupId} ${groupTerm}. Synthesize member contributions into clear decisions and action items organized by agenda item.`,
     userPrompt: facilitatorPrompt,
     agentId: context.facilitator,
     signal,
@@ -600,8 +615,9 @@ Only reference issue numbers that exist. Do not invent issue numbers.`;
 
 /** Build a meeting context header based on meeting kind. */
 function buildMeetingHeader(context: GroupWakeContext): string {
+  const groupTerm = (context.terminology ?? DEFAULT_TERMINOLOGY).group;
   if (context.kind === "governance") {
-    return `This is a GOVERNANCE MEETING for the ${context.groupId} circle.\n\nGovernance queue (${String(context.governanceQueue.length)} items):\n${
+    return `This is a GOVERNANCE MEETING for the ${context.groupId} ${groupTerm}.\n\nGovernance queue (${String(context.governanceQueue.length)} items):\n${
       context.governanceQueue
         .map((item) => {
           const issueNum = context.governanceIssueMap?.get(item.id);
@@ -612,9 +628,9 @@ function buildMeetingHeader(context: GroupWakeContext): string {
     }`;
   }
   if (context.kind === "retrospective" && context.retrospectiveMetrics) {
-    return `This is a RETROSPECTIVE for the ${context.groupId} circle.\n\nPeriod: ${context.retrospectiveMetrics.period}\n\n## Agent Metrics\n\n${context.retrospectiveMetrics.agentMetrics.map((m) => `  - ${m.agentId}: ${String(m.totalWakes)} wakes, ${String(m.totalArtifacts)} artifacts, ${String(m.idleWakes)} idle (${String(Math.round(m.idleRate * 100))}%), ${String(m.consecutiveFailures)} consecutive failures`).join("\n")}`;
+    return `This is a RETROSPECTIVE for the ${context.groupId} ${groupTerm}.\n\nPeriod: ${context.retrospectiveMetrics.period}\n\n## Agent Metrics\n\n${context.retrospectiveMetrics.agentMetrics.map((m) => `  - ${m.agentId}: ${String(m.totalWakes)} wakes, ${String(m.totalArtifacts)} artifacts, ${String(m.idleWakes)} idle (${String(Math.round(m.idleRate * 100))}%), ${String(m.consecutiveFailures)} consecutive failures`).join("\n")}`;
   }
-  return `This is an OPERATIONAL MEETING for the ${context.groupId} circle.`;
+  return `This is an OPERATIONAL MEETING for the ${context.groupId} ${groupTerm}.`;
 }
 
 /** Format agenda items as a numbered list for prompts. */
@@ -679,16 +695,17 @@ async function generateAgenda(
           .join("\n")}`
       : "";
 
-  const userPrompt = `You are ${context.facilitator}, facilitator of the ${context.groupId} circle. Generate the meeting agenda.
+  const groupTerm = (context.terminology ?? DEFAULT_TERMINOLOGY).group;
+  const userPrompt = `You are ${context.facilitator}, facilitator of the ${context.groupId} ${groupTerm}. Generate the meeting agenda.
 
-Review the governance queue, open issues, and signals below. Propose 3-5 focused agenda items for this ${context.kind} meeting. Each item should be actionable — something the circle can decide or act on in this meeting.
+Review the governance queue, open issues, and signals below. Propose 3-5 focused agenda items for this ${context.kind} meeting. Each item should be actionable — something the ${groupTerm} can decide or act on in this meeting.
 ${govSection}${backlogSection}${signalSection}
 
 ---
 
 Output the agenda as a numbered list. For each item:
 - A clear, specific title
-- One sentence describing what the circle needs to decide or do
+- One sentence describing what the ${groupTerm} needs to decide or do
 
 Format:
 1. **Title**: Description
@@ -698,7 +715,7 @@ Format:
 Keep it to 3-5 items maximum. Prioritize by urgency and impact.`;
 
   const response = await deps.callLLM({
-    systemPrompt: `You are ${context.facilitator}, facilitator of the ${context.groupId} circle. Generate a focused meeting agenda. Be specific and actionable — no generic items.`,
+    systemPrompt: `You are ${context.facilitator}, facilitator of the ${context.groupId} ${groupTerm}. Generate a focused meeting agenda. Be specific and actionable — no generic items.`,
     userPrompt,
     agentId: context.facilitator,
     ...(signal ? { signal } : {}),

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -484,24 +484,17 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
     const outputs: AgentOutputArtifact[] = [];
     const governanceEvents: EmittedGovernanceEvent[] = [];
 
-    // 11. Parse governance event with type detection
+    // 11. Emit governance event. Core stays generic — the active
+    // GovernancePlugin decides what kind of item (if any) to create
+    // in its `onEventsEmitted` handler. The raw agent text goes in
+    // `payload.topic` verbatim; any model-specific prefix parsing
+    // (e.g. S3's `TENSION:` / `PROPOSAL:` / `REPORT:`) belongs to
+    // the plugin, not to core.
     if (reflection.governanceEvent) {
-      let govKind = "agent-governance-event";
-      let govTopic = reflection.governanceEvent;
-      if (govTopic.startsWith("PROPOSAL:")) {
-        govKind = "proposal-opened";
-        govTopic = govTopic.slice("PROPOSAL:".length).trim();
-      } else if (govTopic.startsWith("TENSION:")) {
-        govKind = "tension";
-        govTopic = govTopic.slice("TENSION:".length).trim();
-      } else if (govTopic.startsWith("REPORT:")) {
-        govKind = "report";
-        govTopic = govTopic.slice("REPORT:".length).trim();
-      }
       governanceEvents.push({
-        kind: govKind,
+        kind: "agent-governance-event",
         payload: {
-          topic: govTopic,
+          topic: reflection.governanceEvent,
           observation: reflection.observation,
           effectiveness: reflection.effectiveness,
           agentId,

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -270,7 +270,12 @@ describe("createDefaultRunner", () => {
 
     expect(result.governanceEvents).toBeDefined();
     expect(result.governanceEvents!.length).toBeGreaterThanOrEqual(1);
-    expect(result.governanceEvents![0]?.kind).toBe("tension");
+    // Core emits generic "agent-governance-event"; the governance plugin
+    // decides the concrete kind (tension / proposal / report / …) in its
+    // onEventsEmitted handler. This keeps core governance-model-agnostic.
+    expect(result.governanceEvents![0]?.kind).toBe("agent-governance-event");
+    const payload = result.governanceEvents![0]?.payload as { topic?: string } | undefined;
+    expect(payload?.topic).toContain("TENSION:");
   });
 });
 


### PR DESCRIPTION
Core is now governance-model-agnostic. All S3-specific vocabulary lives in the S3 plugin.

## Blockers resolved

1. **Terminology threaded through group meetings** — `GroupWakeContext.terminology` replaces hardcoded "circle". Plugin's `terminology` export is loaded in the convene path.
2a. **TENSION/PROPOSAL/REPORT parsing** — core emits generic `agent-governance-event`; S3 plugin parses prefixes in `onEventsEmitted`.
2b. **resolveKeywords heuristic** — moved to optional `GovernancePlugin.isResolvingRecommendation()` hook. S3 plugin implements it. Plugin-less harness no longer auto-resolves on keyword match.
3. **Single-writer state stores** — `readOnly: true` option on `GovernanceStateStore` and `AgentStateStore` makes mutation methods throw. All CLI instantiations (bin.ts, group-wake.ts, sessions.ts) pass it. Daemon's instantiations remain writable. Engineering Standard #3 code-enforced.

## Tests

650 pass. One test updated.