### PR TITLE
fix(signals): pass full signal content; reserve slicing for runaway-payload guard only

### DIFF
--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -77,8 +77,27 @@ export interface DefaultSignalAggregatorConfig {
 // Text hygiene — bounds + control-char scrub
 // ---------------------------------------------------------------------------
 
-const EXCERPT_MAX_CHARS = 500;
-const SUMMARY_MAX_CHARS = 300;
+/**
+ * Default policy: pass full signal content through to the agent. Modern
+ * LLM context windows (≥1M tokens for current frontier models) make
+ * 500-char-style summary truncation more harmful than helpful — it
+ * silently corrupts authoritative content (live case 2026-04-30: a
+ * 2800-char source-directive lost its per-agent task definitions and
+ * agents honestly reported "the signal excerpt is missing details").
+ *
+ * The caps below are runaway-payload guards, not summarization. They
+ * fire only on extreme content (e.g., a malformed source dumping a
+ * binary blob into an issue body). When a real summary IS needed —
+ * that is, when an agent genuinely cannot use the full content — the
+ * right shape is LLM-driven summarization, NOT substring slicing with
+ * a `[...]` suffix. Slicing produces incoherent excerpts that drop
+ * critical detail; summarization preserves intent.
+ *
+ * Tracked as a follow-up: replace `sanitizeText` slice fallback with
+ * an LLM summarizer once an aggregator-side LLM client is available.
+ */
+const EXCERPT_MAX_CHARS = 64_000;
+const SUMMARY_MAX_CHARS = 8_000;
 // eslint-disable-next-line no-control-regex
 const CONTROL_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -327,6 +327,52 @@ describe("DefaultSignalAggregator", () => {
     }
   });
 
+  it("issue body content reaches the agent intact for normal-sized payloads", async () => {
+    // Live regression 2026-04-30: a 2800-char source-directive body was
+    // truncated to 500 chars, dropping per-agent task definitions. Modern
+    // context windows make summary-style truncation harmful by default —
+    // pass full content through and reserve slicing for runaway-payload
+    // protection only.
+    const longBody = `**Header**\n\n${"x".repeat(2500)}\n\n**Per-agent asks below.**`;
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub([fakeIssue({ body: longBody, labels: ["source-directive"] })]),
+      githubScopes: [{ repo: REPO }],
+    });
+    const result = await agg.aggregate(mkContext("07-wren"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const signal = result.bundle.signals[0];
+      expect(signal?.kind).toBe("github-issue");
+      if (signal?.kind === "github-issue") {
+        expect(signal.excerpt.length).toBeGreaterThan(2500);
+        expect(signal.excerpt).toContain("Per-agent asks below.");
+        expect(signal.excerpt).not.toContain("[...]");
+      }
+    }
+  });
+
+  it("only at extreme size does runaway-payload protection slice the excerpt", async () => {
+    // The cap exists as a defense-in-depth runaway guard. It should not
+    // fire for any reasonable directive or issue body. When it does fire,
+    // operators see [...] as the explicit "this was truncated" marker.
+    const runaway = "z".repeat(70_000); // > 64K cap
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub([fakeIssue({ body: runaway, labels: ["bug"] })]),
+      githubScopes: [{ repo: REPO }],
+    });
+    const result = await agg.aggregate(mkContext("07-wren"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const signal = result.bundle.signals[0];
+      if (signal?.kind === "github-issue") {
+        expect(signal.excerpt.length).toBeLessThan(70_000);
+        expect(signal.excerpt).toContain("[...]");
+      }
+    }
+  });
+
   it("control characters are stripped from excerpts", async () => {
     const agg = new DefaultSignalAggregator({
       rootDir,


### PR DESCRIPTION
## Summary

The signal aggregator was silently truncating issue bodies and private notes to ~500 / 300 chars via substring slicing with a \`[...]\` suffix. Modern frontier LLMs have ≥1M-token context; this kind of summary-style truncation is a relic of the GPT-3 era and now silently corrupts authoritative content.

## Live discovery

2026-04-30: a 2800-char source-directive ([EP #631](https://github.com/xeeban/emergent-praxis/issues/631)) was filed for the engineering circle with per-agent task definitions. The aggregator delivered only the first 500 chars to each agent. Half the circle reported "the per-agent ask is missing from the signal excerpt" (correct, honest reporting) and could not begin work. After this fix, agents receive the full directive content and either complete the task or honestly abstain on the actual blocker (e.g., missing tool capability).

## Changes

- \`EXCERPT_MAX_CHARS\`: 500 → 64,000 (≈16K tokens — runaway-payload guard, not summarization)
- \`SUMMARY_MAX_CHARS\`: 300 → 8,000 (same)
- Comment updated to document the principle: default to full content; slicing is defense-in-depth against a malformed source dumping a binary blob, not a content-shaping mechanism
- Two new tests: full content reaches agent for normal sizes; runaway >64K still slices with \`[...]\` marker

## Follow-up (out of scope here)

When summarization IS needed (extreme-size payloads, semi-trusted external sources), the right shape is LLM-driven summarization — not substring slicing with \`[...]\`. Needs an aggregator-side LLM client that doesn't exist yet.

## Test plan

- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint\` (0 errors)
- [x] \`pnpm run format:check\`
- [x] \`pnpm run test\` — 682 pass, 1 skipped
- [x] Live re-verification against EP #631: typescript-runtime-agent now receives the full per-agent ask (was previously blocked at "specific task is not included in the excerpt")

🤖 Generated with [Claude Code](https://claude.com/claude-code)