### PR TITLE
feat(github): add five read tools to agent's tool surface (replaces #256)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.build.json && mkdir -p dist/spirit/skills && cp src/spirit/skills/*.md dist/spirit/skills/ && mkdir -p dist/builtin-extensions/files && cp src/builtin-extensions/files/*.json src/builtin-extensions/files/*.mjs dist/builtin-extensions/files/ && mkdir -p dist/builtin-extensions/memory && cp src/builtin-extensions/memory/*.json src/builtin-extensions/memory/*.mjs dist/builtin-extensions/memory/ && mkdir -p dist/default-agent && cp src/default-agent/*.md dist/default-agent/ && mkdir -p dist/examples && cp -R src/examples/. dist/examples/ && mkdir -p dist/governance-plugins/s3 && cp src/governance-plugins/s3/index.mjs dist/governance-plugins/s3/",
+    "build": "tsc --build tsconfig.build.json && mkdir -p dist/spirit/skills && cp src/spirit/skills/*.md dist/spirit/skills/ && mkdir -p dist/builtin-extensions/files && cp src/builtin-extensions/files/*.json src/builtin-extensions/files/*.mjs dist/builtin-extensions/files/ && mkdir -p dist/builtin-extensions/memory && cp src/builtin-extensions/memory/*.json src/builtin-extensions/memory/*.mjs dist/builtin-extensions/memory/ && mkdir -p dist/builtin-extensions/github && cp src/builtin-extensions/github/*.json src/builtin-extensions/github/*.mjs dist/builtin-extensions/github/ && mkdir -p dist/default-agent && cp src/default-agent/*.md dist/default-agent/ && mkdir -p dist/examples && cp -R src/examples/. dist/examples/ && mkdir -p dist/governance-plugins/s3 && cp src/governance-plugins/s3/index.mjs dist/governance-plugins/s3/",
     "clean": "rm -rf dist .tsbuildinfo .tsbuildinfo.build",
     "typecheck": "tsc --noEmit",
     "start": "node dist/bin.js start"

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -75,6 +75,7 @@ import { McpToolLoader } from "@murmurations-ai/mcp";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 import { DefaultSignalAggregator } from "@murmurations-ai/signals";
 
+import { buildGithubReadToolsForAgent } from "./github-tools/index.js";
 import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js";
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 import { registerRunningSocket, unregisterRunningSocket } from "./running-sessions.js";
@@ -393,24 +394,36 @@ const buildAgentClients = ({
       }
     : undefined;
 
-  if (hasAnyWriteScope(agent)) {
-    if (dryRun) {
-      if (provider?.has(GITHUB_TOKEN) === true) {
+  // Construct a GithubClient when GITHUB_TOKEN is present, regardless
+  // of whether the agent has declared write scopes. Agents without
+  // write scopes get a read-only client (any write attempt fails with
+  // "no write scopes configured" — see github/src/client.ts §scope check).
+  // This is what powers the github read tools (formerly harness#256):
+  // agents need GitHub-aware tools at all, not bundled bodies.
+  if (provider?.has(GITHUB_TOKEN) === true) {
+    if (hasAnyWriteScope(agent)) {
+      if (dryRun) {
         result.github = createGithubClient({
           token: provider.get(GITHUB_TOKEN),
           ...(githubCostHook ? { defaultCostHook: githubCostHook } : {}),
         });
+      } else {
+        result.github = createGithubClient({
+          token: provider.get(GITHUB_TOKEN),
+          writeScopes: toClientWriteScopes(agent),
+          ...(githubCostHook ? { defaultCostHook: githubCostHook } : {}),
+        });
       }
-      // dry-run never sets githubSkipReason; the caller logs the dryRun event.
-    } else if (provider?.has(GITHUB_TOKEN) === true) {
+    } else {
+      // Read-only agent: omit writeScopes entirely so any accidental
+      // write attempt fails-closed with a clear error.
       result.github = createGithubClient({
         token: provider.get(GITHUB_TOKEN),
-        writeScopes: toClientWriteScopes(agent),
         ...(githubCostHook ? { defaultCostHook: githubCostHook } : {}),
       });
-    } else {
-      result.githubSkipReason = "GITHUB_TOKEN absent; write-scoped client not constructed";
     }
+  } else if (hasAnyWriteScope(agent)) {
+    result.githubSkipReason = "GITHUB_TOKEN absent; write-scoped client not constructed";
   }
 
   return result;
@@ -1021,10 +1034,25 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         agentDir,
       }) as readonly (typeof extensionTools)[number][];
 
+    // GitHub read tools (replacement for harness#256). Construct a
+    // boot-time client when GITHUB_TOKEN is available; the agent's
+    // declared write_scopes (if any) gate write paths separately
+    // through the WakeAction pipeline. Read calls don't yet land in
+    // a per-wake cost builder — that's a known v1 limitation; total
+    // call counts still surface via the daemon-level token's
+    // GitHub-side rate-limit headers.
+    const buildAgentBoundGithub = (): readonly (typeof extensionTools)[number][] => {
+      if (provider?.has(GITHUB_TOKEN) !== true) return [];
+      const client = createGithubClient({
+        token: provider.get(GITHUB_TOKEN),
+      });
+      return buildGithubReadToolsForAgent(client) as readonly (typeof extensionTools)[number][];
+    };
+
     if (agent.plugins.length === 0) {
       // Backward compat: agents with no explicit declaration see all
-      // shared extension tools + per-agent memory tools.
-      return [...extensionTools, ...buildAgentBoundMemory()];
+      // shared extension tools + per-agent memory + github tools.
+      return [...extensionTools, ...buildAgentBoundMemory(), ...buildAgentBoundGithub()];
     }
 
     const declared = new Set<string>();
@@ -1042,14 +1070,19 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     declared.add("@murmurations-ai/files");
     declared.add("memory");
     declared.add("@murmurations-ai/memory");
+    // Auto-include github read tools when GITHUB_TOKEN is present.
+    // Operators can opt out by removing the token from .env. If we
+    // ever add a true read-scope mechanism this auto-include should
+    // gate on declaration instead.
+    declared.add("github");
+    declared.add("@murmurations-ai/github");
 
     const sharedTools = loadedExtensions
       .filter((ext) => declared.has(ext.id))
       .flatMap((ext) => ext.tools);
 
-    // Attach per-agent memory tools — memory is auto-included above
-    // for all agents, so this branch always fires.
-    return [...sharedTools, ...buildAgentBoundMemory()];
+    // Attach per-agent memory + github tools.
+    return [...sharedTools, ...buildAgentBoundMemory(), ...buildAgentBoundGithub()];
   };
 
   // -------------------------------------------------------------------

--- a/packages/cli/src/builtin-extensions/github/index.mjs
+++ b/packages/cli/src/builtin-extensions/github/index.mjs
@@ -1,0 +1,42 @@
+/**
+ * Built-in GitHub read extension.
+ *
+ * MARKER entry: registers the extension id `github` so the loader
+ * discovers it, but contributes no tools at load time. The actual
+ * tools are constructed per-agent at boot by
+ * `buildGithubReadToolsForAgent()` in `packages/cli/src/github-tools/index.ts`,
+ * then merged into the agent's tool list by `selectExtensionToolsFor()`
+ * in boot. Reason: the GithubClient that backs these tools is bound to
+ * the per-agent `defaultCostHook` for accurate `WakeCostBuilder` audit
+ * counts, so it cannot be a shared boot-time singleton.
+ *
+ * Five read-only tools are exposed when an agent declares this plugin
+ * and `GITHUB_TOKEN` is present:
+ *   read_issue(repo, number)
+ *   list_issues(repo, state?, labels?, perPage?)
+ *   list_issue_comments(repo, number)
+ *   list_issue_labels(repo, number)
+ *   get_branch_head(repo, branch)
+ *
+ * Writes are not added here — the existing WakeAction pipeline
+ * already handles labels/comments/issue creation post-wake under
+ * the agent's declared `github.write_scopes` (ADR-0017). Direct
+ * write tools would re-open the Boundary 5 narrative-vs-action
+ * audit hole that #240 closes.
+ *
+ * Declare in `role.md`:
+ *   plugins:
+ *     - provider: "@murmurations-ai/github"
+ */
+
+/** @type {import("@murmurations-ai/core").ExtensionEntry} */
+export default {
+  id: "github",
+  name: "GitHub Read Tools",
+  description:
+    "Read issues, comments, labels, and branch heads via the harness's existing GithubClient. Tools are agent-bound and built per-agent in boot, not registered here.",
+  register(_api) {
+    // Intentional no-op: tools are agent-bound and injected
+    // per-agent in selectExtensionToolsFor, not at load time.
+  },
+};

--- a/packages/cli/src/builtin-extensions/github/openclaw.plugin.json
+++ b/packages/cli/src/builtin-extensions/github/openclaw.plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "github",
+  "providerAuthEnvVars": {},
+  "contracts": {
+    "tools": [
+      "read_issue",
+      "list_issues",
+      "list_issue_comments",
+      "list_issue_labels",
+      "get_branch_head"
+    ]
+  }
+}

--- a/packages/cli/src/github-tools/github-tools.test.ts
+++ b/packages/cli/src/github-tools/github-tools.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for buildGithubReadToolsForAgent.
+ *
+ * Mocks a minimal GithubClient with just the read methods exercised
+ * by the five tools. Verifies (a) tool list shape, (b) repo parsing,
+ * (c) error surfaces flow back as plain strings, (d) successful
+ * responses are JSON-serialized predictably.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { makeIssueNumber, makeRepoCoordinate } from "@murmurations-ai/github";
+import type { GithubClient, GithubIssue } from "@murmurations-ai/github";
+
+import { buildGithubReadToolsForAgent } from "./index.js";
+
+const minimalIssue: GithubIssue = {
+  number: makeIssueNumber(42),
+  repo: makeRepoCoordinate("owner", "repo"),
+  title: "Test issue",
+  body: "Issue body content",
+  state: "open",
+  labels: ["bug", "good-first-issue"],
+  authorLogin: "test-user",
+  createdAt: new Date("2026-04-30T00:00:00Z"),
+  updatedAt: new Date("2026-04-30T01:00:00Z"),
+  closedAt: null,
+  commentCount: 3,
+  htmlUrl: "https://github.com/owner/repo/issues/42",
+};
+
+const successOf = <T>(value: T) => Promise.resolve({ ok: true as const, value });
+const errorOf = (code: string, message: string) =>
+  Promise.resolve({
+    ok: false as const,
+    error: { code, message } as never,
+  });
+
+const stubClient = (
+  overrides: Partial<{
+    [K in keyof GithubClient]: GithubClient[K];
+  }> = {},
+): GithubClient =>
+  ({
+    getIssue: () => successOf(minimalIssue),
+    listIssues: () => successOf([minimalIssue]),
+    listIssueComments: () =>
+      successOf([
+        {
+          id: 1,
+          issueNumber: makeIssueNumber(42),
+          authorLogin: "commenter",
+          body: "First comment",
+          createdAt: new Date("2026-04-30T00:30:00Z"),
+          updatedAt: new Date("2026-04-30T00:30:00Z"),
+          htmlUrl: "https://github.com/owner/repo/issues/42#comment-1",
+        },
+      ]),
+    listIssueLabels: () => successOf(["bug", "good-first-issue"]),
+    getRef: () =>
+      successOf({
+        repo: makeRepoCoordinate("owner", "repo"),
+        branch: "main",
+        oid: "abc123def",
+      }),
+    ...overrides,
+  }) as unknown as GithubClient;
+
+describe("buildGithubReadToolsForAgent", () => {
+  it("registers the five read tools by name", () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    expect(tools.map((t) => t.name)).toEqual([
+      "read_issue",
+      "list_issues",
+      "list_issue_comments",
+      "list_issue_labels",
+      "get_branch_head",
+    ]);
+  });
+
+  it("read_issue returns serialized issue JSON for a valid repo", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_issue");
+    expect(tool).toBeDefined();
+    const result = (await tool!.execute({ repo: "owner/repo", number: 42 })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.title).toBe("Test issue");
+    expect(parsed.state).toBe("open");
+    expect(parsed.body).toBe("Issue body content");
+    expect(parsed.labels).toEqual(["bug", "good-first-issue"]);
+  });
+
+  it("read_issue surfaces parse errors as plain strings", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_issue")!;
+    const result = (await tool.execute({ repo: "not-a-valid-repo", number: 1 })) as string;
+    expect(result).toMatch(/^read_issue error: repo must be "owner\/name"/);
+  });
+
+  it("read_issue surfaces client errors as plain strings", async () => {
+    const client = stubClient({ getIssue: () => errorOf("not-found", "Issue not found") });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "read_issue")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 9999 })) as string;
+    expect(result).toBe("read_issue error: not-found — Issue not found");
+  });
+
+  it("list_issues passes through state and labels filters", async () => {
+    let lastFilter: unknown;
+    const client = stubClient({
+      listIssues: (_repo, filter) => {
+        lastFilter = filter;
+        return successOf([minimalIssue]);
+      },
+    });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "list_issues")!;
+    await tool.execute({
+      repo: "owner/repo",
+      state: "open",
+      labels: ["assigned:agent"],
+      perPage: 5,
+    });
+    expect(lastFilter).toEqual({
+      state: "open",
+      labels: ["assigned:agent"],
+      perPage: 5,
+    });
+  });
+
+  it("list_issues with no optional args sends an empty filter", async () => {
+    let lastFilter: unknown;
+    const client = stubClient({
+      listIssues: (_repo, filter) => {
+        lastFilter = filter;
+        return successOf([]);
+      },
+    });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "list_issues")!;
+    await tool.execute({ repo: "owner/repo" });
+    expect(lastFilter).toEqual({});
+  });
+
+  it("list_issue_comments serializes each comment", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "list_issue_comments")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 42 })) as string;
+    const parsed = JSON.parse(result) as { authorLogin: string; body: string }[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.authorLogin).toBe("commenter");
+    expect(parsed[0]?.body).toBe("First comment");
+  });
+
+  it("list_issue_labels returns newline-joined labels", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "list_issue_labels")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 42 })) as string;
+    expect(result).toBe("bug\ngood-first-issue");
+  });
+
+  it("get_branch_head returns repo + branch + oid as JSON", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "get_branch_head")!;
+    const result = (await tool.execute({ repo: "owner/repo", branch: "main" })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.repo).toBe("owner/repo");
+    expect(parsed.branch).toBe("main");
+    expect(parsed.oid).toBe("abc123def");
+  });
+
+  it("rejects empty-string repo with parse error", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_issue")!;
+    const result = (await tool.execute({ repo: "", number: 1 })) as string;
+    expect(result).toMatch(/repo must be "owner\/name"/);
+  });
+});

--- a/packages/cli/src/github-tools/index.ts
+++ b/packages/cli/src/github-tools/index.ts
@@ -1,0 +1,225 @@
+/**
+ * GitHub read tools — agent-callable wrappers around the
+ * harness's existing GithubClient. Constructed per-agent at boot
+ * so each tool's underlying client carries the agent's per-wake
+ * cost hook and (eventually) per-agent read scopes.
+ *
+ * Five read-only tools (replacement for harness#256, which was
+ * filed against the wrong premise — bodies were already in the
+ * SignalBundle, but agents had no GitHub-aware tools at all):
+ *
+ *   read_issue            — fetch one issue by repo + number
+ *   list_issues           — list issues in a repo (filterable)
+ *   list_issue_comments   — fetch comment thread for one issue
+ *   list_issue_labels     — fetch labels for one issue
+ *   get_branch_head       — fetch HEAD oid of a branch
+ *
+ * Writes are intentionally NOT added here. The existing WakeAction
+ * pipeline handles writes post-wake under ADR-0017 scope enforcement
+ * with the Boundary 5 narrative-vs-action audit (#240). Direct write
+ * tools would reopen that hole.
+ *
+ * The `repo` parameter accepts the natural "owner/name" string form;
+ * we parse it into a `RepoCoordinate` internally so the LLM doesn't
+ * have to construct the branded shape.
+ */
+
+import { z } from "zod";
+
+import { makeIssueNumber, makeRepoCoordinate, type GithubClient } from "@murmurations-ai/github";
+
+interface GithubReadTool {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: unknown;
+  readonly execute: (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+const REPO_RE = /^([\w.-]+)\/([\w.-]+)$/;
+
+/**
+ * Parse "owner/name" into a RepoCoordinate. Returns the structural
+ * error message string on bad input so the tool can surface it as
+ * a normal error response (LLMs handle plain-text errors better
+ * than thrown exceptions inside tool execution).
+ */
+const parseRepo = (
+  raw: string,
+): { ok: true; value: ReturnType<typeof makeRepoCoordinate> } | { ok: false; message: string } => {
+  const m = REPO_RE.exec(raw);
+  if (!m?.[1] || !m[2]) {
+    return {
+      ok: false,
+      message: `repo must be "owner/name" (got: "${raw}")`,
+    };
+  }
+  try {
+    return { ok: true, value: makeRepoCoordinate(m[1], m[2]) };
+  } catch (err) {
+    return {
+      ok: false,
+      message: `invalid repo "${raw}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+};
+
+/**
+ * Build the read-only tool surface against `client`. The client must
+ * be one constructed for this agent's wake (cost hook bound) so calls
+ * land in the per-wake `WakeCostBuilder`.
+ */
+export const buildGithubReadToolsForAgent = (client: GithubClient): readonly GithubReadTool[] => [
+  {
+    name: "read_issue",
+    description:
+      'Fetch a single GitHub issue by repository and number. Returns title, body, state, labels, author, timestamps. The `repo` argument is "owner/name" (e.g. "murmurations-ai/murmurations-harness").',
+    parameters: z.object({
+      repo: z.string().describe('"owner/name", e.g. "murmurations-ai/murmurations-harness"'),
+      number: z.number().int().positive().describe("Issue number"),
+    }),
+    execute: async ({ repo, number }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `read_issue error: ${parsed.message}`;
+      const result = await client.getIssue(parsed.value, makeIssueNumber(Number(number)));
+      if (!result.ok) {
+        return `read_issue error: ${result.error.code} — ${result.error.message}`;
+      }
+      const issue = result.value;
+      return JSON.stringify(
+        {
+          number: issue.number.value,
+          title: issue.title,
+          state: issue.state,
+          body: issue.body ?? "",
+          labels: issue.labels,
+          authorLogin: issue.authorLogin,
+          createdAt: issue.createdAt.toISOString(),
+          updatedAt: issue.updatedAt.toISOString(),
+          closedAt: issue.closedAt?.toISOString() ?? null,
+          commentCount: issue.commentCount,
+          htmlUrl: issue.htmlUrl,
+        },
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "list_issues",
+    description:
+      "List GitHub issues in a repository, optionally filtered by state and labels. Returns up to `perPage` results (default 30, max 100). Useful for finding related/referenced issues that aren't in the agent's signal bundle.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      state: z.enum(["open", "closed", "all"]).optional().describe('Default "open"'),
+      labels: z.array(z.string()).optional().describe("Issues must carry ALL listed labels"),
+      perPage: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Max issues to return (default 30, max 100)"),
+    }),
+    execute: async ({ repo, state, labels, perPage }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `list_issues error: ${parsed.message}`;
+      const filter: {
+        state?: "open" | "closed" | "all";
+        labels?: readonly string[];
+        perPage?: number;
+      } = {};
+      if (state !== undefined) filter.state = state as "open" | "closed" | "all";
+      if (Array.isArray(labels) && labels.length > 0) filter.labels = labels as string[];
+      if (typeof perPage === "number") filter.perPage = perPage;
+      const result = await client.listIssues(parsed.value, filter);
+      if (!result.ok) {
+        return `list_issues error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        result.value.map((issue) => ({
+          number: issue.number.value,
+          title: issue.title,
+          state: issue.state,
+          labels: issue.labels,
+          authorLogin: issue.authorLogin,
+          updatedAt: issue.updatedAt.toISOString(),
+          htmlUrl: issue.htmlUrl,
+        })),
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "list_issue_comments",
+    description:
+      "Fetch the comment thread for a GitHub issue. Returns all comments in chronological order with author + body. Use this when the issue body alone doesn't contain the resolution context (e.g., decisions reached in the comment thread).",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      number: z.number().int().positive().describe("Issue number"),
+    }),
+    execute: async ({ repo, number }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `list_issue_comments error: ${parsed.message}`;
+      const result = await client.listIssueComments(parsed.value, makeIssueNumber(Number(number)));
+      if (!result.ok) {
+        return `list_issue_comments error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        result.value.map((c) => ({
+          id: c.id,
+          authorLogin: c.authorLogin,
+          body: c.body,
+          createdAt: c.createdAt.toISOString(),
+          htmlUrl: c.htmlUrl,
+        })),
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "list_issue_labels",
+    description:
+      "Fetch the current labels on a GitHub issue. Useful for checking governance state (e.g. assigned:<agent>, status:*) without re-reading the whole issue.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      number: z.number().int().positive().describe("Issue number"),
+    }),
+    execute: async ({ repo, number }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `list_issue_labels error: ${parsed.message}`;
+      const result = await client.listIssueLabels(parsed.value, makeIssueNumber(Number(number)));
+      if (!result.ok) {
+        return `list_issue_labels error: ${result.error.code} — ${result.error.message}`;
+      }
+      return result.value.join("\n");
+    },
+  },
+  {
+    name: "get_branch_head",
+    description:
+      "Fetch the HEAD commit oid of a branch in a repository. Read-only lookup; useful before proposing a commit (the WakeAction pipeline needs the expected head to safely commit).",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      branch: z.string().describe('Branch name (e.g. "main")'),
+    }),
+    execute: async ({ repo, branch }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `get_branch_head error: ${parsed.message}`;
+      const result = await client.getRef(parsed.value, String(branch));
+      if (!result.ok) {
+        return `get_branch_head error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        {
+          repo: `${result.value.repo.owner.value}/${result.value.repo.name.value}`,
+          branch: result.value.branch,
+          oid: result.value.oid,
+        },
+        null,
+        2,
+      );
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- Adds a built-in \`github\` extension that exposes five read-only tools wrapping the harness's existing \`GithubClient\`:
  - \`read_issue(repo, number)\`
  - \`list_issues(repo, state?, labels?, perPage?)\`
  - \`list_issue_comments(repo, number)\`
  - \`list_issue_labels(repo, number)\`
  - \`get_branch_head(repo, branch)\`
- Reuses \`GITHUB_TOKEN\` from \`.env\` — one auth path, no operator extra setup.
- Boot.ts now constructs a GithubClient for read-only agents (no declared write scopes); any write attempt fails-closed with \"no write scopes configured\" (existing GithubClient behavior).
- Auto-included for every agent when \`GITHUB_TOKEN\` is present (parallels \`files\`/\`memory\` auto-include).
- Replaces #256, which was filed against the wrong premise (bodies were already in the SignalBundle since #248; the actual gap was \"agents have no GitHub tools at all\").

Closes #256 via replacement.

## Why

Yesterday's GPT-5.5 cost test surfaced the real gap. The security-agent's TENSION explicitly said:

> Security Agent is assigned PR/commit review and GitHub-commenting tasks while this wake exposes no PR/commit inspection tool and no GitHub issue/PR comment tool, causing legitimate blockers on #606, #481, #468, #629

The signal aggregator surfaces issues the agent is *assigned* to. But agents need to read *referenced* issues (cross-issue context), comment threads (resolution discussion), and branch state. None of that was reachable from inside a wake.

## Architecture choice

Considered four options:
1. \`gh\` CLI as shell-exec'd tool — bypasses ADR-0017 write scopes, doubles auth surface.
2. \`server-github\` MCP — separate auth, no scope awareness, no cost-ledger integration.
3. **Built-in extension wrapping existing GithubClient** — typed surface, single auth, scope-aware, integrates with WakeCostBuilder.
4. Hybrid: reads as tools, writes via existing WakeAction pipeline. **(picked)**

Writes intentionally NOT added: the existing WakeAction pipeline handles writes post-wake under ADR-0017 scope enforcement with the Boundary 5 narrative-vs-action audit (#240). Direct write tools would reopen that hole.

## Test plan

- [x] \`pnpm run check\` — 52 files / 710 tests pass (up from 51 / 700).
- [x] 10 new unit tests in \`packages/cli/src/github-tools/github-tools.test.ts\` covering tool list shape, repo parsing, client error surfaces, and filter pass-through.
- [x] Lint + format clean.
- [ ] Live: rerun yesterday's security-agent wake against directive #631 with the new tools and confirm the agent uses \`read_issue\` for the referenced #606/#481/#468 instead of TENSION-ing about the missing capability.

## Out of scope (follow-ups)

- **Cost tracking attribution:** the boot-time GithubClient used by these tools does NOT yet carry a per-wake \`defaultCostHook\`. Read calls don't land in the per-wake \`WakeCostBuilder\`. Total counts still surface via the daemon-level token's GitHub-side rate-limit headers. Threading the per-wake cost hook into agent-bound github tools is a follow-up.
- **Per-agent read scopes:** today, any agent with the github extension can read any repo the \`GITHUB_TOKEN\` can access. Add read_scopes alongside write_scopes if cross-agent isolation matters.
- **Pull-request-shaped tools** (\`get_pr\`, \`list_pr_files\`, \`get_commit_diff\`): the GithubClient doesn't expose these today. Adding them is mechanical when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)