### PR TITLE
fix(runner): gate request.tools on client capabilities (subscription-CLI v0.6.0 regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -107,6 +107,16 @@ export interface DefaultRunnerClients {
           error: { code: string; message: string };
         }
     >;
+    /**
+     * Reports the bound client's tool-delivery contract. The runner
+     * consults `supportsToolUse` before spreading `request.tools` —
+     * subscription-CLI clients (ADR-0034, ADR-0038) report `false`
+     * because tools reach those clients via Spirit MCP at construction
+     * time, not on the per-request wire. Only the field the runner
+     * reads is declared here; the underlying `LLMClient` interface
+     * surfaces more.
+     */
+    capabilities(): { readonly supportsToolUse: boolean };
   };
   /** MCP tool loader — connects to MCP servers and returns tool definitions. */
   readonly mcpToolLoader?: {
@@ -479,6 +489,19 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
     // the one provider it actually applied to (balanced → flash, not
     // pro). The actual model used in the wake is reported back via
     // `result.value.modelUsed` and logged below.
+    //
+    // Tool delivery is gated on the client's reported capability. The
+    // subscription-CLI provider family (ADR-0034, ADR-0038) reports
+    // `supportsToolUse: false` because tools reach those clients via
+    // the Spirit MCP bridge at construction time, not via the per-
+    // request wire. Passing `tools` regardless would trip the CF-A
+    // fail-loudly guard in `SubprocessAdapter.complete()`. The runner
+    // honors the contract: skip the request-side spread when the
+    // bound client doesn't support it. Tools that need to reach a
+    // subscription-CLI agent must be configured via mcpConfigPath at
+    // client construction (boot.ts wiring, harness#286).
+    const supportsRequestTools = clients.llm.capabilities().supportsToolUse;
+    const passToolsOnRequest = supportsRequestTools && tools !== undefined && tools.length > 0;
     let result: Awaited<ReturnType<NonNullable<DefaultRunnerClients["llm"]>["complete"]>>;
     try {
       result = await clients.llm.complete(
@@ -487,7 +510,7 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
           systemPromptOverride: systemPrompt,
           maxOutputTokens: 16000,
           temperature: 0.3,
-          ...(tools && tools.length > 0 ? { tools, maxSteps: options.maxSteps ?? 256 } : {}),
+          ...(passToolsOnRequest ? { tools, maxSteps: options.maxSteps ?? 256 } : {}),
         },
         ...(signal ? [{ signal }] : []),
       );

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -499,7 +499,7 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
     // honors the contract: skip the request-side spread when the
     // bound client doesn't support it. Tools that need to reach a
     // subscription-CLI agent must be configured via mcpConfigPath at
-    // client construction (boot.ts wiring, harness#286).
+    // client construction (boot.ts wiring, harness#291).
     const supportsRequestTools = clients.llm.capabilities().supportsToolUse;
     const passToolsOnRequest = supportsRequestTools && tools !== undefined && tools.length > 0;
     let result: Awaited<ReturnType<NonNullable<DefaultRunnerClients["llm"]>["complete"]>>;

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -80,7 +80,10 @@ const makeSpawn = (overrides: Partial<AgentSpawnContext> = {}): AgentSpawnContex
   ...overrides,
 });
 
-const makeLlmClient = (responseContent: string): NonNullable<DefaultRunnerClients["llm"]> => {
+const makeLlmClient = (
+  responseContent: string,
+  capabilities: { readonly supportsToolUse: boolean } = { supportsToolUse: true },
+): NonNullable<DefaultRunnerClients["llm"]> => {
   const calls: unknown[] = [];
   return {
     complete: (opts: Record<string, unknown>) => {
@@ -95,6 +98,7 @@ const makeLlmClient = (responseContent: string): NonNullable<DefaultRunnerClient
         },
       });
     },
+    capabilities: () => capabilities,
     _calls: calls,
   } as NonNullable<DefaultRunnerClients["llm"]> & { _calls: unknown[] };
 };
@@ -211,6 +215,43 @@ describe("createDefaultRunner", () => {
     expect(llmCalls[0]?.maxSteps).toBe(256);
   });
 
+  it("does not pass tools/maxSteps to LLM when client reports supportsToolUse=false (subscription-CLI gate, ADR-0034 / ADR-0038)", async () => {
+    // Regression: harness#286. Subscription-CLI clients route tools
+    // through the Spirit MCP bridge at construction time, not on the
+    // per-request wire. Passing `request.tools` regardless trips
+    // CF-A's fail-loudly guard in SubprocessAdapter.complete(). The
+    // runner consults `capabilities().supportsToolUse` and skips the
+    // request-side spread when false.
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const llm = makeLlmClient("Text-only wake.", { supportsToolUse: false });
+
+    const loadedTools: RunnerToolDefinition[] = [
+      {
+        name: "fs__read_file",
+        description: "Read a file",
+        parameters: {},
+        execute: () => Promise.resolve("file contents"),
+      },
+    ];
+
+    const mcpToolLoader: NonNullable<DefaultRunnerClients["mcpToolLoader"]> = {
+      loadTools: () => Promise.resolve(loadedTools),
+      close: () => Promise.resolve(),
+    };
+
+    const spawn = makeSpawn({
+      mcpServerConfigs: [{ name: "fs", command: "npx", args: ["-y", "mcp-fs"] }],
+    });
+
+    await runner({ spawn, clients: { llm, mcpToolLoader } });
+
+    const llmCalls = (llm as unknown as { _calls: { tools?: unknown; maxSteps?: number }[] })
+      ._calls;
+    expect(llmCalls).toHaveLength(1);
+    expect(llmCalls[0]?.tools).toBeUndefined();
+    expect(llmCalls[0]?.maxSteps).toBeUndefined();
+  });
+
   it("does not load tools when no mcpServerConfigs", async () => {
     const runner = createDefaultRunner("test-agent", [], {}, rootDir);
     const llm = makeLlmClient("No tools needed.");
@@ -241,6 +282,7 @@ describe("createDefaultRunner", () => {
           ok: false as const,
           error: { code: "INTERNAL", message: "LLM exploded" },
         }),
+      capabilities: () => ({ supportsToolUse: true }),
     };
 
     let closeWasCalled = false;
@@ -279,6 +321,7 @@ describe("createDefaultRunner", () => {
             modelUsed: "test-model",
           },
         }),
+      capabilities: () => ({ supportsToolUse: true }),
     };
 
     const result = await runner({

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -216,7 +216,7 @@ describe("createDefaultRunner", () => {
   });
 
   it("does not pass tools/maxSteps to LLM when client reports supportsToolUse=false (subscription-CLI gate, ADR-0034 / ADR-0038)", async () => {
-    // Regression: harness#286. Subscription-CLI clients route tools
+    // Regression: harness#291. Subscription-CLI clients route tools
     // through the Spirit MCP bridge at construction time, not on the
     // per-request wire. Passing `request.tools` regardless trips
     // CF-A's fail-loudly guard in SubprocessAdapter.complete(). The

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## Summary

- v0.6.0 shipped a regression: every wake bound to a subscription-CLI client failed with `validation — Subscription-CLI does not honor per-request tools or maxSteps. Got 17 tools, maxSteps=30.` because the runner unconditionally spread `tools`/`maxSteps` onto the LLM request.
- Fix: runner now consults `clients.llm.capabilities().supportsToolUse` before the spread. Subscription-CLI clients already report `false`; Vercel/API path still reports `true`. Behavior change is scoped to subscription-CLI.
- Bumps all packages 0.6.0 → 0.6.1.

## Why this happened

CF-A (the fail-loudly guard in `SubprocessAdapter.complete()`, ADR-0038) is doing exactly what it was designed to do — refusing to silently drop tools that subscription-CLI clients can't honor on the wire. The runner just wasn't asking the client whether it supported per-request tools before passing them. The two layers were each correct in isolation; they hadn't been wired together.

## Behavior on subscription-CLI agents

After this fix, subscription-CLI wakes proceed in **text-only mode** — no tool calls, since `boot.ts` doesn't yet wire `mcpConfigPath` into daemon-spawned subscription-CLI clients. That's harness#286 follow-up. Yesterday's successful EP engineering circle wakes also ran tool-less (digests show `tool_calls: 0`); agents produce inline analysis and Source relays to GitHub. Same posture, no regression.

The Spirit interactive REPL (`murmuration attach`) already wires `mcpConfigPath` for claude-cli (`packages/cli/src/spirit/client.ts:227`) — that path is unaffected.

## Test plan

- [x] Added regression test in `runner.test.ts`: subscription-CLI client (capabilities `supportsToolUse: false`) does NOT receive `tools`/`maxSteps` in the LLM request even when MCP tools are loaded.
- [x] Existing test `loads MCP tools and passes them to LLM when mcpServerConfigs present` still passes (Vercel/API path with `supportsToolUse: true`).
- [x] Full suite green: 776 passed / 1 skipped (54 files).
- [x] Build, typecheck, lint, format:check all pass.
- [x] **Live test**: EP security-agent wake on local build with `--once --now`. claude-cli subprocess invokes successfully, no CF-A failure, wake runs to completion.

## Follow-ups

- harness#286 — wire `mcpConfigPath` through `boot.ts` so daemon-spawned subscription-CLI agents get tools via Spirit MCP. This is the bigger win; the current fix unblocks every wake, but subscription-CLI agents stay text-only until #286 lands.