### PR TITLE
fix(convene): truncate meeting minutes to GitHub body limit (#267)

### DIFF
--- a/packages/cli/src/group-wake.test.ts
+++ b/packages/cli/src/group-wake.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 import { CollaborationError } from "@murmurations-ai/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { formatCollaborationError, GroupWakeError, resolveLLMConfig } from "./group-wake.js";
+import {
+  formatCollaborationError,
+  GITHUB_BODY_LIMIT,
+  GroupWakeError,
+  resolveLLMConfig,
+  truncateMinutesForGithub,
+} from "./group-wake.js";
 
 describe("GroupWakeError", () => {
   it("has correct name property", () => {
@@ -58,6 +64,57 @@ describe("formatCollaborationError (v0.5.0 Milestone 1)", () => {
   it("trims whitespace from the message", () => {
     const err = new CollaborationError("github", "RATE_LIMITED", "  slow down please  ");
     expect(formatCollaborationError(err)).toBe("RATE_LIMITED: slow down please");
+  });
+});
+
+describe("truncateMinutesForGithub (harness#267)", () => {
+  const fallbackPath = "/tmp/runs/group-engineering/2026-05-01/meeting-abcd1234.md";
+
+  it("returns body unchanged when under the limit", () => {
+    const body = "x".repeat(GITHUB_BODY_LIMIT - 100);
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(false);
+    expect(result.body).toBe(body);
+  });
+
+  it("returns body unchanged when exactly at the limit", () => {
+    const body = "x".repeat(GITHUB_BODY_LIMIT);
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(false);
+    expect(result.body).toBe(body);
+  });
+
+  it("truncates and appends a marker when over the limit", () => {
+    const body = "x".repeat(GITHUB_BODY_LIMIT + 50_000);
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(true);
+    expect(result.body.length).toBeLessThanOrEqual(GITHUB_BODY_LIMIT);
+    expect(result.body).toContain("Minutes truncated for GitHub issue body limit");
+    expect(result.body).toContain(fallbackPath);
+    expect(result.body).toContain(String(body.length)); // original length surfaced
+  });
+
+  it("preserves the head of the body when truncating", () => {
+    const head = "## Important first decision\n\nSome content here.\n";
+    const body = head + "x".repeat(GITHUB_BODY_LIMIT);
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(true);
+    expect(result.body.startsWith(head)).toBe(true);
+  });
+
+  it("includes the fallback path so operators can find the full record", () => {
+    const body = "x".repeat(GITHUB_BODY_LIMIT + 1);
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(true);
+    expect(result.body).toContain(fallbackPath);
+  });
+
+  it("real-world case: 110k char minutes from a Sonnet-with-tools convene", () => {
+    // Reproduces today's failure: GITHUB_BODY_LIMIT=65536, body=113992
+    const body = "real-meeting-content-".repeat(5_500); // ~110k chars
+    const result = truncateMinutesForGithub(body, fallbackPath);
+    expect(result.truncated).toBe(true);
+    expect(result.body.length).toBeLessThanOrEqual(GITHUB_BODY_LIMIT);
   });
 });
 

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -184,6 +184,43 @@ export const formatCollaborationError = (err: CollaborationError): string => {
   return `${err.code}: ${msg}`;
 };
 
+/**
+ * GitHub issue body limit (REST API). Bodies longer than this fail
+ * `createItem` with `INVALID_INPUT`. harness#267.
+ */
+export const GITHUB_BODY_LIMIT = 65_536;
+
+/** Headroom reserved for the truncation marker block. */
+export const TRUNCATION_BUDGET = 1_500;
+
+/**
+ * Truncate a meeting minutes body to fit within {@link GITHUB_BODY_LIMIT},
+ * appending a marker that points operators at the locally-saved full record.
+ *
+ * Pure function — exported for unit tests. The caller is responsible for
+ * writing the full body to `fallbackPath` before calling `createItem` with
+ * the returned (possibly truncated) body, so the marker links to a file
+ * that already exists on disk.
+ */
+export const truncateMinutesForGithub = (
+  body: string,
+  fallbackPath: string,
+): { body: string; truncated: boolean } => {
+  if (body.length <= GITHUB_BODY_LIMIT) return { body, truncated: false };
+  const cap = GITHUB_BODY_LIMIT - TRUNCATION_BUDGET;
+  const head = body.slice(0, cap);
+  const marker = [
+    "",
+    "---",
+    "",
+    `_**Minutes truncated for GitHub issue body limit (${String(GITHUB_BODY_LIMIT)} chars).**_`,
+    `_Full minutes (${String(body.length)} chars) saved locally at:_`,
+    `_\`${fallbackPath}\`_`,
+    "",
+  ].join("\n");
+  return { body: `${head}${marker}`, truncated: true };
+};
+
 /** Fetch the group's open items backlog via the collaboration provider. */
 const fetchGroupBacklog = async (provider: CollaborationProvider): Promise<string> => {
   try {
@@ -761,34 +798,46 @@ export const runGroupWakeCommand = async (
 
   const meetingLabel = kind === "governance" ? "governance-meeting" : "group-meeting";
 
+  // harness#267: GitHub's issue body limit is GITHUB_BODY_LIMIT (65,536) chars.
+  // With Sonnet 4.6 + tool calls (PR #265), minutes routinely exceed 70k–110k
+  // chars and createItem fails INVALID_INPUT, silently falling back to local-
+  // only — breaking the governance audit trail. Strategy: always write the
+  // local fallback first (preserves the full record), then publish a truncated
+  // copy to GitHub with a marker pointing at the local file when truncated.
+  const fallbackFilename = `meeting-${randomUUID().slice(0, 8)}.md`;
+  const fallbackPath = join(root, "runs", `group-${groupId}`, dayUtc, fallbackFilename);
+
   const writeFallback = async (): Promise<void> => {
     const { writeFile: wf, mkdir } = await import("node:fs/promises");
-    const meetingDir = join(root, "runs", `group-${groupId}`, dayUtc);
-    await mkdir(meetingDir, { recursive: true });
-    await wf(
-      join(meetingDir, `meeting-${randomUUID().slice(0, 8)}.md`),
-      `# ${config.name} — ${kind} meeting — ${dayUtc}\n\n${minutes}`,
-      "utf8",
-    );
+    await mkdir(join(root, "runs", `group-${groupId}`, dayUtc), { recursive: true });
+    await wf(fallbackPath, `# ${config.name} — ${kind} meeting — ${dayUtc}\n\n${minutes}`, "utf8");
   };
 
   if (collaboration) {
+    // Write the local fallback FIRST so the truncation marker can reference
+    // a file that already exists on disk.
+    await writeFallback();
+    const { body: githubBody, truncated } = truncateMinutesForGithub(minutes, fallbackPath);
     const itemResult = await collaboration.createItem({
       title: `[${kind.toUpperCase()} MEETING] ${config.name} — ${dayUtc}`,
       labels: [meetingLabel, `group:${groupId}`],
-      body: minutes,
+      body: githubBody,
     });
     if (itemResult.ok) {
       meetingMinutesUrl = itemResult.value.url ?? itemResult.value.id;
-      console.log(`\nMeeting minutes: ${meetingMinutesUrl}`);
+      const note = truncated ? ` (truncated; full minutes at ${fallbackPath})` : "";
+      console.log(`\nMeeting minutes: ${meetingMinutesUrl}${note}`);
     } else {
-      console.log(`\nFailed to create meeting item: ${itemResult.error.code}`);
-      await writeFallback();
-      console.log(`  (saved locally as fallback)`);
+      // createItem still failed despite truncation — surface the underlying
+      // message (not just the code) so operators can diagnose. Local fallback
+      // is already on disk from above.
+      console.log(`\nFailed to create meeting item: ${formatCollaborationError(itemResult.error)}`);
+      console.log(`  (saved locally at: ${fallbackPath})`);
     }
   } else {
     await writeFallback();
     console.log(`\nMeeting minutes saved locally (no collaboration provider).`);
+    console.log(`  Path: ${fallbackPath}`);
   }
 
   return {


### PR DESCRIPTION
## Summary

Closes #267. Meeting minutes from \`murmuration convene\` have been silently failing to post to GitHub all day today — \`createItem\` returns \`INVALID_INPUT\` and the fallback path saves to local disk only, breaking the governance audit trail because subsequent agent wakes can't see the minutes via signal bundle.

## Root cause

Confirmed via the four local fallback files from today's runs:

| File | Size | Over limit? |
|---|---|---|
| meeting-864a7c4d.md (08:19) | 72,703 chars | Yes |
| meeting-45ad9c84.md (09:04) | 113,992 chars | Yes (74% over) |
| meeting-37138bc7.md (09:54) | 99,745 chars | Yes (52% over) |
| meeting-7c017006.md (10:05) | 70,297 chars | Yes (7% over) |

GitHub's REST API issue body limit is **65,536 characters**. Sonnet 4.6 + the GitHub read tools wired in #265 produce dense, well-cited minutes that routinely exceed that.

## What changed

\`packages/cli/src/group-wake.ts\` — three changes:

1. **Always write the local fallback first** (was: only on createItem failure). Preserves the full record on disk regardless of GitHub outcome, so the truncation marker can reference a file that already exists.

2. **Truncate body to fit when over 65,536 chars** via new exported \`truncateMinutesForGithub\` helper. Caps at \`GITHUB_BODY_LIMIT - TRUNCATION_BUDGET\` (1,500 reserved for the marker block). Marker tells operators:
   - that the body was truncated
   - the original length
   - the local fallback path

3. **Surface the underlying error message** when createItem still fails despite truncation — reuses the existing \`formatCollaborationError\` helper. Operators see \`INVALID_INPUT: <github's actual message>\` instead of just the code.

## Tests

\`packages/cli/src/group-wake.test.ts\` — 6 new tests:

- under limit → unchanged
- exactly at limit → unchanged
- over limit → truncated with marker
- preserves head when truncating
- includes fallback path in marker
- real-world case: 110k char body (reproduces today's failure mode)

Total: 723 tests pass (was 717), full \`pnpm run check\` green.

## Verification path post-merge

This PR is independent of #265 (the convene-tools-wiring fix). Both should land for full benefit:
- #265 alone: tools-wired convenes still failed because their minutes exceeded 65k
- #267 alone (this): minutes always fit on GitHub regardless of tools
- Both: tools-wired convenes post their dense, grounded minutes successfully, with truncation markers when they overflow

After both merge, run \`murmuration convene\` against any sufficiently-active circle and confirm the minutes URL appears in stdout (rather than the \"saved locally as fallback\" message).

## Test plan

- [x] \`pnpm run check\` passes (build + typecheck + lint + format + 723 tests)
- [x] 6 unit tests for truncation logic, including a real-world 110k-char case
- [ ] Live verification post-merge with #265 — convene engineering circle, confirm minutes URL prints + truncation marker is present
- [ ] Confirm the truncated GitHub issue body links to the local fallback path correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)