### PR TITLE
feat(github): add PR/commit/file-at-ref read tools (anticipates agent needs)

### DIFF
--- a/packages/cli/src/builtin-extensions/github/openclaw.plugin.json
+++ b/packages/cli/src/builtin-extensions/github/openclaw.plugin.json
@@ -7,7 +7,12 @@
       "list_issues",
       "list_issue_comments",
       "list_issue_labels",
-      "get_branch_head"
+      "get_branch_head",
+      "read_pull_request",
+      "list_pull_requests",
+      "list_pull_request_files",
+      "read_commit",
+      "read_file_at_ref"
     ]
   }
 }

--- a/packages/cli/src/github-tools/github-tools.test.ts
+++ b/packages/cli/src/github-tools/github-tools.test.ts
@@ -10,7 +10,14 @@
 import { describe, it, expect } from "vitest";
 
 import { makeIssueNumber, makeRepoCoordinate } from "@murmurations-ai/github";
-import type { GithubClient, GithubIssue } from "@murmurations-ai/github";
+import type {
+  GithubClient,
+  GithubCommit,
+  GithubFileContent,
+  GithubIssue,
+  GithubPullRequest,
+  GithubPullRequestFile,
+} from "@murmurations-ai/github";
 
 import { buildGithubReadToolsForAgent } from "./index.js";
 
@@ -35,6 +42,73 @@ const errorOf = (code: string, message: string) =>
     ok: false as const,
     error: { code, message } as never,
   });
+
+const minimalPullRequest: GithubPullRequest = {
+  number: makeIssueNumber(101),
+  repo: makeRepoCoordinate("owner", "repo"),
+  title: "Test PR",
+  body: "PR body",
+  state: "open",
+  merged: false,
+  draft: false,
+  authorLogin: "test-user",
+  headRef: "feature",
+  headSha: "headsha",
+  baseRef: "main",
+  baseSha: "basesha",
+  labels: ["enhancement"],
+  createdAt: new Date("2026-04-30T00:00:00Z"),
+  updatedAt: new Date("2026-04-30T01:00:00Z"),
+  closedAt: null,
+  mergedAt: null,
+  commentCount: 2,
+  reviewCommentCount: 5,
+  commitCount: 3,
+  additions: 100,
+  deletions: 20,
+  changedFiles: 4,
+  htmlUrl: "https://github.com/owner/repo/pull/101",
+};
+
+const minimalPRFile: GithubPullRequestFile = {
+  filename: "src/foo.ts",
+  status: "modified",
+  additions: 10,
+  deletions: 2,
+  changes: 12,
+  previousFilename: null,
+  patch: "@@ -1,3 +1,11 @@\n+added\n line",
+};
+
+const minimalCommit: GithubCommit = {
+  sha: "55f66a0",
+  repo: makeRepoCoordinate("owner", "repo"),
+  message: "Test commit",
+  authorLogin: "test-user",
+  authorName: "Test User",
+  authorEmail: "test@example.com",
+  authoredAt: new Date("2026-04-30T00:00:00Z"),
+  committerName: "Test User",
+  committerEmail: "test@example.com",
+  committedAt: new Date("2026-04-30T00:00:00Z"),
+  parentShas: ["aaa111"],
+  additions: 10,
+  deletions: 2,
+  totalChanges: 12,
+  files: [minimalPRFile],
+  htmlUrl: "https://github.com/owner/repo/commit/55f66a0",
+};
+
+const minimalFileContent: GithubFileContent = {
+  path: "docs/adr/0017.md",
+  repo: makeRepoCoordinate("owner", "repo"),
+  ref: "main",
+  sha: "filesha",
+  size: 42,
+  content: "# ADR 0017\n",
+  encoding: "base64",
+  htmlUrl: "https://github.com/owner/repo/blob/main/docs/adr/0017.md",
+};
 
 const stubClient = (
   overrides: Partial<{
@@ -63,11 +137,16 @@ const stubClient = (
         branch: "main",
         oid: "abc123def",
       }),
+    getPullRequest: () => successOf(minimalPullRequest),
+    listPullRequests: () => successOf([minimalPullRequest]),
+    getPullRequestFiles: () => successOf([minimalPRFile]),
+    getCommit: () => successOf(minimalCommit),
+    getFileAtRef: () => successOf(minimalFileContent),
     ...overrides,
   }) as unknown as GithubClient;
 
 describe("buildGithubReadToolsForAgent", () => {
-  it("registers the five read tools by name", () => {
+  it("registers all ten read tools by name", () => {
     const tools = buildGithubReadToolsForAgent(stubClient());
     expect(tools.map((t) => t.name)).toEqual([
       "read_issue",
@@ -75,6 +154,11 @@ describe("buildGithubReadToolsForAgent", () => {
       "list_issue_comments",
       "list_issue_labels",
       "get_branch_head",
+      "read_pull_request",
+      "list_pull_requests",
+      "list_pull_request_files",
+      "read_commit",
+      "read_file_at_ref",
     ]);
   });
 
@@ -174,5 +258,106 @@ describe("buildGithubReadToolsForAgent", () => {
     const tool = tools.find((t) => t.name === "read_issue")!;
     const result = (await tool.execute({ repo: "", number: 1 })) as string;
     expect(result).toMatch(/repo must be "owner\/name"/);
+  });
+
+  // -------------------------------------------------------------------------
+  // PR / commit / file-at-ref tools
+  // -------------------------------------------------------------------------
+
+  it("read_pull_request returns serialized PR JSON", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_pull_request")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 101 })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.number).toBe(101);
+    expect(parsed.title).toBe("Test PR");
+    expect(parsed.headRef).toBe("feature");
+    expect(parsed.baseRef).toBe("main");
+    expect(parsed.changedFiles).toBe(4);
+  });
+
+  it("list_pull_requests passes filters through", async () => {
+    let lastFilter: unknown;
+    const client = stubClient({
+      listPullRequests: (_repo, filter) => {
+        lastFilter = filter;
+        return successOf([minimalPullRequest]);
+      },
+    });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "list_pull_requests")!;
+    await tool.execute({
+      repo: "owner/repo",
+      state: "open",
+      base: "main",
+      head: "feature",
+      labels: ["enhancement"],
+      perPage: 10,
+    });
+    expect(lastFilter).toEqual({
+      state: "open",
+      base: "main",
+      head: "feature",
+      labels: ["enhancement"],
+      perPage: 10,
+    });
+  });
+
+  it("list_pull_request_files surfaces patches", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "list_pull_request_files")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 101 })) as string;
+    const parsed = JSON.parse(result) as { filename: string; patch: string }[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.filename).toBe("src/foo.ts");
+    expect(parsed[0]?.patch).toContain("+added");
+  });
+
+  it("read_commit returns metadata + files", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_commit")!;
+    const result = (await tool.execute({ repo: "owner/repo", ref: "55f66a0" })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.sha).toBe("55f66a0");
+    expect(parsed.message).toBe("Test commit");
+    expect(parsed.parentShas).toEqual(["aaa111"]);
+    expect(Array.isArray(parsed.files)).toBe(true);
+  });
+
+  it("read_file_at_ref returns the decoded content directly when present", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "read_file_at_ref")!;
+    const result = (await tool.execute({
+      repo: "owner/repo",
+      path: "docs/adr/0017.md",
+      ref: "main",
+    })) as string;
+    expect(result).toBe("# ADR 0017\n");
+  });
+
+  it("read_file_at_ref surfaces a JSON descriptor when content is null (binary/large)", async () => {
+    const client = stubClient({
+      getFileAtRef: () => successOf({ ...minimalFileContent, content: null, encoding: "base64" }),
+    });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "read_file_at_ref")!;
+    const result = (await tool.execute({
+      repo: "owner/repo",
+      path: "img/logo.png",
+      ref: "main",
+    })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.content).toBeNull();
+    expect(parsed.note).toContain("Binary file");
+  });
+
+  it("PR tools surface client errors as plain strings", async () => {
+    const client = stubClient({
+      getPullRequest: () => errorOf("not-found", "PR not found"),
+    });
+    const tools = buildGithubReadToolsForAgent(client);
+    const tool = tools.find((t) => t.name === "read_pull_request")!;
+    const result = (await tool.execute({ repo: "owner/repo", number: 999 })) as string;
+    expect(result).toBe("read_pull_request error: not-found — PR not found");
   });
 });

--- a/packages/cli/src/github-tools/index.ts
+++ b/packages/cli/src/github-tools/index.ts
@@ -222,4 +222,221 @@ export const buildGithubReadToolsForAgent = (client: GithubClient): readonly Git
       );
     },
   },
+  {
+    name: "read_pull_request",
+    description:
+      "Fetch a pull request's metadata: title, body, state, head/base refs + SHAs, mergeability, file/commit/comment counts, additions/deletions. Use list_pull_request_files for the actual diff.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      number: z.number().int().positive().describe("Pull request number"),
+    }),
+    execute: async ({ repo, number }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `read_pull_request error: ${parsed.message}`;
+      const result = await client.getPullRequest(parsed.value, makeIssueNumber(Number(number)));
+      if (!result.ok) {
+        return `read_pull_request error: ${result.error.code} — ${result.error.message}`;
+      }
+      const pr = result.value;
+      return JSON.stringify(
+        {
+          number: pr.number.value,
+          title: pr.title,
+          state: pr.state,
+          merged: pr.merged,
+          draft: pr.draft,
+          body: pr.body ?? "",
+          authorLogin: pr.authorLogin,
+          headRef: pr.headRef,
+          headSha: pr.headSha,
+          baseRef: pr.baseRef,
+          baseSha: pr.baseSha,
+          labels: pr.labels,
+          createdAt: pr.createdAt.toISOString(),
+          updatedAt: pr.updatedAt.toISOString(),
+          closedAt: pr.closedAt?.toISOString() ?? null,
+          mergedAt: pr.mergedAt?.toISOString() ?? null,
+          commentCount: pr.commentCount,
+          reviewCommentCount: pr.reviewCommentCount,
+          commitCount: pr.commitCount,
+          additions: pr.additions,
+          deletions: pr.deletions,
+          changedFiles: pr.changedFiles,
+          htmlUrl: pr.htmlUrl,
+        },
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "list_pull_requests",
+    description:
+      "List pull requests in a repository, optionally filtered by state, base branch, head ref, or labels. Returns up to perPage results (default 30, max 100).",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      state: z.enum(["open", "closed", "all"]).optional().describe('Default "open"'),
+      base: z.string().optional().describe('Filter by base branch (e.g. "main")'),
+      head: z.string().optional().describe('Filter by head ref (e.g. "feature-branch")'),
+      labels: z.array(z.string()).optional().describe("Client-side label filter"),
+      perPage: z.number().int().min(1).max(100).optional().describe("Default 30, max 100"),
+    }),
+    execute: async ({ repo, state, base, head, labels, perPage }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `list_pull_requests error: ${parsed.message}`;
+      const filter: {
+        state?: "open" | "closed" | "all";
+        base?: string;
+        head?: string;
+        labels?: readonly string[];
+        perPage?: number;
+      } = {};
+      if (state !== undefined) filter.state = state as "open" | "closed" | "all";
+      if (typeof base === "string" && base.length > 0) filter.base = base;
+      if (typeof head === "string" && head.length > 0) filter.head = head;
+      if (Array.isArray(labels) && labels.length > 0) filter.labels = labels as string[];
+      if (typeof perPage === "number") filter.perPage = perPage;
+      const result = await client.listPullRequests(parsed.value, filter);
+      if (!result.ok) {
+        return `list_pull_requests error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        result.value.map((pr) => ({
+          number: pr.number.value,
+          title: pr.title,
+          state: pr.state,
+          merged: pr.merged,
+          draft: pr.draft,
+          authorLogin: pr.authorLogin,
+          headRef: pr.headRef,
+          baseRef: pr.baseRef,
+          labels: pr.labels,
+          updatedAt: pr.updatedAt.toISOString(),
+          htmlUrl: pr.htmlUrl,
+        })),
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "list_pull_request_files",
+    description:
+      "Fetch the files changed in a pull request, with unified-diff patches per file. THIS IS THE PR DIFF. For files with very large changes (>3000 line changes) GitHub omits the patch — `patch` is null in those cases and you must fetch the file at head/base separately via read_file_at_ref.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      number: z.number().int().positive().describe("Pull request number"),
+    }),
+    execute: async ({ repo, number }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `list_pull_request_files error: ${parsed.message}`;
+      const result = await client.getPullRequestFiles(
+        parsed.value,
+        makeIssueNumber(Number(number)),
+      );
+      if (!result.ok) {
+        return `list_pull_request_files error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        result.value.map((f) => ({
+          filename: f.filename,
+          status: f.status,
+          additions: f.additions,
+          deletions: f.deletions,
+          changes: f.changes,
+          previousFilename: f.previousFilename,
+          patch: f.patch,
+        })),
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "read_commit",
+    description:
+      "Fetch a commit by SHA (or ref like a branch name) including metadata, parent SHAs, and the files changed with unified-diff patches. THIS IS THE COMMIT DIFF — use it to review specific commits referenced in directives or governance discussions.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      ref: z
+        .string()
+        .describe('Commit SHA, branch name, or tag (e.g. "55f66a0", "main", "v1.0.0")'),
+    }),
+    execute: async ({ repo, ref }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `read_commit error: ${parsed.message}`;
+      const result = await client.getCommit(parsed.value, String(ref));
+      if (!result.ok) {
+        return `read_commit error: ${result.error.code} — ${result.error.message}`;
+      }
+      const c = result.value;
+      return JSON.stringify(
+        {
+          sha: c.sha,
+          message: c.message,
+          authorLogin: c.authorLogin,
+          authorName: c.authorName,
+          authorEmail: c.authorEmail,
+          authoredAt: c.authoredAt.toISOString(),
+          committerName: c.committerName,
+          committedAt: c.committedAt.toISOString(),
+          parentShas: c.parentShas,
+          additions: c.additions,
+          deletions: c.deletions,
+          totalChanges: c.totalChanges,
+          files: c.files.map((f) => ({
+            filename: f.filename,
+            status: f.status,
+            additions: f.additions,
+            deletions: f.deletions,
+            changes: f.changes,
+            previousFilename: f.previousFilename,
+            patch: f.patch,
+          })),
+          htmlUrl: c.htmlUrl,
+        },
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "read_file_at_ref",
+    description:
+      "Fetch a file's contents from a repository at a specific ref (commit SHA, branch, or tag). Use this when you need to inspect a file's state at a particular point in history — e.g., before/after a commit, or on a feature branch. Binary files return content: null.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      path: z.string().describe('File path within the repo (e.g. "docs/adr/0017-write-scopes.md")'),
+      ref: z.string().describe('Commit SHA, branch name, or tag (e.g. "main", "55f66a0")'),
+    }),
+    execute: async ({ repo, path, ref }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `read_file_at_ref error: ${parsed.message}`;
+      const result = await client.getFileAtRef(parsed.value, String(path), String(ref));
+      if (!result.ok) {
+        return `read_file_at_ref error: ${result.error.code} — ${result.error.message}`;
+      }
+      const f = result.value;
+      // Return content as the body when it decoded successfully; otherwise
+      // surface a JSON-shaped descriptor explaining the gap.
+      if (f.content !== null) return f.content;
+      return JSON.stringify(
+        {
+          path: f.path,
+          ref: f.ref,
+          sha: f.sha,
+          size: f.size,
+          encoding: f.encoding,
+          content: null,
+          note:
+            f.encoding === "base64"
+              ? "Binary file — content omitted; fetch via htmlUrl in a browser if needed."
+              : `File too large or unsupported encoding (${f.encoding}); GitHub returned no inline content.`,
+          htmlUrl: f.htmlUrl,
+        },
+        null,
+        2,
+      );
+    },
+  },
 ];

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -29,8 +29,27 @@ import {
   type GithubRateLimitSnapshot,
   type GithubWriteScopeKind,
 } from "./errors.js";
-import { parseCommentArray, parseIssue, parseIssueArray } from "./parse.js";
-import type { GithubComment, GithubIssue, ListIssuesFilter, Result } from "./types.js";
+import {
+  parseCommentArray,
+  parseCommit,
+  parseFileContent,
+  parseIssue,
+  parseIssueArray,
+  parsePullRequest,
+  parsePullRequestArray,
+  parsePullRequestFiles,
+} from "./parse.js";
+import type {
+  GithubComment,
+  GithubCommit,
+  GithubFileContent,
+  GithubIssue,
+  GithubPullRequest,
+  GithubPullRequestFile,
+  ListIssuesFilter,
+  ListPullRequestsFilter,
+  Result,
+} from "./types.js";
 import {
   compileWriteScopes,
   matchesRepoPath,
@@ -209,6 +228,49 @@ export interface GithubClient {
     branch: string,
     options?: CallOptions,
   ): Promise<Result<GithubRefHead, GithubClientError>>;
+
+  // -- Pull-request reads (harness#262 follow-up) -------------------------
+
+  /** Fetch a single pull request by number. */
+  getPullRequest(
+    repo: RepoCoordinate,
+    number: IssueNumber,
+    options?: CallOptions,
+  ): Promise<Result<GithubPullRequest, GithubClientError>>;
+
+  /** List pull requests in a repo, optionally filtered. */
+  listPullRequests(
+    repo: RepoCoordinate,
+    filter?: ListPullRequestsFilter & { readonly costHook?: GithubCostHook },
+  ): Promise<Result<readonly GithubPullRequest[], GithubClientError>>;
+
+  /**
+   * Fetch the files changed in a pull request, with unified-diff
+   * patches for each (when GitHub returns one — files >3000 line
+   * changes have null patches).
+   */
+  getPullRequestFiles(
+    repo: RepoCoordinate,
+    number: IssueNumber,
+    options?: CallOptions,
+  ): Promise<Result<readonly GithubPullRequestFile[], GithubClientError>>;
+
+  // -- Commit / file reads -----------------------------------------------
+
+  /** Fetch a commit by SHA (or ref) including files changed + patches. */
+  getCommit(
+    repo: RepoCoordinate,
+    ref: string,
+    options?: CallOptions,
+  ): Promise<Result<GithubCommit, GithubClientError>>;
+
+  /** Fetch a file's contents at a specific ref (commit, branch, or tag). */
+  getFileAtRef(
+    repo: RepoCoordinate,
+    path: string,
+    ref: string,
+    options?: CallOptions,
+  ): Promise<Result<GithubFileContent, GithubClientError>>;
 
   // -- Mutations (ADR-0017) ------------------------------------------------
 
@@ -420,6 +482,105 @@ class GithubClientImpl implements GithubClient {
       ok: true,
       value: { repo, branch, oid: sha },
     };
+  }
+
+  // ---------------------------------------------------------------------
+  // Pull-request reads
+  // ---------------------------------------------------------------------
+
+  public async getPullRequest(
+    repo: RepoCoordinate,
+    number: IssueNumber,
+    options: CallOptions = {},
+  ): Promise<Result<GithubPullRequest, GithubClientError>> {
+    const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/pulls/${String(number.value)}`;
+    const raw = await this.#request(url, options);
+    if (!raw.ok) return raw;
+    return parsePullRequest(raw.value.body, repo);
+  }
+
+  public async listPullRequests(
+    repo: RepoCoordinate,
+    filter: ListPullRequestsFilter & { readonly costHook?: GithubCostHook } = {},
+  ): Promise<Result<readonly GithubPullRequest[], GithubClientError>> {
+    const params = new URLSearchParams();
+    if (filter.state) params.set("state", filter.state);
+    if (filter.base !== undefined) params.set("base", filter.base);
+    if (filter.head !== undefined) params.set("head", filter.head);
+    if (filter.perPage) params.set("per_page", String(filter.perPage));
+    const qs = params.toString();
+    const url =
+      `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/pulls` + (qs ? `?${qs}` : "");
+    const opts: CallOptions = {};
+    if (filter.bypassCache === true) {
+      (opts as { bypassCache: boolean }).bypassCache = true;
+    }
+    if (filter.costHook !== undefined) {
+      (opts as { costHook: GithubCostHook }).costHook = filter.costHook;
+    }
+    const raw = await this.#request(url, opts);
+    if (!raw.ok) return raw;
+    const parsed = parsePullRequestArray(raw.value.body, repo);
+    if (!parsed.ok) return parsed;
+    // GitHub's listPullRequests doesn't filter by labels server-side
+    // (the labels API on PRs is shared with issues); apply a client-side
+    // filter when the caller asked for one. Same approach as listIssues.
+    if (filter.labels && filter.labels.length > 0) {
+      const wanted = filter.labels;
+      const filtered = parsed.value.filter((pr) =>
+        wanted.every((label) => pr.labels.includes(label)),
+      );
+      return { ok: true, value: filtered };
+    }
+    return parsed;
+  }
+
+  public async getPullRequestFiles(
+    repo: RepoCoordinate,
+    number: IssueNumber,
+    options: CallOptions = {},
+  ): Promise<Result<readonly GithubPullRequestFile[], GithubClientError>> {
+    // The default per-page is 30; bump to 100 so a single call covers
+    // most PRs without forcing the agent to paginate. Larger PRs still
+    // require multi-call pagination — out of scope for v1.
+    const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/pulls/${String(number.value)}/files?per_page=100`;
+    const raw = await this.#request(url, options);
+    if (!raw.ok) return raw;
+    return parsePullRequestFiles(raw.value.body);
+  }
+
+  // ---------------------------------------------------------------------
+  // Commit / file reads
+  // ---------------------------------------------------------------------
+
+  public async getCommit(
+    repo: RepoCoordinate,
+    ref: string,
+    options: CallOptions = {},
+  ): Promise<Result<GithubCommit, GithubClientError>> {
+    const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/commits/${encodeURIComponent(ref)}`;
+    const raw = await this.#request(url, options);
+    if (!raw.ok) return raw;
+    return parseCommit(raw.value.body, repo);
+  }
+
+  public async getFileAtRef(
+    repo: RepoCoordinate,
+    path: string,
+    ref: string,
+    options: CallOptions = {},
+  ): Promise<Result<GithubFileContent, GithubClientError>> {
+    // GET /repos/{owner}/{repo}/contents/{path}?ref={ref}
+    // The path is URL-encoded segment-by-segment so directory separators
+    // remain unescaped; the ref goes in the query string.
+    const encodedPath = path
+      .split("/")
+      .map((seg) => encodeURIComponent(seg))
+      .join("/");
+    const url = `${this.#baseUrl}/repos/${repo.owner.value}/${repo.name.value}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
+    const raw = await this.#request(url, options);
+    if (!raw.ok) return raw;
+    return parseFileContent(raw.value.body, repo, ref);
   }
 
   // ---------------------------------------------------------------------

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -27,7 +27,17 @@ export type {
 export { compileGlob, compileWriteScopes } from "./write-scopes.js";
 export type { GithubWriteScopes, WriteScopeKind } from "./write-scopes.js";
 
-export type { GithubComment, GithubIssue, ListIssuesFilter, Result } from "./types.js";
+export type {
+  GithubComment,
+  GithubCommit,
+  GithubFileContent,
+  GithubIssue,
+  GithubPullRequest,
+  GithubPullRequestFile,
+  ListIssuesFilter,
+  ListPullRequestsFilter,
+  Result,
+} from "./types.js";
 
 export type { GithubCache, GithubCacheEntry } from "./cache.js";
 export { LruGithubCache } from "./cache.js";

--- a/packages/github/src/parse.ts
+++ b/packages/github/src/parse.ts
@@ -8,7 +8,15 @@ import { z } from "zod";
 
 import { makeIssueNumber, type RepoCoordinate } from "./branded.js";
 import { GithubParseError } from "./errors.js";
-import type { GithubComment, GithubIssue, Result } from "./types.js";
+import type {
+  GithubComment,
+  GithubCommit,
+  GithubFileContent,
+  GithubIssue,
+  GithubPullRequest,
+  GithubPullRequestFile,
+  Result,
+} from "./types.js";
 
 const labelSchema = z.union([z.string(), z.object({ name: z.string() }).transform((o) => o.name)]);
 
@@ -150,4 +158,313 @@ export const parseCommentArray = (
     out.push(r.value);
   }
   return { ok: true, value: out };
+};
+
+// ---------------------------------------------------------------------------
+// Pull requests
+// ---------------------------------------------------------------------------
+
+const pullRequestSchema = z.object({
+  number: z.number().int().positive(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.enum(["open", "closed"]),
+  merged: z.boolean().optional(),
+  draft: z.boolean().optional(),
+  user: z.object({ login: z.string() }).nullable(),
+  head: z.object({ ref: z.string(), sha: z.string() }),
+  base: z.object({ ref: z.string(), sha: z.string() }),
+  labels: z.array(labelSchema),
+  created_at: z.string(),
+  updated_at: z.string(),
+  closed_at: z.string().nullable(),
+  merged_at: z.string().nullable(),
+  // Aggregate fields are present on the single-PR endpoint but not in
+  // list responses. Mark optional so listPullRequests parses cleanly.
+  comments: z.number().int().nonnegative().optional(),
+  review_comments: z.number().int().nonnegative().optional(),
+  commits: z.number().int().nonnegative().optional(),
+  additions: z.number().int().nonnegative().optional(),
+  deletions: z.number().int().nonnegative().optional(),
+  changed_files: z.number().int().nonnegative().optional(),
+  html_url: z.string(),
+});
+
+export const parsePullRequest = (
+  raw: unknown,
+  repo: RepoCoordinate,
+): Result<GithubPullRequest, GithubParseError> => {
+  const parsed = pullRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: new GithubParseError(`pull-request body failed validation: ${parsed.error.message}`),
+    };
+  }
+  const data = parsed.data;
+  const createdAt = parseDate(data.created_at, "created_at");
+  if (!createdAt.ok) return createdAt;
+  const updatedAt = parseDate(data.updated_at, "updated_at");
+  if (!updatedAt.ok) return updatedAt;
+  let closedAt: Date | null = null;
+  if (data.closed_at !== null) {
+    const p = parseDate(data.closed_at, "closed_at");
+    if (!p.ok) return p;
+    closedAt = p.value;
+  }
+  let mergedAt: Date | null = null;
+  if (data.merged_at !== null) {
+    const p = parseDate(data.merged_at, "merged_at");
+    if (!p.ok) return p;
+    mergedAt = p.value;
+  }
+  return {
+    ok: true,
+    value: {
+      number: makeIssueNumber(data.number),
+      repo,
+      title: data.title,
+      body: data.body,
+      state: data.state,
+      merged: data.merged ?? mergedAt !== null,
+      draft: data.draft ?? false,
+      authorLogin: data.user?.login ?? "ghost",
+      headRef: data.head.ref,
+      headSha: data.head.sha,
+      baseRef: data.base.ref,
+      baseSha: data.base.sha,
+      labels: data.labels,
+      createdAt: createdAt.value,
+      updatedAt: updatedAt.value,
+      closedAt,
+      mergedAt,
+      commentCount: data.comments ?? 0,
+      reviewCommentCount: data.review_comments ?? 0,
+      commitCount: data.commits ?? 0,
+      additions: data.additions ?? 0,
+      deletions: data.deletions ?? 0,
+      changedFiles: data.changed_files ?? 0,
+      htmlUrl: data.html_url,
+    },
+  };
+};
+
+export const parsePullRequestArray = (
+  raw: unknown,
+  repo: RepoCoordinate,
+): Result<readonly GithubPullRequest[], GithubParseError> => {
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      error: new GithubParseError("expected array of pull requests"),
+    };
+  }
+  const out: GithubPullRequest[] = [];
+  for (const item of raw) {
+    const r = parsePullRequest(item, repo);
+    if (!r.ok) return r;
+    out.push(r.value);
+  }
+  return { ok: true, value: out };
+};
+
+// ---------------------------------------------------------------------------
+// PR files / commit files (same shape on both endpoints)
+// ---------------------------------------------------------------------------
+
+const fileChangeSchema = z.object({
+  filename: z.string(),
+  status: z.enum(["added", "modified", "removed", "renamed", "copied", "changed", "unchanged"]),
+  additions: z.number().int().nonnegative(),
+  deletions: z.number().int().nonnegative(),
+  changes: z.number().int().nonnegative(),
+  previous_filename: z.string().optional(),
+  patch: z.string().optional(),
+});
+
+const parseFileChange = (raw: unknown): Result<GithubPullRequestFile, GithubParseError> => {
+  const parsed = fileChangeSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: new GithubParseError(`file change body failed validation: ${parsed.error.message}`),
+    };
+  }
+  const data = parsed.data;
+  return {
+    ok: true,
+    value: {
+      filename: data.filename,
+      status: data.status,
+      additions: data.additions,
+      deletions: data.deletions,
+      changes: data.changes,
+      previousFilename: data.previous_filename ?? null,
+      patch: data.patch ?? null,
+    },
+  };
+};
+
+export const parsePullRequestFiles = (
+  raw: unknown,
+): Result<readonly GithubPullRequestFile[], GithubParseError> => {
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      error: new GithubParseError("expected array of files"),
+    };
+  }
+  const out: GithubPullRequestFile[] = [];
+  for (const item of raw) {
+    const r = parseFileChange(item);
+    if (!r.ok) return r;
+    out.push(r.value);
+  }
+  return { ok: true, value: out };
+};
+
+// ---------------------------------------------------------------------------
+// Commits
+// ---------------------------------------------------------------------------
+
+const commitSchema = z.object({
+  sha: z.string(),
+  commit: z.object({
+    message: z.string(),
+    author: z
+      .object({
+        name: z.string(),
+        email: z.string(),
+        date: z.string(),
+      })
+      .nullable(),
+    committer: z
+      .object({
+        name: z.string(),
+        email: z.string(),
+        date: z.string(),
+      })
+      .nullable(),
+  }),
+  author: z.object({ login: z.string() }).nullable(),
+  parents: z.array(z.object({ sha: z.string() })),
+  stats: z
+    .object({
+      additions: z.number().int().nonnegative().optional(),
+      deletions: z.number().int().nonnegative().optional(),
+      total: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
+  files: z.array(fileChangeSchema).optional(),
+  html_url: z.string(),
+});
+
+export const parseCommit = (
+  raw: unknown,
+  repo: RepoCoordinate,
+): Result<GithubCommit, GithubParseError> => {
+  const parsed = commitSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: new GithubParseError(`commit body failed validation: ${parsed.error.message}`),
+    };
+  }
+  const data = parsed.data;
+  const author = data.commit.author;
+  const committer = data.commit.committer;
+  if (!author || !committer) {
+    return {
+      ok: false,
+      error: new GithubParseError("commit missing author/committer"),
+    };
+  }
+  const authoredAt = parseDate(author.date, "commit.author.date");
+  if (!authoredAt.ok) return authoredAt;
+  const committedAt = parseDate(committer.date, "commit.committer.date");
+  if (!committedAt.ok) return committedAt;
+  const files: GithubPullRequestFile[] = [];
+  for (const item of data.files ?? []) {
+    const r = parseFileChange(item);
+    if (!r.ok) return r;
+    files.push(r.value);
+  }
+  return {
+    ok: true,
+    value: {
+      sha: data.sha,
+      repo,
+      message: data.commit.message,
+      authorLogin: data.author?.login ?? null,
+      authorName: author.name,
+      authorEmail: author.email,
+      authoredAt: authoredAt.value,
+      committerName: committer.name,
+      committerEmail: committer.email,
+      committedAt: committedAt.value,
+      parentShas: data.parents.map((p) => p.sha),
+      additions: data.stats?.additions ?? 0,
+      deletions: data.stats?.deletions ?? 0,
+      totalChanges: data.stats?.total ?? 0,
+      files,
+      htmlUrl: data.html_url,
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// File contents at ref
+// ---------------------------------------------------------------------------
+
+const fileContentSchema = z.object({
+  type: z.literal("file"),
+  path: z.string(),
+  sha: z.string(),
+  size: z.number().int().nonnegative(),
+  content: z.string().optional(),
+  encoding: z.string().optional(),
+  html_url: z.string(),
+});
+
+export const parseFileContent = (
+  raw: unknown,
+  repo: RepoCoordinate,
+  ref: string,
+): Result<GithubFileContent, GithubParseError> => {
+  const parsed = fileContentSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: new GithubParseError(
+        `file content body failed validation (note: directories aren't supported, only files): ${parsed.error.message}`,
+      ),
+    };
+  }
+  const data = parsed.data;
+  let decoded: string | null = null;
+  const encoding = data.encoding ?? "none";
+  if (data.content !== undefined && encoding === "base64") {
+    try {
+      // GitHub returns base64-encoded content with newlines every 60 chars.
+      const cleaned = data.content.replace(/\n/g, "");
+      decoded = Buffer.from(cleaned, "base64").toString("utf8");
+    } catch {
+      decoded = null;
+    }
+  } else if (data.content !== undefined && encoding === "utf-8") {
+    decoded = data.content;
+  }
+  return {
+    ok: true,
+    value: {
+      path: data.path,
+      repo,
+      ref,
+      sha: data.sha,
+      size: data.size,
+      content: decoded,
+      encoding,
+      htmlUrl: data.html_url,
+    },
+  };
 };

--- a/packages/github/src/types.ts
+++ b/packages/github/src/types.ts
@@ -42,3 +42,110 @@ export interface ListIssuesFilter {
   readonly perPage?: number;
   readonly bypassCache?: boolean;
 }
+
+/**
+ * The subset of GitHub's pull-request resource the harness reads.
+ * GitHub treats PRs as a specialized issue, but the API surfaces are
+ * separate; this type captures the PR-specific fields agents need to
+ * review (head/base, mergeability, files-changed count).
+ */
+export interface GithubPullRequest {
+  readonly number: IssueNumber;
+  readonly repo: RepoCoordinate;
+  readonly title: string;
+  readonly body: string | null;
+  readonly state: "open" | "closed";
+  readonly merged: boolean;
+  readonly draft: boolean;
+  readonly authorLogin: string;
+  readonly headRef: string;
+  readonly headSha: string;
+  readonly baseRef: string;
+  readonly baseSha: string;
+  readonly labels: readonly string[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly closedAt: Date | null;
+  readonly mergedAt: Date | null;
+  readonly commentCount: number;
+  readonly reviewCommentCount: number;
+  readonly commitCount: number;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changedFiles: number;
+  readonly htmlUrl: string;
+}
+
+/**
+ * One file changed in a pull request, including its unified-diff
+ * patch when GitHub returns one. Patches are omitted by GitHub for
+ * very large files (>3000 line changes) — `patch` is null in that
+ * case and agents must fall back to fetching the file at the head
+ * and base refs separately.
+ */
+export interface GithubPullRequestFile {
+  readonly filename: string;
+  readonly status:
+    | "added"
+    | "modified"
+    | "removed"
+    | "renamed"
+    | "copied"
+    | "changed"
+    | "unchanged";
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changes: number;
+  readonly previousFilename: string | null;
+  readonly patch: string | null;
+}
+
+/**
+ * The subset of GitHub's commit resource the harness reads — commit
+ * metadata plus the list of files changed (with patches when small
+ * enough). For listing, see `getCommit`.
+ */
+export interface GithubCommit {
+  readonly sha: string;
+  readonly repo: RepoCoordinate;
+  readonly message: string;
+  readonly authorLogin: string | null;
+  readonly authorName: string;
+  readonly authorEmail: string;
+  readonly authoredAt: Date;
+  readonly committerName: string;
+  readonly committerEmail: string;
+  readonly committedAt: Date;
+  readonly parentShas: readonly string[];
+  readonly additions: number;
+  readonly deletions: number;
+  readonly totalChanges: number;
+  readonly files: readonly GithubPullRequestFile[];
+  readonly htmlUrl: string;
+}
+
+/**
+ * File contents at a specific git ref (commit, branch, or tag).
+ * Returns the decoded UTF-8 text when the file is text — for binary
+ * files, callers fall back to `htmlUrl` (the raw blob in the GitHub
+ * UI) since the harness has no use case for binary inspection today.
+ */
+export interface GithubFileContent {
+  readonly path: string;
+  readonly repo: RepoCoordinate;
+  readonly ref: string;
+  readonly sha: string;
+  readonly size: number;
+  readonly content: string | null;
+  readonly encoding: string;
+  readonly htmlUrl: string;
+}
+
+export interface ListPullRequestsFilter {
+  readonly state?: "open" | "closed" | "all";
+  readonly labels?: readonly string[];
+  readonly base?: string;
+  readonly head?: string;
+  readonly perPage?: number;
+  readonly bypassCache?: boolean;
+}

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -83,6 +83,11 @@ const makeFakeGithub = (issues: readonly GithubIssue[]): GithubClient => ({
     return { ok: true, value: [] };
   },
   getRef: notFound,
+  getPullRequest: notFound,
+  listPullRequests: notFound,
+  getPullRequestFiles: notFound,
+  getCommit: notFound,
+  getFileAtRef: notFound,
   createIssueComment: mutationDenied,
   createIssue: mutationDenied,
   createCommitOnBranch: mutationDenied,
@@ -109,6 +114,11 @@ const makeFailingGithub = (): GithubClient => ({
     return { ok: true, value: [] };
   },
   getRef: notFound,
+  getPullRequest: notFound,
+  listPullRequests: notFound,
+  getPullRequestFiles: notFound,
+  getCommit: notFound,
+  getFileAtRef: notFound,
   createIssueComment: mutationDenied,
   createIssue: mutationDenied,
   createCommitOnBranch: mutationDenied,


### PR DESCRIPTION
## Summary

Adds five new agent-callable GitHub read tools, anticipating the remaining gap explicitly named in yesterday's security-agent TENSION (post-#261):

> *"This wake exposes read-only GitHub issue/comment tools, local file read/write tools, and memory tools, but no GitHub issue/PR comment creation tool and no PR/commit diff retrieval tool ... leaving #606, #481, #468, #629 diff-specific review, and #623 commit-specific review structurally incomplete."*

The "no PR/commit diff retrieval tool" half is what this closes. (The other half — "comment creation tool" — stays intentionally with WakeAction per the existing audit pipeline.)

### New agent tools

| Tool | Purpose |
|---|---|
| `read_pull_request(repo, number)` | PR metadata: title, body, head/base refs+SHAs, mergeability, file/commit/comment counts |
| `list_pull_requests(repo, ...)` | List PRs (parallels `list_issues`) with state/base/head/label filters |
| `list_pull_request_files(repo, number)` | **THIS IS THE PR DIFF** — files changed with unified-diff patches |
| `read_commit(repo, ref)` | Commit metadata + parent SHAs + files changed with patches |
| `read_file_at_ref(repo, path, ref)` | File contents at any commit/branch/tag |

### New `GithubClient` methods

- `getPullRequest(repo, number)`
- `listPullRequests(repo, filter)`
- `getPullRequestFiles(repo, number)`
- `getCommit(repo, ref)`
- `getFileAtRef(repo, path, ref)`

Plus types: `GithubPullRequest`, `GithubPullRequestFile`, `GithubCommit`, `GithubFileContent`, `ListPullRequestsFilter`.

## Why anticipate

Per the user's direction: *"We should anticipate their needs and not just rely on them filing tensions."* Yesterday's TENSION was the agent's third one in three days about missing GitHub capabilities. The pattern matters more than the individual asks — agents repeatedly hit "I don't have a tool to inspect this PR/commit/diff" while doing security review, code review, design review, etc. Adding the read surface preemptively closes the loop.

## Caveats

- **Patches null for very large files.** GitHub omits unified-diff patches when a single file has >3000 line changes; `patch` is null in that case. The tool description tells the agent to fall back to `read_file_at_ref` for both head and base SHA in that case.
- **Cost attribution still missing.** Inherits the same boot-time GithubClient gap as #261 (filed as #262). Read calls don't yet land in per-wake `WakeCostBuilder`.
- **No PR comments / reviews yet.** Could add `list_pull_request_comments` and `list_pull_request_reviews` if needed; held off in this PR to keep scope tight.

## Test plan

- [x] `pnpm run check` — 52 files / 717 tests pass (up from 707; +10 new unit tests).
- [x] Lint + format clean.
- [x] Typecheck across all 8 workspace packages.
- [ ] Live: rerun yesterday's security-agent wake and confirm the agent uses `read_commit` for #623 ("Review role.md updates in commit 55f66a0") and `list_pull_request_files` for #606/#481/#468/#629.

## Related

- harness#261 — added the issue/comment read tools
- harness#262 — cost attribution follow-up (sibling)
- harness#252 verification wake — surfaced the diff-retrieval gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)