### PR TITLE
fix(runner): stop synthesizing Gemini model names regardless of provider (#252)

### DIFF
--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -73,7 +73,13 @@ export interface DefaultRunnerClients {
   readonly llm?: {
     complete(
       opts: {
-        model: string;
+        /**
+         * Concrete model id is optional — the underlying LLMClient binds
+         * its model at construction and ignores this field. Pass it for
+         * observability when known; the bound model wins regardless.
+         * See harness#252.
+         */
+        model?: string;
         messages: { role: string; content: string }[];
         systemPromptOverride?: string;
         maxOutputTokens?: number;
@@ -458,18 +464,25 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
 `;
 
     // 9. Call LLM (tools loaded above as section 7a)
-    const llmModel =
-      spawn.identity.frontmatter.modelTier === "fast"
-        ? "gemini-2.5-flash"
-        : spawn.identity.frontmatter.modelTier === "deep"
-          ? "gemini-2.5-pro"
-          : "gemini-2.5-flash";
-
+    //
+    // We do NOT pass a model — the LLMClient was constructed with the
+    // agent's resolved provider+model at boot, and the Vercel adapter
+    // uses that bound model regardless of what's in the request. The
+    // bound model is the single source of truth.
+    //
+    // Previous code (harness#252) synthesized a Gemini model name from
+    // modelTier here regardless of the agent's actual provider. The
+    // adapter ignored it for non-Gemini agents (which is why nothing
+    // visibly broke), but it was a latent regression — any future
+    // adapter that respected request.model would silently swap every
+    // agent to a Gemini name. It also produced the wrong default for
+    // the one provider it actually applied to (balanced → flash, not
+    // pro). The actual model used in the wake is reported back via
+    // `result.value.modelUsed` and logged below.
     let result: Awaited<ReturnType<NonNullable<DefaultRunnerClients["llm"]>["complete"]>>;
     try {
       result = await clients.llm.complete(
         {
-          model: llmModel,
           messages: [{ role: "user", content: userPrompt }],
           systemPromptOverride: systemPrompt,
           maxOutputTokens: 16000,

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -131,6 +131,24 @@ describe("createDefaultRunner", () => {
     expect(result.wakeSummary).toContain("test-agent");
   });
 
+  it("does not pass a model field — bound LLMClient model is the source of truth (harness#252)", async () => {
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const llm = makeLlmClient("Hello.");
+
+    await runner({
+      spawn: makeSpawn(),
+      clients: { llm },
+    });
+
+    const calls = (llm as unknown as { _calls: Record<string, unknown>[] })._calls;
+    expect(calls).toHaveLength(1);
+    // Regression guard: the runner used to synthesize "gemini-2.5-flash"
+    // / "gemini-2.5-pro" from modelTier here, which silently overrode
+    // every non-Gemini agent in adapters that respected request.model.
+    // The fix dropped the field entirely.
+    expect(calls[0]).not.toHaveProperty("model");
+  });
+
   it("skips when no LLM client provided", async () => {
     const runner = createDefaultRunner("test-agent", [], {}, rootDir);
     const result = await runner({

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -49,8 +49,17 @@ export interface ToolCallResult {
 
 /** Input to {@link LLMClient.complete}. */
 export interface LLMRequest {
-  /** Concrete model id; resolved via tier table if omitted in the client config. */
-  readonly model: string;
+  /**
+   * Concrete model id, optional. The Vercel adapter uses the model
+   * bound to the LLMClient at construction (`createLLMClient({ model })`)
+   * and ignores this field. Callers pass it for observability /
+   * downstream logging when known; it is not authoritative routing.
+   * harness#252: previously the runner synthesized a Gemini-specific
+   * value here, which was both misleading and a latent regression
+   * (any future adapter that respected the field would silently swap
+   * every agent to a Gemini model name).
+   */
+  readonly model?: string;
   readonly messages: readonly LLMMessage[];
   readonly maxOutputTokens: number;
   readonly temperature?: number;


### PR DESCRIPTION
## Summary

- Removes the \`gemini-2.5-flash\` / \`gemini-2.5-pro\` ternary in \`packages/core/src/runner/index.ts\` that was being passed as \`model:\` for every LLM call regardless of the agent's actual provider.
- Drops the field from the runner's \`complete()\` call entirely. The bound \`LLMClient\` model (resolved at boot via \`agent.llm.model ?? providerRegistry.resolveModelForTier(provider, tier)\`) is the source of truth.
- Marks \`LLMRequest.model\` as optional in the type to match runtime reality (the Vercel adapter has always ignored it in favor of the bound model — see \`vercel-adapter.ts:185\` using \`this.#model\`, not \`request.model\`).
- Adds a regression test asserting the runner no longer passes a \`model\` field.

Closes #252.

## Why

Today's investigation surfaced this at \`runner/index.ts:461\`:

\`\`\`ts
const llmModel =
  spawn.identity.frontmatter.modelTier === "fast"
    ? "gemini-2.5-flash"
    : spawn.identity.frontmatter.modelTier === "deep"
      ? "gemini-2.5-pro"
      : "gemini-2.5-flash"; // balanced → flash, not pro. wrong default.
\`\`\`

Three problems:
1. **Latent regression.** The Vercel adapter ignores \`request.model\` so this didn't visibly break Anthropic/OpenAI agents. But any future adapter that respected the field would silently swap every non-Gemini agent to Gemini model names.
2. **Wrong default for the one provider it actually applied to.** \`balanced\` mapped to \`gemini-2.5-flash\` (the *fast* model), not \`gemini-2.5-pro\`. Gemini "balanced" wakes have been quietly running on Flash.
3. **Architecturally wrong.** Per [ADR-0025](https://github.com/murmurations-ai/murmurations-harness/blob/main/docs/adr/0025-pluggable-llm-providers.md), the harness must be provider-agnostic. Hardcoded Gemini literals in core directly violate that.

## Test plan

- [x] \`pnpm run check\` — 51 test files, 701 tests pass (+1 regression test).
- [x] Typecheck clean across all 8 workspace packages.
- [x] Existing \`group-wake.ts\` and \`spirit/client.ts\` callers unaffected — they pass \`model:\` correctly from \`llmConfig.model\` (the actually-configured value), and \`LLMRequest.model\` being optional is a relaxation, not a break.

## Out of scope

- Threading \`modelUsed\` from the bound LLMClient back into the runner's spawn context for richer observability — the existing \`result.value.modelUsed\` already surfaces the actual model used in wake summaries; that's enough today. Could be added later if Phase 1 of the OAuth work needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)