### PR TITLE
feat(llm): per-step structured debug logging in Vercel adapter

### DIFF
--- a/packages/llm/src/adapters/vercel-adapter.ts
+++ b/packages/llm/src/adapters/vercel-adapter.ts
@@ -181,6 +181,11 @@ export class VercelAdapter implements LLMAdapter {
           )
         : undefined;
 
+      // Per-call step counter. Incremented in onStepFinish below so the
+      // debug log shows monotonic step numbers (1, 2, 3 ...) rather than
+      // having to count from raw event order.
+      let stepIndex = 0;
+
       const result = await generateText({
         model: this.#model,
         ...(systemPrompt ? { system: systemPrompt } : {}),
@@ -211,6 +216,7 @@ export class VercelAdapter implements LLMAdapter {
         },
         // Per-step cost tracking for multi-step tool loops
         onStepFinish: (step) => {
+          stepIndex += 1;
           if (options.costHook) {
             options.costHook.onLlmCall({
               provider: this.providerId,
@@ -218,6 +224,43 @@ export class VercelAdapter implements LLMAdapter {
               inputTokens: step.usage.inputTokens ?? 0,
               outputTokens: step.usage.outputTokens ?? 0,
             });
+          }
+          // Per-step debug logging — gated on MURMURATION_DEBUG_STEPS=1.
+          // Surfaces what an agent is doing inside a long tool-call loop
+          // so operators can see "agent on step 28/30, still reading
+          // files, hasn't written anything" instead of staring at a
+          // silent 10-minute wake. Writes structured JSONL to stderr;
+          // matches the daemon log format so it interleaves cleanly.
+          if (process.env.MURMURATION_DEBUG_STEPS === "1") {
+            const toolNames = step.toolCalls.map(
+              (c) => (c as unknown as { toolName?: string }).toolName ?? "unknown",
+            );
+            const finishReason = (step as unknown as { finishReason?: string }).finishReason;
+            const textLen =
+              typeof (step as unknown as { text?: string }).text === "string"
+                ? (step as unknown as { text: string }).text.length
+                : 0;
+            process.stderr.write(
+              `${JSON.stringify({
+                ts: new Date().toISOString(),
+                level: "debug",
+                event: "llm.step",
+                step: stepIndex,
+                provider: this.providerId,
+                model: this.modelUsed,
+                inputTokens: step.usage.inputTokens ?? 0,
+                outputTokens: step.usage.outputTokens ?? 0,
+                toolCalls: toolNames,
+                textLen,
+                finishReason,
+                ...(options.telemetryContext
+                  ? {
+                      agentId: options.telemetryContext.agentId,
+                      wakeId: options.telemetryContext.wakeId,
+                    }
+                  : {}),
+              })}\n`,
+            );
           }
         },
       });


### PR DESCRIPTION
## Summary

Adds opt-in per-step structured logging to the Vercel adapter's tool-call loop. Gated on \`MURMURATION_DEBUG_STEPS=1\`. ~30 lines, all inside the existing \`onStepFinish\` callback.

## Why

Solo-wake observability today is two events: \`daemon.wake.fire\` at start, \`daemon.wake.cost\` (or \`.timedOut\`) at end. For a 10-minute Sonnet 4.6 wake with 30+ tool calls, operators stare at silence until convergence or wall-clock cutoff.

Today's architecture-agent diagnosis confirmed the cost: 1.57M input tokens / \$5.15 / no artifact, root cause discovered only after the wake completed and we read the digest. Per-step visibility lets us see *during the wake* whether an agent is reading-then-acting or just reading-then-reading.

## What gets logged

One JSONL line to stderr per LLM tool-call round:

\`\`\`json
{
  \"ts\": \"2026-05-01T18:11:09.510Z\",
  \"level\": \"debug\",
  \"event\": \"llm.step\",
  \"step\": 1,
  \"provider\": \"anthropic\",
  \"model\": \"claude-sonnet-4-6\",
  \"inputTokens\": 18420,
  \"outputTokens\": 312,
  \"toolCalls\": [\"read_issue\", \"read_pull_request\"],
  \"textLen\": 0,
  \"finishReason\": \"tool-calls\",
  \"agentId\": \"architecture-agent\",
  \"wakeId\": \"050e3d37-1cb3-4ec8-9788-57ed82fc8c0a\"
}
\`\`\`

That's enough to read \"agent on step 28/30, still reading files (\`textLen: 0\`), \`toolCalls\` repeating same names — likely looping\" while it's happening.

## Behavior when flag is off

Identical to before. The flag is checked inside the existing \`onStepFinish\` callback (which already runs every step for cost tracking). Zero overhead in default operation.

## Test plan

- [x] \`pnpm run check\` passes (build + typecheck + lint + format + 717 tests)
- [ ] Live verification: re-wake an EP agent with \`MURMURATION_DEBUG_STEPS=1\` and confirm the per-step lines stream to stderr
- [ ] Confirm step counts, tool names, and finish reasons match what the post-wake digest reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)