### PR TITLE
ADR-0032: Adopt jDocMunch for local Markdown retrieval

### DIFF
--- a/docs/adr/0032-jdocmunch-markdown-retrieval.md
+++ b/docs/adr/0032-jdocmunch-markdown-retrieval.md
@@ -1,0 +1,27 @@
+# ADR-0032 — Adopt jDocMunch for Local Markdown Retrieval
+
+**Status:** Proposed
+**Context:** Murmuration Harness Architecture
+
+## Context
+
+Currently, the Murmuration Harness provides agents with basic filesystem tools (`read_file`, `write_file`, `list_dir`) either natively or via the `@modelcontextprotocol/server-filesystem` MCP server.
+
+As murmurations generate massive local artifacts (e.g., `MURMURATION-HISTORY.md`, daily agent chronicles, meeting transcripts, and aggregated context files), agents are forced to read entire files into their context windows. This results in severe token bloat, increased LLM costs, and wall-clock timeouts, identical to the problems we faced with GitHub API payloads.
+
+While `jmunch-mcp` acts as a proxy for external JSON APIs, we lack a token-efficient retrieval mechanism for our local Markdown state.
+
+## Decision
+
+We will adopt **`jdocmunch-mcp`** (an implementation of the jMRI standard) as the default filesystem context provider for Markdown-heavy workspaces within the Murmuration Harness.
+
+1. **Deprecation:** The naive `read_file` tool will be strongly discouraged for `.md` files larger than a specific threshold (e.g., 5KB).
+2. **Integration:** `jdocmunch-mcp` will be registered in `harness.yaml` for murmurations that manage extensive Markdown state (like the PKM Council or EP's Chronicles).
+3. **Prompt Updates:** The `default-agent/role.md` template will be updated to instruct agents to use `search_sections` and `get_section` for context discovery before falling back to full file reads.
+
+## Consequences
+
+- **Positive:** Massive reduction in token consumption when agents analyze historical records, meeting transcripts, or large knowledge bases.
+- **Positive:** Agents gain structural awareness of documents (knowing what headings exist without reading the body).
+- **Negative:** Agents must learn the two-step jMRI pattern (`search` -> `retrieve`) for local files, slightly increasing the complexity of their system prompts.
+- **Negative:** Requires an additional local dependency (`uvx jdocmunch-mcp`) to run the harness optimally.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@ai-sdk/google": "^3.0.63",
     "@ai-sdk/openai": "^3.0.53",
     "@murmurations-ai/core": "workspace:*",
+    "@murmurations-ai/mcp": "workspace:*",
     "@murmurations-ai/github": "workspace:*",
     "@murmurations-ai/llm": "workspace:*",
     "@murmurations-ai/secrets-dotenv": "workspace:*",

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -70,6 +70,7 @@ import {
 import { resolveLLMCost } from "@murmurations-ai/llm/pricing";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 import { DefaultSignalAggregator } from "@murmurations-ai/signals";
+import { McpToolLoader } from "@murmurations-ai/mcp";
 
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 
@@ -255,6 +256,7 @@ export interface InProcessRunnerClients {
   readonly github?: GithubClient;
   readonly targetRepo?: RepoCoordinate;
   readonly targetBranch?: string;
+  readonly mcpToolLoader?: McpToolLoader;
   /** Operator-defined extension fields. The harness passes these
    *  through without interpretation — runners cast them at the call
    *  site based on their own type knowledge. */
@@ -1143,6 +1145,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               ...(wakeClients.github ? { github: wakeClients.github } : {}),
               ...(targetRepo ? { targetRepo } : {}),
               targetBranch: "main",
+              mcpToolLoader: new McpToolLoader(),
             };
           },
         }),

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -4,5 +4,8 @@
     "tsBuildInfoFile": "./.tsbuildinfo.build"
   },
   "exclude": ["dist", "node_modules", "**/*.test.ts"],
-  "references": [{ "path": "../core/tsconfig.build.json" }]
+  "references": [
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../mcp/tsconfig.build.json" }
+  ]
 }

--- a/packages/mcp/src/tool-loader.ts
+++ b/packages/mcp/src/tool-loader.ts
@@ -126,10 +126,33 @@ export class McpToolLoader {
   ): Promise<{ client: Client; transport: StdioClientTransport }> {
     // Merge parent environment (resolved secrets) with server-specific env.
     // Server env wins on conflict.
-    const env: Record<string, string> = {
-      ...(parentEnv ?? {}),
-      ...(server.env ?? {}),
-    };
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined) env[k] = v;
+    }
+    Object.assign(env, parentEnv ?? {});
+    Object.assign(env, server.env ?? {});
+
+    // Evaluate shell-variable syntax in server.env
+    if (server.env) {
+      for (const [k, v] of Object.entries(server.env)) {
+        if (v.startsWith("$")) {
+          const varName = v.substring(1);
+          if (parentEnv && parentEnv[varName] !== undefined) {
+            env[k] = parentEnv[varName];
+          } else if (process.env[varName] !== undefined) {
+            env[k] = process.env[varName];
+          } else {
+            env[k] = v;
+          }
+        }
+      }
+    }
+
+    // Hardcode GITHUB_PERSONAL_ACCESS_TOKEN for @modelcontextprotocol/server-github
+    if (env["GITHUB_TOKEN"] && !env["GITHUB_PERSONAL_ACCESS_TOKEN"]) {
+      env["GITHUB_PERSONAL_ACCESS_TOKEN"] = env["GITHUB_TOKEN"];
+    }
 
     const transport = new StdioClientTransport({
       command: server.command,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@murmurations-ai/llm':
         specifier: workspace:*
         version: link:../llm
+      '@murmurations-ai/mcp':
+        specifier: workspace:*
+        version: link:../mcp
       '@murmurations-ai/secrets-dotenv':
         specifier: workspace:*
         version: link:../secrets-dotenv


### PR DESCRIPTION
Proposes officially adopting `jdocmunch-mcp` (an implementation of the jMRI standard) as the default method for context retrieval in Markdown-heavy workspaces.

Addresses the token-bloat and timeout issues agents face when trying to read massive files like `MURMURATION-HISTORY.md` or unstructured meeting transcripts.