### PR TITLE
fix(pricing): populate catalog with current models + warn on unknown (#251)

### DIFF
--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for boot.ts exported helpers. Today this file only covers
+ * `makeDaemonHook` — the rest of `boot.ts` is exercised through the
+ * daemon test suite and integration paths.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeAgentId, makeWakeId, WakeCostBuilder } from "@murmurations-ai/core";
+
+import { makeDaemonHook } from "./boot.js";
+
+describe("makeDaemonHook", () => {
+  const builder = (): WakeCostBuilder =>
+    WakeCostBuilder.start({
+      wakeId: makeWakeId("test-wake"),
+      agentId: makeAgentId("test-agent"),
+      modelTier: "balanced",
+      groupIds: [],
+    });
+
+  const fakeLogger = (): {
+    warn: (event: string, fields?: Record<string, unknown>) => void;
+    calls: { event: string; fields?: Record<string, unknown> }[];
+  } => {
+    const calls: { event: string; fields?: Record<string, unknown> }[] = [];
+    return {
+      warn: (event, fields) => {
+        if (fields !== undefined) calls.push({ event, fields });
+        else calls.push({ event });
+      },
+      calls,
+    };
+  };
+
+  it("prices a known model and does not warn", () => {
+    const log = fakeLogger();
+    const hook = makeDaemonHook(builder(), log);
+    hook.onLlmCall({
+      provider: "openai",
+      model: "gpt-5.5",
+      inputTokens: 1_000,
+      outputTokens: 1_000,
+    });
+    expect(log.calls).toHaveLength(0);
+  });
+
+  it("warns once for an unknown model, then dedupes", () => {
+    const log = fakeLogger();
+    const hook = makeDaemonHook(builder(), log);
+    for (let i = 0; i < 5; i++) {
+      hook.onLlmCall({
+        provider: "openai",
+        model: "gpt-5.99-imaginary",
+        inputTokens: 100,
+        outputTokens: 100,
+      });
+    }
+    expect(log.calls).toHaveLength(1);
+    expect(log.calls[0]?.event).toBe("daemon.cost.pricing.unknown");
+    expect(log.calls[0]?.fields).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.99-imaginary",
+      code: "unknown-model",
+    });
+  });
+
+  it("warns separately for each unknown (provider, model) pair", () => {
+    const log = fakeLogger();
+    const hook = makeDaemonHook(builder(), log);
+    hook.onLlmCall({
+      provider: "openai",
+      model: "fake-a",
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    hook.onLlmCall({
+      provider: "anthropic",
+      model: "fake-b",
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    hook.onLlmCall({
+      provider: "openai",
+      model: "fake-a",
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    expect(log.calls).toHaveLength(2);
+  });
+
+  it("does not throw when no logger is supplied (boot validation pass)", () => {
+    const hook = makeDaemonHook(builder());
+    expect(() =>
+      hook.onLlmCall({
+        provider: "openai",
+        model: "fake",
+        inputTokens: 1,
+        outputTokens: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  it("still records token counts when pricing is unknown (cost as 0)", () => {
+    const log = fakeLogger();
+    const b = builder();
+    const hook = makeDaemonHook(b, log);
+    hook.onLlmCall({
+      provider: "openai",
+      model: "fake",
+      inputTokens: 7_000,
+      outputTokens: 1_500,
+    });
+    const record = b.finalize(new Date());
+    expect(record.llm.inputTokens).toBe(7_000);
+    expect(record.llm.outputTokens).toBe(1_500);
+    expect(record.llm.costMicros.value).toBe(0);
+  });
+});

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -50,6 +50,7 @@ import {
   type RegisteredAgent,
   type SecretDeclaration,
   type SecretKey,
+  type USDMicros,
   type SignalAggregator,
   type SubprocessCommand,
   type WakeCostBuilder,
@@ -91,34 +92,60 @@ const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
  * ADR-0015 catalog at emit time. Exported so future per-wake executors
  * can build one hook per `WakeCostBuilder` without re-implementing the
  * catalog lookup. See ADR-0014 §Cost hook contract.
+ *
+ * When the (provider, model) pair isn't in the catalog the call still
+ * lands as `costMicros: 0` — hard-failing here would swallow a
+ * successful LLM call on a catalog gap. But silent zeros let stale
+ * catalog entries hide for weeks (harness#251). The optional `logger`
+ * argument fires a one-shot `daemon.cost.pricing.unknown` warn the
+ * first time each pair is seen, with dedupe state held on the hook
+ * instance so test wakes don't bleed into each other.
  */
-export const makeDaemonHook = (builder: WakeCostBuilder): LLMCostHook => ({
-  onLlmCall: (call) => {
-    const priced = resolveLLMCost({
-      provider: call.provider,
-      model: call.model,
-      inputTokens: call.inputTokens,
-      outputTokens: call.outputTokens,
-      ...(call.cacheReadTokens !== undefined ? { cacheReadTokens: call.cacheReadTokens } : {}),
-      ...(call.cacheWriteTokens !== undefined ? { cacheWriteTokens: call.cacheWriteTokens } : {}),
-    });
-    // Pricing errors (unknown model, negative tokens) degrade to a
-    // zero-cost record — the token counts still post to the builder,
-    // the observability event still fires, and the boot-time warn
-    // catches misconfiguration before a real wake. Hard-failing here
-    // would swallow a successful LLM call on a pricing catalog gap.
-    const costMicros = priced.ok ? priced.value : makeUSDMicros(0);
-    builder.addLlmTokens({
-      inputTokens: call.inputTokens,
-      outputTokens: call.outputTokens,
-      ...(call.cacheReadTokens !== undefined ? { cacheReadTokens: call.cacheReadTokens } : {}),
-      ...(call.cacheWriteTokens !== undefined ? { cacheWriteTokens: call.cacheWriteTokens } : {}),
-      modelProvider: call.provider,
-      modelName: call.model,
-      costMicros,
-    });
-  },
-});
+export const makeDaemonHook = (
+  builder: WakeCostBuilder,
+  logger?: { warn: (event: string, fields?: Record<string, unknown>) => void },
+): LLMCostHook => {
+  const warned = new Set<string>();
+  return {
+    onLlmCall: (call) => {
+      const priced = resolveLLMCost({
+        provider: call.provider,
+        model: call.model,
+        inputTokens: call.inputTokens,
+        outputTokens: call.outputTokens,
+        ...(call.cacheReadTokens !== undefined ? { cacheReadTokens: call.cacheReadTokens } : {}),
+        ...(call.cacheWriteTokens !== undefined ? { cacheWriteTokens: call.cacheWriteTokens } : {}),
+      });
+      let costMicros: USDMicros;
+      if (priced.ok) {
+        costMicros = priced.value;
+      } else {
+        costMicros = makeUSDMicros(0);
+        const key = `${call.provider}:${call.model}`;
+        if (logger && !warned.has(key)) {
+          warned.add(key);
+          logger.warn("daemon.cost.pricing.unknown", {
+            provider: call.provider,
+            model: call.model,
+            code: priced.error.code,
+            message: priced.error.message,
+            impact:
+              "wake cost reports as $0 until this model is added to packages/llm/src/pricing/catalog.ts",
+          });
+        }
+      }
+      builder.addLlmTokens({
+        inputTokens: call.inputTokens,
+        outputTokens: call.outputTokens,
+        ...(call.cacheReadTokens !== undefined ? { cacheReadTokens: call.cacheReadTokens } : {}),
+        ...(call.cacheWriteTokens !== undefined ? { cacheWriteTokens: call.cacheWriteTokens } : {}),
+        modelProvider: call.provider,
+        modelName: call.model,
+        costMicros,
+      });
+    },
+  };
+};
 
 /**
  * Parse an `"owner/repo"` write-scope key into a typed
@@ -283,6 +310,9 @@ interface BuildAgentClientsArgs {
   readonly costBuilder?: WakeCostBuilder;
   readonly dryRun: boolean;
   readonly ollamaBaseUrl: string | undefined;
+  /** Optional logger so the cost hook can emit `daemon.cost.pricing.unknown`
+   *  warns when a model isn't in the pricing catalog (harness#251). */
+  readonly logger?: { warn: (event: string, fields?: Record<string, unknown>) => void };
 }
 
 interface BuildAgentClientsResult {
@@ -306,6 +336,7 @@ const buildAgentClients = ({
   costBuilder,
   dryRun,
   ollamaBaseUrl,
+  logger,
 }: BuildAgentClientsArgs): BuildAgentClientsResult => {
   const result: {
     llm?: LLMClient;
@@ -324,7 +355,7 @@ const buildAgentClients = ({
       if (!resolvedModel) {
         result.llmSkipReason = `no model for provider "${agent.llm.provider}" (pin role.md llm.model)`;
       } else {
-        const costHook = costBuilder ? makeDaemonHook(costBuilder) : undefined;
+        const costHook = costBuilder ? makeDaemonHook(costBuilder, logger) : undefined;
         if (providerDef.envKeyName === null) {
           // Keyless provider (e.g. local Ollama).
           result.llm = createLLMClient({
@@ -1199,6 +1230,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               costBuilder,
               dryRun,
               ollamaBaseUrl,
+              logger,
             });
             const firstBranchScope = capturedAgent.githubWriteScopes.branchCommits[0];
             const targetRepo = firstBranchScope ? parseRepoKey(firstBranchScope.repo) : undefined;

--- a/packages/llm/src/pricing/catalog.ts
+++ b/packages/llm/src/pricing/catalog.ts
@@ -1,10 +1,25 @@
 /**
  * Per-provider LLM pricing catalog. Populates
  * `WakeCostRecord.llm.costMicros` via `resolveLLMCost` in
- * `./resolve.ts`. Seed entries are PLACEHOLDER for the paid
- * providers — the 2B6 gate flips Gemini by spot-checking against
- * the Google AI Studio console; Anthropic + OpenAI are flipped via
- * a Source spot check before Phase 3.
+ * `./resolve.ts`.
+ *
+ * Update protocol: when a new model ships, fetch the pricing from the
+ * provider's published table and add an entry below with a `source:`
+ * line that records the URL + the date you verified it. Stale entries
+ * are detectable by their `effectiveFrom` and `source` fields.
+ *
+ * Operators running models not in this catalog will see a
+ * `daemon.cost.pricing.unknown` warn event in the daemon log and
+ * `costMicros: 0` in their wake cost record. The zero is **not a
+ * bill** — it is a "we couldn't price this call" sentinel that the
+ * warn event explains. File an issue with the model id and we'll
+ * add a verified entry.
+ *
+ * Source URLs (verified 2026-04-30):
+ * - OpenAI:    https://developers.openai.com/api/docs/pricing
+ *              and per-model pages https://developers.openai.com/api/docs/models/<id>
+ * - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
+ * - Gemini:    https://ai.google.dev/gemini-api/docs/pricing
  *
  * See `docs/adr/0015-pricing-catalog.md` for the full rationale.
  */
@@ -25,13 +40,12 @@ export interface ProviderRate {
   readonly effectiveFrom: string; // ISO "YYYY-MM-DD"
 }
 
-/**
- * Seed catalog. **Every paid rate is marked PLACEHOLDER** —
- * ADR-0015 §S5. The 2B6 gate test resolves the Gemini entries by
- * spot-checking a live call against the AI Studio console; a
- * separate Source spot check resolves Anthropic + OpenAI before
- * Phase 3.
- */
+const VERIFIED_2026_04_30 = "2026-04-30";
+
+const OPENAI_PRICING_URL = "https://developers.openai.com/api/docs/pricing";
+const ANTHROPIC_PRICING_URL = "https://platform.claude.com/docs/en/about-claude/pricing";
+const GEMINI_PRICING_URL = "https://ai.google.dev/gemini-api/docs/pricing";
+
 export const SEED_CATALOG: readonly ProviderRate[] = [
   // ───── Google Gemini ────────────────────────────────────────────
   {
@@ -46,70 +60,246 @@ export const SEED_CATALOG: readonly ProviderRate[] = [
     // + `thoughtsTokenCount` to report true billed output count.
     outputUSDMicrosPerMillionTokens: 2_500_000,
     maxContextTokens: 1_048_576,
-    source:
-      "Verified 2026-04-09 via live 2A11 smoke call + https://ai.google.dev/gemini-api/docs/pricing",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${GEMINI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "gemini",
+    model: "gemini-2.5-flash-lite",
+    tier: "fast",
+    // $0.10/M input (text/image/video), $0.40/M output. Audio input
+    // is $0.30/M; harness only sends text so text rate applies.
+    inputUSDMicrosPerMillionTokens: 100_000,
+    outputUSDMicrosPerMillionTokens: 400_000,
+    maxContextTokens: 1_048_576,
+    source: `Verified 2026-04-30 via ${GEMINI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
   {
     provider: "gemini",
     model: "gemini-2.5-pro",
     tier: "balanced",
-    inputUSDMicrosPerMillionTokens: 1_250_000, // ≈ $1.25/M — VERIFY
-    outputUSDMicrosPerMillionTokens: 10_000_000, // ≈ $10/M — VERIFY
+    // $1.25/M input / $10/M output for prompts ≤200K tokens. Long
+    // prompts >200K are billed at $2.50/M input and $15/M output for
+    // the full request, but the catalog can't represent conditional
+    // pricing today — pick the short-prompt rate as the canonical
+    // entry; long-prompt usage will under-report by at most 2x until
+    // we model this properly (tracked separately).
+    inputUSDMicrosPerMillionTokens: 1_250_000,
+    outputUSDMicrosPerMillionTokens: 10_000_000,
     maxContextTokens: 2_097_152,
-    source:
-      "PLACEHOLDER — verify before Phase 2 gate (https://ai.google.dev/gemini-api/docs/pricing)",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${GEMINI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
 
   // ───── Anthropic ────────────────────────────────────────────────
+  // Pricing pattern across the 4.x line: input/output rates fixed
+  // per tier, prompt-cache 5min-write at 1.25× input, cache-read at
+  // 0.1× input. Source: platform.claude.com/docs/en/about-claude/pricing.
+  {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    tier: "fast",
+    inputUSDMicrosPerMillionTokens: 1_000_000, // $1/M
+    outputUSDMicrosPerMillionTokens: 5_000_000, // $5/M
+    cacheReadUSDMicrosPerMillionTokens: 100_000, // $0.10/M (0.1× input)
+    cacheWriteUSDMicrosPerMillionTokens: 1_250_000, // $1.25/M (1.25× input, 5m)
+    maxContextTokens: 200_000,
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
   {
     provider: "anthropic",
     model: "claude-sonnet-4-5-20250929",
     tier: "balanced",
-    inputUSDMicrosPerMillionTokens: 3_000_000, // ≈ $3/M — VERIFY
-    outputUSDMicrosPerMillionTokens: 15_000_000, // ≈ $15/M — VERIFY
-    cacheReadUSDMicrosPerMillionTokens: 300_000, // ≈ 0.1× input — VERIFY
-    cacheWriteUSDMicrosPerMillionTokens: 3_750_000, // ≈ 1.25× input — VERIFY
+    inputUSDMicrosPerMillionTokens: 3_000_000, // $3/M
+    outputUSDMicrosPerMillionTokens: 15_000_000, // $15/M
+    cacheReadUSDMicrosPerMillionTokens: 300_000, // $0.30/M
+    cacheWriteUSDMicrosPerMillionTokens: 3_750_000, // $3.75/M (5m write)
     maxContextTokens: 200_000,
-    source: "PLACEHOLDER — verify before Phase 3 (https://www.anthropic.com/pricing)",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
   {
     provider: "anthropic",
-    model: "claude-opus-4-6-20251030",
+    model: "claude-sonnet-4-6",
+    tier: "balanced",
+    inputUSDMicrosPerMillionTokens: 3_000_000,
+    outputUSDMicrosPerMillionTokens: 15_000_000,
+    cacheReadUSDMicrosPerMillionTokens: 300_000,
+    cacheWriteUSDMicrosPerMillionTokens: 3_750_000,
+    maxContextTokens: 1_000_000, // 1M long-context window
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "anthropic",
+    model: "claude-opus-4-5",
     tier: "deep",
-    inputUSDMicrosPerMillionTokens: 15_000_000, // ≈ $15/M — VERIFY
-    outputUSDMicrosPerMillionTokens: 75_000_000, // ≈ $75/M — VERIFY
-    cacheReadUSDMicrosPerMillionTokens: 1_500_000, // ≈ 0.1× input — VERIFY
-    cacheWriteUSDMicrosPerMillionTokens: 18_750_000, // ≈ 1.25× input — VERIFY
+    inputUSDMicrosPerMillionTokens: 5_000_000, // $5/M (4.5/4.6/4.7 share this row)
+    outputUSDMicrosPerMillionTokens: 25_000_000, // $25/M
+    cacheReadUSDMicrosPerMillionTokens: 500_000, // $0.50/M
+    cacheWriteUSDMicrosPerMillionTokens: 6_250_000, // $6.25/M (5m write)
+    maxContextTokens: 200_000,
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    tier: "deep",
+    inputUSDMicrosPerMillionTokens: 5_000_000,
+    outputUSDMicrosPerMillionTokens: 25_000_000,
+    cacheReadUSDMicrosPerMillionTokens: 500_000,
+    cacheWriteUSDMicrosPerMillionTokens: 6_250_000,
     maxContextTokens: 1_000_000,
-    source: "PLACEHOLDER — verify before Phase 3 (https://www.anthropic.com/pricing)",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    tier: "deep",
+    inputUSDMicrosPerMillionTokens: 5_000_000,
+    outputUSDMicrosPerMillionTokens: 25_000_000,
+    cacheReadUSDMicrosPerMillionTokens: 500_000,
+    cacheWriteUSDMicrosPerMillionTokens: 6_250_000,
+    maxContextTokens: 1_000_000,
+    source: `Verified 2026-04-30 via ${ANTHROPIC_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
 
   // ───── OpenAI ───────────────────────────────────────────────────
+  // The 5.4 / 5.5 lines are current as of 2026-04-30. Earlier
+  // single-digit-only ids (gpt-5, gpt-5.1) are still callable but
+  // OpenAI has positioned 5.4 / 5.5 as the recommended path; we keep
+  // the older entries so existing operator configs don't fall into
+  // the unknown-model warn.
+  {
+    provider: "openai",
+    model: "gpt-5",
+    tier: "balanced",
+    inputUSDMicrosPerMillionTokens: 1_250_000, // $1.25/M
+    outputUSDMicrosPerMillionTokens: 10_000_000, // $10/M
+    cacheReadUSDMicrosPerMillionTokens: 125_000, // $0.125/M (0.1× input)
+    maxContextTokens: 400_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.1",
+    tier: "balanced",
+    inputUSDMicrosPerMillionTokens: 1_250_000,
+    outputUSDMicrosPerMillionTokens: 10_000_000,
+    cacheReadUSDMicrosPerMillionTokens: 125_000,
+    maxContextTokens: 400_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5-codex",
+    tier: "balanced",
+    inputUSDMicrosPerMillionTokens: 1_250_000,
+    outputUSDMicrosPerMillionTokens: 10_000_000,
+    cacheReadUSDMicrosPerMillionTokens: 125_000,
+    maxContextTokens: 400_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4",
+    tier: "balanced",
+    inputUSDMicrosPerMillionTokens: 2_500_000, // $2.50/M
+    outputUSDMicrosPerMillionTokens: 15_000_000, // $15/M
+    cacheReadUSDMicrosPerMillionTokens: 250_000, // $0.25/M
+    maxContextTokens: 1_050_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    tier: "fast",
+    inputUSDMicrosPerMillionTokens: 750_000, // $0.75/M
+    outputUSDMicrosPerMillionTokens: 4_500_000, // $4.50/M
+    cacheReadUSDMicrosPerMillionTokens: 75_000, // $0.075/M
+    maxContextTokens: 400_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4-nano",
+    tier: "fast",
+    inputUSDMicrosPerMillionTokens: 200_000, // $0.20/M
+    outputUSDMicrosPerMillionTokens: 1_250_000, // $1.25/M
+    // Cached input not separately listed for the nano tier; resolve.ts
+    // falls back to input rate when cache rate is omitted, which is
+    // conservative (over-reports cache cost rather than zero).
+    maxContextTokens: 400_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4-pro",
+    tier: "deep",
+    inputUSDMicrosPerMillionTokens: 30_000_000, // $30/M
+    outputUSDMicrosPerMillionTokens: 180_000_000, // $180/M
+    // The pro tier doesn't offer a cached-input discount.
+    maxContextTokens: 1_050_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.5",
+    tier: "deep",
+    inputUSDMicrosPerMillionTokens: 5_000_000, // $5/M
+    outputUSDMicrosPerMillionTokens: 30_000_000, // $30/M
+    cacheReadUSDMicrosPerMillionTokens: 500_000, // $0.50/M
+    // Note: prompts >272K input tokens get 2× input + 1.5× output for
+    // the full session. Catalog doesn't model conditional rates yet;
+    // long-prompt usage under-reports by up to 2×.
+    maxContextTokens: 1_050_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.5-pro",
+    tier: "deep",
+    inputUSDMicrosPerMillionTokens: 30_000_000, // $30/M
+    outputUSDMicrosPerMillionTokens: 180_000_000, // $180/M
+    // No cached-input discount on pro tier.
+    maxContextTokens: 1_050_000,
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
+  },
   {
     provider: "openai",
     model: "gpt-4o",
     tier: "balanced",
-    inputUSDMicrosPerMillionTokens: 2_500_000, // ≈ $2.50/M — VERIFY
-    outputUSDMicrosPerMillionTokens: 10_000_000, // ≈ $10/M — VERIFY
-    cacheReadUSDMicrosPerMillionTokens: 1_250_000, // 50% of input — VERIFY
+    inputUSDMicrosPerMillionTokens: 2_500_000, // $2.50/M
+    outputUSDMicrosPerMillionTokens: 10_000_000, // $10/M
+    cacheReadUSDMicrosPerMillionTokens: 1_250_000, // $1.25/M (50% of input)
     maxContextTokens: 128_000,
-    source: "PLACEHOLDER — verify before Phase 3 (https://openai.com/api/pricing/)",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
   {
     provider: "openai",
     model: "gpt-4o-mini",
     tier: "fast",
-    inputUSDMicrosPerMillionTokens: 150_000, // ≈ $0.15/M — VERIFY
-    outputUSDMicrosPerMillionTokens: 600_000, // ≈ $0.60/M — VERIFY
-    cacheReadUSDMicrosPerMillionTokens: 75_000, // 50% of input — VERIFY
+    inputUSDMicrosPerMillionTokens: 150_000, // $0.15/M
+    outputUSDMicrosPerMillionTokens: 600_000, // $0.60/M
+    cacheReadUSDMicrosPerMillionTokens: 75_000, // $0.075/M (50% of input)
     maxContextTokens: 128_000,
-    source: "PLACEHOLDER — verify before Phase 3 (https://openai.com/api/pricing/)",
-    effectiveFrom: "2026-04-09",
+    source: `Verified 2026-04-30 via ${OPENAI_PRICING_URL}`,
+    effectiveFrom: VERIFIED_2026_04_30,
   },
 
   // ───── Ollama sentinel (real entry, zero rate) ──────────────────

--- a/packages/llm/src/pricing/pricing.test.ts
+++ b/packages/llm/src/pricing/pricing.test.ts
@@ -120,6 +120,48 @@ describe("resolveLLMCost", () => {
     if (result.ok) expect(result.value.value).toBe(1_250);
   });
 
+  it("gpt-5.5 50K input + 8K output computes against verified pricing", () => {
+    // gpt-5.5: $5/M input, $30/M output (verified 2026-04-30)
+    // input:  50_000 * 5_000_000 / 1M = 250_000 micros
+    // output:  8_000 * 30_000_000 / 1M = 240_000 micros
+    // total: 490_000 micros = $0.49
+    const result = resolveLLMCost({
+      provider: "openai",
+      model: "gpt-5.5",
+      inputTokens: 50_000,
+      outputTokens: 8_000,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.value).toBe(490_000);
+  });
+
+  it("gpt-5.4-pro applies the deep-tier $30/$180 rates", () => {
+    // input:  1_000 * 30_000_000 / 1M = 30_000 micros
+    // output: 1_000 * 180_000_000 / 1M = 180_000 micros
+    const result = resolveLLMCost({
+      provider: "openai",
+      model: "gpt-5.4-pro",
+      inputTokens: 1_000,
+      outputTokens: 1_000,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.value).toBe(210_000);
+  });
+
+  it("claude-opus-4-7 applies cache read at 0.1× input", () => {
+    // Opus 4.7: $5/M input, $25/M output, $0.50/M cache read.
+    // 100_000 cache read * 500_000 / 1M = 50_000 micros
+    const result = resolveLLMCost({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 100_000,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.value).toBe(50_000);
+  });
+
   it("Sonnet 4.5 mixed 50K input + 8K output matches hand computation", () => {
     // input: 50_000 * 3_000_000 / 1M = 150_000 micros
     // output: 8_000 * 15_000_000 / 1M = 120_000 micros


### PR DESCRIPTION
## Summary

- Populates `packages/llm/src/pricing/catalog.ts` with verified-2026-04-30 pricing for the current OpenAI (gpt-5, gpt-5.1, gpt-5-codex, gpt-5.4 family, gpt-5.5, gpt-5.5-pro, gpt-4o, gpt-4o-mini) and Anthropic Claude 4.x (Haiku, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7) model lineups.
- Adds `gemini-2.5-flash-lite` and refreshes Gemini 2.5 source URLs to today.
- Removes the wrong claude-opus-4-6 entry that had \$15/\$75 (Opus 4 pricing — opus 4.5+ is \$5/\$25).
- `makeDaemonHook` now takes an optional logger and emits a one-shot `daemon.cost.pricing.unknown` warn event per (provider, model) gap. Per-hook dedupe state means it fires once per wake per gap, not per LLM call. The cost record still records \$0 — failing the wake on a catalog miss is worse — but operators see the gap clearly in their daemon log.

Closes #251.

## Why

Today's GPT-5.5 cost-test wake reported \`costMicros: 0\` despite consuming 415K input + 7.7K output tokens (real cost ~\$0.76). The model wasn't in the catalog. Same for every claude-opus-4-7 and gpt-5.x wake. Operator cost reports systematically understated spend, and the gap was invisible because the catalog miss path silently mapped to zero with a comment claiming "the boot-time warn catches misconfiguration before a real wake" — except boot doesn't know which models will be invoked at wake time.

## Pricing sources (verified 2026-04-30)

- OpenAI:    https://developers.openai.com/api/docs/pricing + per-model pages at /api/docs/models/<id>
- Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
- Gemini:    https://ai.google.dev/gemini-api/docs/pricing

## Test plan

- [x] \`pnpm run check\` — 51 test files, 699 tests pass (up from 691; +5 boot.test.ts + +3 pricing.test.ts).
- [x] Hand-verified test computations against published rates for gpt-5.5 (\$5/\$30), gpt-5.4-pro (\$30/\$180), claude-opus-4-7 cache read (\$0.50/M = 0.1× input).
- [ ] Live: rerun a GPT-5.5 wake against the new catalog; expect non-zero \`costMicros\` in the wake event.

## Out of scope

- Long-context conditional pricing (gpt-5.5 prompts >272K tokens get 2× input + 1.5× output for the full session). The catalog can't model conditional rates yet; long-prompt usage under-reports by up to 2× until that's added. Filed as a separate concern.
- Externalizing the catalog so it can be updated without a harness release. Worth doing eventually but mechanical and orthogonal to closing the gap.
- Migrating costMicros to a nullable type so unknown-pricing wakes get \`null\` instead of \`0\`. That's a schema migration touching budget enforcement, dashboard, JSON output, and tests across the stack — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)