### PR TITLE
fix(convene): wire GitHub read tools to group meeting LLM calls (#264)

### DIFF
--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -30,6 +30,7 @@ import {
   type GovernanceTally,
   GovernanceStateStore,
 } from "@murmurations-ai/core";
+import { createGithubClient } from "@murmurations-ai/github";
 import { createLLMClient, formatLLMError, type LLMClient } from "@murmurations-ai/llm";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 
@@ -39,6 +40,7 @@ import {
   CollaborationBuildError,
   findDefaultRepo,
 } from "./collaboration-factory.js";
+import { buildGithubReadToolsForAgent } from "./github-tools/index.js";
 
 /**
  * Discriminated result for resolving the facilitator's LLM config.
@@ -442,7 +444,14 @@ export const runGroupWakeCommand = async (
   const secretKeyName = typeof envKeyName === "string" ? envKeyName : undefined;
   if (existsSync(envPath)) {
     secretsProvider = new DotenvSecretsProvider({ envPath });
-    const optionalKeys = secretKeyName ? [makeSecretKey(secretKeyName)] : [];
+    // Load the LLM provider's token AND GITHUB_TOKEN. The latter is needed
+    // for harness#264: members and facilitator need GitHub read tools so
+    // they can verify issue/PR/commit references during the meeting,
+    // matching what solo wakes get via boot.ts:selectExtensionToolsFor.
+    const optionalKeys = [
+      ...(secretKeyName ? [makeSecretKey(secretKeyName)] : []),
+      makeSecretKey("GITHUB_TOKEN"),
+    ];
     await secretsProvider.load({ required: [], optional: optionalKeys });
     const tokenKey = secretKeyName ? makeSecretKey(secretKeyName) : null;
     if (envKeyName === null) {
@@ -614,10 +623,29 @@ export const runGroupWakeCommand = async (
   const { loadExtensions } = await import("@murmurations-ai/core");
   const extensionsDir = join(root, "extensions");
   const loadedExtensions = await loadExtensions(extensionsDir, root);
-  const extensionTools = loadedExtensions.flatMap((ext) => ext.tools);
+  const operatorExtensionTools = loadedExtensions.flatMap((ext) => ext.tools);
+
+  // harness#264: wire built-in GitHub read tools into convene the same way
+  // boot.ts wires them for solo wakes (selectExtensionToolsFor → buildAgentBoundGithub).
+  // Without this, members and facilitator can never verify issue/PR/commit
+  // references during a meeting — they're stuck with whatever leaked into the
+  // signal bundle. Reads are idempotent, so a single shared client across the
+  // meeting is safe; ADR-0017 write-scope enforcement still routes mutations
+  // through the WakeAction pipeline post-meeting.
+  const githubTokenKey = makeSecretKey("GITHUB_TOKEN");
+  const githubReadTools =
+    secretsProvider?.has(githubTokenKey) === true
+      ? buildGithubReadToolsForAgent(
+          createGithubClient({ token: secretsProvider.get(githubTokenKey) }),
+        )
+      : [];
+
+  const extensionTools = [...operatorExtensionTools, ...githubReadTools];
   if (extensionTools.length > 0) {
+    const githubMsg =
+      githubReadTools.length > 0 ? `, ${String(githubReadTools.length)} github` : "";
     console.log(
-      `  Extensions: ${String(loadedExtensions.length)} loaded (${String(extensionTools.length)} tools)`,
+      `  Extensions: ${String(loadedExtensions.length)} loaded (${String(operatorExtensionTools.length)} operator${githubMsg} tools)`,
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #264 — \`murmuration convene\` now wires the 10 GitHub read tools (from #261/#263) into the LLM calls used by member contributions, agenda generation, and facilitator synthesis. Previously these tools were only available in solo wakes via \`boot.ts:selectExtensionToolsFor\` and were structurally invisible to convene-mode wakes.

## Why now

Two convene runs of the same engineering circle directive on 2026-05-01 made the gap concrete:

| | No tools (default branch) | With tools (this PR) |
|---|---|---|
| LLM | anthropic/claude-sonnet-4-6 | anthropic/claude-sonnet-4-6 |
| Input tokens | 22,535 | **413,277** (~18×) |
| Output tokens | 15,315 | **32,208** (~2×) |
| Cost | \$0.0126 | **\$0.0813** (~6.5×) |
| Actions executed | 45 | 50 |
| Issue references | sparse, hallucinated cross-circle (#634/#635) | **dense, grounded** (#262, #246, #240, #243, #225, #215, #9, #222 — verified existent) |

The 18× input-token jump is the smoking gun: tool definitions + tool-call results are now in the conversation. The verification run's facilitator independently filed a TENSION on convene-mode verification gaps that exactly matches the proposal sketch in #264, and one of its parsed action items is *literally* this PR's design (\"Wire to facilitator synthesis call only, not member contribution calls\").

## What changed

- \`packages/cli/src/group-wake.ts\` only:
  - Import \`createGithubClient\` and \`buildGithubReadToolsForAgent\`
  - Add \`GITHUB_TOKEN\` to the optional secrets loaded by \`secretsProvider\`
  - When the token is present, build a \`GithubClient\` + the 10 read tools and concat them onto the existing \`extensionTools\` array
  - Log \`\"Extensions: N loaded (X operator, 10 github tools)\"\` for visibility
- One file, +31 / −3 lines

## Cost note (and v2 follow-up)

This implementation gives tools to all 6 members + facilitator + agenda-gen → 6.5× cost. The agents in the verification convene independently proposed the cost-optimized v2: wire tools to **facilitator synthesis only** (1× multiplier). That requires a \`phase\` field on \`GroupWakeRunnerDeps.callLLM\` (a core API change with cascading test updates), so it's tracked as a separate issue. The current v1 still resolves the structural blocker — meeting minutes can no longer hallucinate issue references undetected.

Operators can opt out by removing \`GITHUB_TOKEN\` from \`.env\` — the existing \`.has(githubTokenKey)\` gate skips tool construction entirely. CI environments without the token continue to run convene tool-less, no error.

## What this unblocks

- The B5 narrative-vs-action audit (PR #240) can now potentially fire in convene mode (was structurally impossible before)
- Group-meeting facilitators can verify issue/PR references before persisting minutes as governance artifacts
- Cross-circle issue leakage (today's Gemini run showed #634/#635 from \`group:intelligence\` bleeding into engineering) is detectable

## Test plan

- [x] \`pnpm run check\` passes (build + typecheck + lint + format + 717 tests)
- [x] Live convene run against EP engineering circle on Sonnet 4.6 — \`Extensions: 0 loaded (0 operator, 10 github tools)\` line confirms wiring; 50/50 actions executed; cost rose 6.5× as expected
- [ ] Operator without \`GITHUB_TOKEN\` in \`.env\` should see no \"Extensions:\" line and convene should run as before (logical analysis: \`secretsProvider?.has(githubTokenKey) === true\` short-circuits to empty array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)