### PR TITLE
fix: agents now actually call tools instead of narrating about them (B5 root cause)

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -957,22 +957,33 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
    * Backward compat: when `agent.plugins` is empty, return all loaded
    * extension tools (matches pre-gating behavior).
    *
-   * Local-governance auto-include: when the murmuration uses the local
-   * `CollaborationProvider`, agents need file access to record
-   * governance artifacts (proposals, decisions, tensions). Without
-   * file-writes they can't participate in governance. So we auto-grant
-   * the built-in `files` plugin to every agent that has declared any
-   * plugins at all — the agent still sees their other declared plugins
-   * explicitly; we just add `files` on top. Empty declaration still
-   * gets everything via the backward-compat path.
+   * Built-in tool auto-include: every agent gets `files` + `memory` on
+   * top of any plugins they declare. These two are floor capabilities
+   * — agents need file access to read repo docs / write artifacts, and
+   * memory access to persist state across wakes (ADR-0029). Without
+   * them an agent reaches the LLM with an empty tool catalog and can
+   * only narrate (Boundary 5 hallucination shape).
+   *
+   * History: this auto-include used to fire only for the local
+   * collaboration provider, on the (incorrect) reasoning that github
+   * agents posted everything to GitHub and didn't need filesystem.
+   * Live discovery 2026-04-30: every wake of every EP engineering
+   * agent (github collab) produced `tool_calls: 0` because their
+   * declared plugin (`github-extras` — phantom, not actually loaded)
+   * filtered the tool set down to nothing. The runner reached the LLM
+   * with `tools=undefined`, which collapses the agent into pure
+   * narrative output — exactly the ARCHITECTURE.md §12 anti-pattern
+   * the harness exists to detect.
+   *
+   * Empty plugins declaration still gets the full extension tool set
+   * via the backward-compat path below.
    */
   const selectExtensionToolsFor = (
     agent: RegisteredAgent,
     agentDir: string,
   ): readonly (typeof extensionTools)[number][] => {
     // ADR-0029: memory is agent-scoped — tools are built per-agent,
-    // not shared across agents. Emit them whenever the agent declared
-    // memory explicitly OR when local-gov auto-includes them.
+    // not shared across agents.
     const buildAgentBoundMemory = (): readonly (typeof extensionTools)[number][] =>
       buildMemoryToolsForAgent({
         rootDir: exampleRoot,
@@ -980,14 +991,9 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       }) as readonly (typeof extensionTools)[number][];
 
     if (agent.plugins.length === 0) {
-      // Backward compat: agents with no explicit declaration see the
-      // shared extension tools. Memory is agent-bound so we add
-      // per-agent tools on top only when local-gov makes it
-      // automatic.
-      if (config.collaboration.provider === "local") {
-        return [...extensionTools, ...buildAgentBoundMemory()];
-      }
-      return extensionTools;
+      // Backward compat: agents with no explicit declaration see all
+      // shared extension tools + per-agent memory tools.
+      return [...extensionTools, ...buildAgentBoundMemory()];
     }
 
     const declared = new Set<string>();
@@ -997,23 +1003,22 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       const last = parts[parts.length - 1];
       if (last !== undefined && parts.length > 1) declared.add(last);
     }
-    if (config.collaboration.provider === "local") {
-      declared.add("files");
-      declared.add("@murmurations-ai/files");
-      declared.add("memory");
-      declared.add("@murmurations-ai/memory");
-    }
+    // Auto-include floor capabilities for every agent regardless of
+    // collaboration provider. There is no legitimate scenario today
+    // for waking an agent with zero tools; an opt-out mechanism can
+    // be added if a use case emerges.
+    declared.add("files");
+    declared.add("@murmurations-ai/files");
+    declared.add("memory");
+    declared.add("@murmurations-ai/memory");
 
     const sharedTools = loadedExtensions
       .filter((ext) => declared.has(ext.id))
       .flatMap((ext) => ext.tools);
 
-    // Attach per-agent memory tools if the memory plugin is declared
-    // (either explicitly or via the local-gov auto-include above).
-    if (declared.has("memory") || declared.has("@murmurations-ai/memory")) {
-      return [...sharedTools, ...buildAgentBoundMemory()];
-    }
-    return sharedTools;
+    // Attach per-agent memory tools — memory is auto-included above
+    // for all agents, so this branch always fires.
+    return [...sharedTools, ...buildAgentBoundMemory()];
   };
 
   // -------------------------------------------------------------------

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -370,11 +370,35 @@ export function createDefaultRunner(
         ? `\n\n_Wake mode: ${wakeMode} — you are participating in a group meeting. Contribute your perspective; do NOT execute action items._`
         : "";
 
-    // 7. Capabilities
+    // 7a. Load tools first — the system prompt needs to surface them
+    //     so the LLM uses tool calls instead of narration. Live
+    //     regression 2026-04-30: 7 tools threaded via the API but
+    //     tool_calls: 0 across Gemini and Anthropic because the prompt
+    //     never told the LLM the tools existed (Boundary 5 root cause).
+    const allTools: RunnerToolDefinition[] = [];
+    if (options.extensionTools && options.extensionTools.length > 0) {
+      allTools.push(...options.extensionTools);
+    }
+    const mcpConfigs = spawn.mcpServerConfigs ?? [];
+    if (clients.mcpToolLoader && mcpConfigs.length > 0) {
+      const mcpTools = await clients.mcpToolLoader.loadTools(mcpConfigs, spawn.environment);
+      allTools.push(...mcpTools);
+    }
+    const tools: RunnerToolDefinition[] | undefined = allTools.length > 0 ? allTools : undefined;
+
+    // 7b. Capabilities — including the live tool inventory.
     const caps = spawn.capabilities;
+    const toolsBlock =
+      tools && tools.length > 0
+        ? `\n### Tools you can call this wake\n${tools
+            .map((t) => `- \`${t.name}\`${t.description ? ` — ${t.description}` : ""}`)
+            .join(
+              "\n",
+            )}\n\nThese are real tool calls. **Use them** — do not narrate "I will read X" or "I would post Y." Either call the tool to do the work, or file a GOVERNANCE_EVENT explaining the specific blocker that prevents the call. Narrating an action without calling its tool is a Boundary 5 hallucination and will be flagged in your wake artifacts.`
+        : `\n### Tools you can call this wake\n_None._ If your task requires a tool you don't have, file a GOVERNANCE_EVENT requesting the capability rather than narrating fictional completion.`;
     const capsBlock = caps
-      ? `\n\n## Your Capabilities\nIf any capability you need to fulfill your role is missing, file a GOVERNANCE_EVENT requesting it.\n### GitHub\n- Commit files: ${caps.github.canCommit ? `YES (paths: ${caps.github.commitPaths.join(", ")})` : "NO"}\n- Comment on issues: ${caps.github.canCommentIssues ? "YES" : "NO"}\n- Create issues: ${caps.github.canCreateIssues ? "YES" : "NO"}\n- Label issues: ${caps.github.canLabelIssues ? "YES" : "NO"}${caps.cliTools.length > 0 ? `\n### CLI Tools\n${caps.cliTools.map((t) => `- ${t}`).join("\n")}` : ""}${caps.mcpServers.length > 0 ? `\n### MCP Servers\n${caps.mcpServers.map((s) => `- ${s}`).join("\n")}` : ""}\n### Signal Sources\n${caps.signalSources.map((s) => `- ${s}`).join("\n") || "- (none configured)"}`
-      : "";
+      ? `\n\n## Your Capabilities\nIf any capability you need to fulfill your role is missing, file a GOVERNANCE_EVENT requesting it.\n### GitHub\n- Commit files: ${caps.github.canCommit ? `YES (paths: ${caps.github.commitPaths.join(", ")})` : "NO"}\n- Comment on issues: ${caps.github.canCommentIssues ? "YES" : "NO"}\n- Create issues: ${caps.github.canCreateIssues ? "YES" : "NO"}\n- Label issues: ${caps.github.canLabelIssues ? "YES" : "NO"}${caps.cliTools.length > 0 ? `\n### CLI Tools\n${caps.cliTools.map((t) => `- ${t}`).join("\n")}` : ""}${caps.mcpServers.length > 0 ? `\n### MCP Servers\n${caps.mcpServers.map((s) => `- ${s}`).join("\n")}` : ""}\n### Signal Sources\n${caps.signalSources.map((s) => `- ${s}`).join("\n") || "- (none configured)"}${toolsBlock}`
+      : toolsBlock;
 
     // 8. Assemble user prompt
     const dayUtc = new Date().toISOString().slice(0, 10);
@@ -404,24 +428,7 @@ GOVERNANCE_EVENT: none — OR one of:
 If you were asked to draft a proposal (e.g. an action item saying "draft proposal for X"), file it as PROPOSAL: <your proposal>
 `;
 
-    // 9. Load tools: extensions (ADR-0023) + MCP (ADR-0020 Phase 3)
-    const allTools: RunnerToolDefinition[] = [];
-
-    // Extension tools (loaded at boot, available to all agents)
-    if (options.extensionTools && options.extensionTools.length > 0) {
-      allTools.push(...options.extensionTools);
-    }
-
-    // MCP tools (per-agent, loaded at wake time)
-    const mcpConfigs = spawn.mcpServerConfigs ?? [];
-    if (clients.mcpToolLoader && mcpConfigs.length > 0) {
-      const mcpTools = await clients.mcpToolLoader.loadTools(mcpConfigs, spawn.environment);
-      allTools.push(...mcpTools);
-    }
-
-    const tools: RunnerToolDefinition[] | undefined = allTools.length > 0 ? allTools : undefined;
-
-    // 10. Call LLM
+    // 9. Call LLM (tools loaded above as section 7a)
     const llmModel =
       spawn.identity.frontmatter.modelTier === "fast"
         ? "gemini-2.5-flash"


### PR DESCRIPTION
## Summary

Root cause of every \`tool_calls: 0\` wake observed today and the entire Boundary 5 hallucination class. Two compounding bugs:

### Bug 1: built-in tools filtered out for github-collab agents
\`packages/cli/src/boot.ts\` \`selectExtensionToolsFor\` auto-included \`files\` + \`memory\` only when collaboration.provider was \`local\`. EP agents (github collab) declared a phantom \`github-extras\` plugin that doesn't exist anywhere in the codebase, so the filter resolved to empty. The runner reached the LLM with \`tools=undefined\`.

### Bug 2: system prompt never listed actual tool inventory
\`packages/core/src/runner/index.ts\` capabilities block listed GitHub permissions, CLI tools, MCP servers, signal sources — but never the extension tools threaded into the LLM's API request. So even when tools WERE passed (after fixing bug 1), the prompt didn't tell the LLM they existed. Both Gemini 2.5 Pro and Claude Sonnet 4.5 defaulted to pure narration.

## Live verification

\`\`\`
Before fix:  tool_calls: 0, steps: 1/256, 27K input tokens — pure narration
After  fix:  tool_calls: 1, steps: 2/256, 49K input tokens — tool call → response
\`\`\`

The agent attempted \`read_file\` on a path outside its murmuration scope, learned the scope boundary, adapted, and filed a real TENSION about the actual capability gap (read access to a sister repo) instead of the phantom narrative one. Honest abstention with structured evidence — exactly what ARCHITECTURE.md §12 / Boundary 5 prescribes.

## Test plan

- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint\` (0 errors, 25 pre-existing warnings)
- [x] \`pnpm run format:check\`
- [x] \`pnpm run test\` — 680 pass, 1 skipped
- [x] Live wake against EP murmuration with anthropic provider — confirmed \`tool_calls: 1\`

## Related

- harness#246 — investigation issue. Hypothesis #2 (tools registered but not threaded) and hypothesis #3 (prompt biases narration) BOTH confirmed; bug 1 is hypothesis #2, bug 2 is hypothesis #3.
- harness#240 — B5 Phase 1 detection (merged) — the symptom-detection layer that exists precisely because the underlying bug here was hard to find.
- harness#247 — directive CLI fix (merged) — separate fix uncovered during the same investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)