### PR TITLE
fix(runner,subprocess): skip tool advertising when client lacks supportsToolUse + D10 process-group kill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -391,14 +391,27 @@ export function createDefaultRunner(
     //     regression 2026-04-30: 7 tools threaded via the API but
     //     tool_calls: 0 across Gemini and Anthropic because the prompt
     //     never told the LLM the tools existed (Boundary 5 root cause).
+    //
+    // When the bound client reports `supportsToolUse: false`
+    // (subscription-CLI family, ADR-0034 / ADR-0038), per-request
+    // tool delivery is disabled. The prompt must NOT advertise tools
+    // the agent can't actually call — doing so produces the
+    // narrative-only-claim regression observed across May 1's
+    // engineering circle wakes (5 of 6 raised this as a TENSION).
+    // We collapse to the "_None._" fallback in that case so the
+    // agent stays text-only and routes capability gaps through
+    // GOVERNANCE_EVENT instead of pretending to call missing tools.
+    const supportsRequestTools = clients.llm.capabilities().supportsToolUse;
+    const mcpConfigs = supportsRequestTools ? (spawn.mcpServerConfigs ?? []) : [];
     const allTools: RunnerToolDefinition[] = [];
-    if (options.extensionTools && options.extensionTools.length > 0) {
-      allTools.push(...options.extensionTools);
-    }
-    const mcpConfigs = spawn.mcpServerConfigs ?? [];
-    if (clients.mcpToolLoader && mcpConfigs.length > 0) {
-      const mcpTools = await clients.mcpToolLoader.loadTools(mcpConfigs, spawn.environment);
-      allTools.push(...mcpTools);
+    if (supportsRequestTools) {
+      if (options.extensionTools && options.extensionTools.length > 0) {
+        allTools.push(...options.extensionTools);
+      }
+      if (clients.mcpToolLoader && mcpConfigs.length > 0) {
+        const mcpTools = await clients.mcpToolLoader.loadTools(mcpConfigs, spawn.environment);
+        allTools.push(...mcpTools);
+      }
     }
     const tools: RunnerToolDefinition[] | undefined = allTools.length > 0 ? allTools : undefined;
 
@@ -500,7 +513,9 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
     // bound client doesn't support it. Tools that need to reach a
     // subscription-CLI agent must be configured via mcpConfigPath at
     // client construction (boot.ts wiring, harness#291).
-    const supportsRequestTools = clients.llm.capabilities().supportsToolUse;
+    // `supportsRequestTools` was computed at section 7a so the prompt-
+    // building stage could honor the same gate. Reused here for the
+    // request-side spread.
     const passToolsOnRequest = supportsRequestTools && tools !== undefined && tools.length > 0;
     let result: Awaited<ReturnType<NonNullable<DefaultRunnerClients["llm"]>["complete"]>>;
     try {

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -220,22 +220,21 @@ describe("createDefaultRunner", () => {
     // through the Spirit MCP bridge at construction time, not on the
     // per-request wire. Passing `request.tools` regardless trips
     // CF-A's fail-loudly guard in SubprocessAdapter.complete(). The
-    // runner consults `capabilities().supportsToolUse` and skips the
-    // request-side spread when false.
+    // runner consults `capabilities().supportsToolUse` and:
+    //   1. skips MCP loadTools (no point paying the startup cost)
+    //   2. omits tools/maxSteps from the request payload
+    // The system prompt's "Tools you can call this wake" section
+    // collapses to "_None._" via the existing fallback, so the agent
+    // doesn't get told about tools it can't actually call.
     const runner = createDefaultRunner("test-agent", [], {}, rootDir);
     const llm = makeLlmClient("Text-only wake.", { supportsToolUse: false });
 
-    const loadedTools: RunnerToolDefinition[] = [
-      {
-        name: "fs__read_file",
-        description: "Read a file",
-        parameters: {},
-        execute: () => Promise.resolve("file contents"),
-      },
-    ];
-
+    let loadToolsCalled = false;
     const mcpToolLoader: NonNullable<DefaultRunnerClients["mcpToolLoader"]> = {
-      loadTools: () => Promise.resolve(loadedTools),
+      loadTools: () => {
+        loadToolsCalled = true;
+        return Promise.resolve([]);
+      },
       close: () => Promise.resolve(),
     };
 
@@ -244,6 +243,8 @@ describe("createDefaultRunner", () => {
     });
 
     await runner({ spawn, clients: { llm, mcpToolLoader } });
+
+    expect(loadToolsCalled).toBe(false);
 
     const llmCalls = (llm as unknown as { _calls: { tools?: unknown; maxSteps?: number }[] })
       ._calls;

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/src/providers/subprocess/base-client.ts
+++ b/packages/llm/src/providers/subprocess/base-client.ts
@@ -173,9 +173,20 @@ export class SubprocessAdapter implements LLMAdapter {
       let child: ReturnType<typeof spawn>;
       try {
         // Array argv only. Never shell:true. Prompt is NOT in flags (D1).
+        //
+        // detached:true puts the child in its own process group on
+        // POSIX (PGID == PID). Combined with `process.kill(-pid, SIG)`
+        // in killTree() below, this lets us signal the CLI AND any
+        // helper processes it spawns. Without this, SIGKILL only kills
+        // the immediate child — if that child is a node wrapper (claude
+        // is `node /…/claude`) or has spawned helpers, those linger.
+        // Live evidence (2026-05-03 verification wake): claude-cli
+        // lingered ~5min past SIGKILL because helper subprocesses
+        // ignored the parent's death (D10).
         child = spawn(this.#cli.command, flags, {
           stdio: ["pipe", "pipe", "pipe"],
           shell: false,
+          detached: true,
         });
       } catch (err) {
         settle({
@@ -216,20 +227,37 @@ export class SubprocessAdapter implements LLMAdapter {
         stderr += chunk.toString("utf8");
       });
 
-      // Wall-clock timeout (D4): SIGTERM after timeoutMs, SIGKILL after grace.
-      const termTimer = setTimeout(() => {
-        timedOut = true;
-        try {
-          child.kill("SIGTERM");
-        } catch {
-          /* already exited */
+      // killTree(): signal the entire process group, not just the
+      // immediate child. Required because `detached:true` on spawn
+      // gave the child its own PGID; without group-targeted kill,
+      // descendants survive (the D10 lingering-claude case).
+      // `process.kill(-pgid, sig)` is the POSIX idiom; on platforms
+      // where PGID isn't reliable we fall back to `child.kill()`.
+      const killTree = (signal: "SIGTERM" | "SIGKILL"): void => {
+        const pid = child.pid;
+        if (pid === undefined) {
+          // Child never started cleanly; nothing to signal.
+          return;
         }
-        setTimeout(() => {
+        try {
+          process.kill(-pid, signal);
+        } catch {
+          // -pid path failed (already-exited group, or POSIX limitation).
+          // Fall through to direct child kill so we still send the signal.
           try {
-            child.kill("SIGKILL");
+            child.kill(signal);
           } catch {
             /* already exited */
           }
+        }
+      };
+
+      // Wall-clock timeout (D4): SIGTERM after timeoutMs, SIGKILL after grace.
+      const termTimer = setTimeout(() => {
+        timedOut = true;
+        killTree("SIGTERM");
+        setTimeout(() => {
+          killTree("SIGKILL");
           // D10: prevent zombies — let event loop exit even if child lingers.
           child.unref();
         }, this.#killGraceMs);
@@ -239,17 +267,9 @@ export class SubprocessAdapter implements LLMAdapter {
       const onAbort = (): void => {
         timedOut = true;
         clearTimeout(termTimer);
-        try {
-          child.kill("SIGTERM");
-        } catch {
-          /* already exited */
-        }
+        killTree("SIGTERM");
         setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            /* already exited */
-          }
+          killTree("SIGKILL");
           child.unref();
         }, this.#killGraceMs);
       };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## Summary

Two follow-ups to v0.6.1's runner gate, both surfaced by the live verification wake of v0.6.1:

- **(3)** Runner now also skips MCP tool loading and the system-prompt tool advertising when the bound LLM client reports \`supportsToolUse: false\`. Previously the gate only stopped tools at the request payload — the prompt still told subscription-CLI agents about tools they couldn't call, producing the narrative-only-claim regression observed across May 1's EP engineering wakes.
- **(2)** \`SubprocessAdapter\` now uses \`detached: true\` on spawn and signals the entire process group (\`process.kill(-pid, SIG)\`) on timeout/abort. Live evidence on 2026-05-03: claude-cli lingered ~5 minutes past SIGKILL because helper subprocesses ignored the parent's death (D10).

Bumps all packages 0.6.1 → 0.6.2.

## What this fixes for operators

- Subscription-CLI agents stop wandering through fictional tool calls, drop the prompt overhead from advertising 17+ tool definitions, and complete faster (the 9-min timeout we hit during v0.6.1 verification was driven partly by the agent retrying tools that don't exist).
- Wake cancellations actually clean up. No more zombie helper processes.

## Test plan

- [x] Existing v0.6.1 request-side gate test strengthened to also verify \`mcpToolLoader.loadTools\` is NOT called when \`supportsToolUse: false\`.
- [x] Full suite: 776 passed / 1 skipped (54 files).
- [x] Build, typecheck, lint, format:check all green.

## Out of scope

- harness#291 — wire \`mcpConfigPath\` through \`boot.ts\` so subscription-CLI agents actually get tools via Spirit MCP. That's the bigger win; this PR makes the text-only fallback work cleanly until #291 lands.