### PR TITLE
fix(boot,spirit): wire Spirit MCP bridge through boot.ts for daemon-spawned subscription-CLI agents (closes harness#291)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -85,6 +85,7 @@ import type { HarnessLLMConfig } from "./harness-config.js";
 import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js";
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 import { registerRunningSocket, unregisterRunningSocket } from "./running-sessions.js";
+import { writeSpiritMcpConfig } from "./spirit/mcp-config.js";
 
 const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
 
@@ -352,6 +353,15 @@ interface BuildAgentClientsArgs {
    *  Closes harness#271 (agent compose silently fell back to a placeholder
    *  stub when `cli` was set only at harness.yaml level). */
   readonly harnessLlm: HarnessLLMConfig;
+  /** Murmuration root directory (the operator's `<root>` containing
+   *  `murmuration/`, `agents/`, etc.). Required for subscription-CLI
+   *  agents on the claude-cli path because the Spirit MCP config gets
+   *  written under `<rootDir>/.murmuration/spirit-mcp.json` and the
+   *  spawned `mcp-bin.js` reads `MURMURATION_ROOT` from this path to
+   *  attach to the daemon socket. Closes harness#291 — without this
+   *  wiring, daemon-spawned subscription-CLI wakes ran text-only with
+   *  no tool surface, while the Spirit interactive REPL had it. */
+  readonly rootDir: string;
   /** Optional logger so the cost hook can emit `daemon.cost.pricing.unknown`
    *  warns when a model isn't in the pricing catalog (harness#251). */
   readonly logger?: { warn: (event: string, fields?: Record<string, unknown>) => void };
@@ -379,6 +389,7 @@ const buildAgentClients = ({
   dryRun,
   ollamaBaseUrl,
   harnessLlm,
+  rootDir,
   logger,
 }: BuildAgentClientsArgs): BuildAgentClientsResult => {
   const result: {
@@ -404,6 +415,15 @@ const buildAgentClients = ({
         const costHook = costBuilder ? makeDaemonHook(costBuilder, logger) : undefined;
         // Same fallback shape for model: agent override → harness default → empty
         const model = agent.llm.model ?? harnessLlm.model ?? "";
+        // harness#291: wire Spirit MCP config so daemon-spawned claude-cli
+        // agents can call harness-internal tools (status, agents, wake, ...)
+        // through the same MCP bridge the interactive REPL uses (ADR-0038
+        // Phase A). Without this, daemon wakes ran text-only — every EP
+        // engineering wake on May 1 staged inline analysis instead of
+        // posting to GitHub. Codex/gemini fall through (no `--mcp-config`
+        // analogue today) and remain text-only until per-CLI MCP support
+        // lands.
+        const mcpConfigPath = cli === "claude" ? writeSpiritMcpConfig(rootDir) : undefined;
         result.llm = createSubscriptionCliClient({
           cli,
           model,
@@ -411,6 +431,7 @@ const buildAgentClients = ({
           ...(agent.llm.permissionMode !== undefined
             ? { permissionMode: agent.llm.permissionMode }
             : {}),
+          ...(mcpConfigPath !== undefined ? { mcpConfigPath } : {}),
           ...(costHook !== undefined ? { defaultCostHook: costHook } : {}),
         });
       }
@@ -1185,6 +1206,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       dryRun,
       ollamaBaseUrl,
       harnessLlm: config.llm,
+      rootDir: exampleRoot,
     });
 
     if (agent.llm && validation.llmSkipReason) {
@@ -1339,6 +1361,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               dryRun,
               ollamaBaseUrl,
               harnessLlm: config.llm,
+              rootDir: exampleRoot,
               logger,
             });
             const firstBranchScope = capturedAgent.githubWriteScopes.branchCommits[0];

--- a/packages/cli/src/spirit/client.ts
+++ b/packages/cli/src/spirit/client.ts
@@ -10,9 +10,8 @@
  * detach drops it.
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import { makeSecretKey, makeSecretValue, type SecretValue } from "@murmurations-ai/core";
 import {
@@ -34,6 +33,7 @@ import {
   type SubscriptionCliPermissionMode,
   type SubscriptionCli,
 } from "../harness-config.js";
+import { writeSpiritMcpConfig } from "./mcp-config.js";
 import { buildSpiritSystemPrompt } from "./system-prompt.js";
 import { buildSpiritTools } from "./tools.js";
 
@@ -107,37 +107,6 @@ const PRICING: Record<LLMProvider, { readonly input: number; readonly output: nu
   openai: { input: 2.5, output: 10.0 },
   ollama: { input: 0, output: 0 },
   "subscription-cli": { input: 0, output: 0 },
-};
-
-/**
- * Write Spirit's MCP config so the subscription CLI exposes harness-internal
- * tools (status, agents, wake, directive, etc.) to its tool loop. The CLI
- * spawns `node <mcp-bin.js>` with `MURMURATION_ROOT` set to the murmuration
- * root; the spawned process attaches to the daemon socket and serves Spirit's
- * tools over MCP stdio.
- *
- * Returns the absolute path to the written config so the caller can pass it
- * via `--mcp-config <path>` (claude). Codex/gemini support is a follow-up.
- */
-const writeSpiritMcpConfig = (rootDir: string): string => {
-  const configDir = join(rootDir, ".murmuration");
-  mkdirSync(configDir, { recursive: true });
-  const configPath = join(configDir, "spirit-mcp.json");
-
-  const here = dirname(fileURLToPath(import.meta.url));
-  const mcpBinPath = join(here, "mcp-bin.js");
-
-  const config = {
-    mcpServers: {
-      "murmuration-spirit": {
-        command: "node",
-        args: [mcpBinPath],
-        env: { MURMURATION_ROOT: rootDir },
-      },
-    },
-  };
-  writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
-  return configPath;
 };
 
 /** Resolve the API key for a provider. Reads `<rootDir>/.env` first,

--- a/packages/cli/src/spirit/mcp-config.test.ts
+++ b/packages/cli/src/spirit/mcp-config.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeSpiritMcpConfig } from "./mcp-config.js";
+
+describe("writeSpiritMcpConfig", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("writes a valid MCP config file under <rootDir>/.murmuration/spirit-mcp.json", () => {
+    const path = writeSpiritMcpConfig(tmpRoot);
+
+    expect(path).toBe(join(tmpRoot, ".murmuration", "spirit-mcp.json"));
+    expect(existsSync(path)).toBe(true);
+
+    const content = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+    };
+
+    expect(content.mcpServers["murmuration-spirit"]).toBeDefined();
+    expect(content.mcpServers["murmuration-spirit"]?.command).toBe("node");
+    expect(content.mcpServers["murmuration-spirit"]?.args).toHaveLength(1);
+    expect(content.mcpServers["murmuration-spirit"]?.args[0]).toMatch(/mcp-bin\.js$/);
+    expect(content.mcpServers["murmuration-spirit"]?.env).toEqual({
+      MURMURATION_ROOT: tmpRoot,
+    });
+  });
+
+  it("creates the .murmuration directory if it does not exist", () => {
+    const configDir = join(tmpRoot, ".murmuration");
+    expect(existsSync(configDir)).toBe(false);
+
+    writeSpiritMcpConfig(tmpRoot);
+
+    expect(existsSync(configDir)).toBe(true);
+  });
+
+  it("is idempotent — overwrites the file on each call (config is a pure function of rootDir)", () => {
+    const first = writeSpiritMcpConfig(tmpRoot);
+    const firstContent = readFileSync(first, "utf8");
+    const second = writeSpiritMcpConfig(tmpRoot);
+    const secondContent = readFileSync(second, "utf8");
+
+    expect(first).toBe(second);
+    expect(firstContent).toBe(secondContent);
+  });
+
+  it("encodes the rootDir in the spawned MCP server's MURMURATION_ROOT env (D1: not in argv)", () => {
+    // ADR-0034 D1: prompt content + sensitive paths must never appear in
+    // argv. The rootDir is sensitive (operator's home path) so it goes
+    // through env, not argv. Verifies the config never serializes
+    // rootDir into args[].
+    const path = writeSpiritMcpConfig(tmpRoot);
+    const content = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, { args: string[]; env: Record<string, string> }>;
+    };
+    const args = content.mcpServers["murmuration-spirit"]?.args ?? [];
+    for (const arg of args) {
+      expect(arg).not.toContain(tmpRoot);
+    }
+    expect(content.mcpServers["murmuration-spirit"]?.env.MURMURATION_ROOT).toBe(tmpRoot);
+  });
+});

--- a/packages/cli/src/spirit/mcp-config.ts
+++ b/packages/cli/src/spirit/mcp-config.ts
@@ -1,0 +1,61 @@
+/**
+ * Spirit MCP config writer — produces the JSON file that subscription-CLI
+ * subprocesses load (via `--mcp-config <path>` for claude) so they can
+ * call harness-internal tools (status, agents, wake, directive, etc.)
+ * over MCP stdio.
+ *
+ * The config points each spawned CLI subprocess at `mcp-bin.js`, which
+ * runs the Spirit MCP server (`runSpiritMcpServer`) and attaches to the
+ * daemon socket via `MURMURATION_ROOT`. Tool implementations are reused
+ * verbatim from `./tools.ts` — same daemon-RPC contract, no logic
+ * duplication.
+ *
+ * Two callers consume this module:
+ *
+ * 1. **Spirit interactive REPL** (`./client.ts`) — when the operator
+ *    runs `murmuration attach` against a subscription-CLI murmuration.
+ * 2. **Daemon-spawned solo wakes** (`../boot.ts`) — when an agent's
+ *    role.md (or harness.yaml) pins `provider: subscription-cli`.
+ *    Without this wiring, daemon wakes ran text-only and 5 of 6 EP
+ *    engineering agents flagged the missing tool surface as a TENSION
+ *    (harness#291).
+ *
+ * Today only claude-cli supports `--mcp-config`. Codex and gemini have
+ * MCP support on different surfaces — handled in their respective
+ * adapters, not here.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Write Spirit's MCP config under `<rootDir>/.murmuration/spirit-mcp.json`.
+ * The CLI subprocess spawns `node <mcp-bin.js>` with `MURMURATION_ROOT`
+ * set; the spawned process attaches to the daemon socket and serves
+ * Spirit's tools over MCP stdio.
+ *
+ * Returns the absolute path to the written config so the caller can
+ * pass it via `--mcp-config <path>` (claude). Idempotent — overwrites
+ * the file each call (the contents are pure functions of `rootDir`).
+ */
+export const writeSpiritMcpConfig = (rootDir: string): string => {
+  const configDir = join(rootDir, ".murmuration");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "spirit-mcp.json");
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const mcpBinPath = join(here, "mcp-bin.js");
+
+  const config = {
+    mcpServers: {
+      "murmuration-spirit": {
+        command: "node",
+        args: [mcpBinPath],
+        env: { MURMURATION_ROOT: rootDir },
+      },
+    },
+  };
+  writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+  return configPath;
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## Summary

Closes harness#291. Daemon-spawned claude-cli wakes now load Spirit's MCP tool surface (\`status\`, \`agents\`, \`groups\`, \`events\`, \`read_file\`, \`list_dir\`, \`load_skill\`, \`wake\`, \`directive\`) — the same tools the Spirit interactive REPL has had since v0.6.0.

Before this PR: subscription-CLI agents on the daemon path ran text-only. Five of six EP engineering agents (May 1 wakes) flagged the missing tool surface as a TENSION — same harness#285 capability-uncertainty pattern. Agents staged inline analysis Source had to relay manually.

After this PR: agents call MCP tools themselves and post real artifacts to GitHub during the wake.

## Changes

- Extracted \`writeSpiritMcpConfig\` from \`spirit/client.ts\` into a dedicated module \`spirit/mcp-config.ts\` so both the REPL path and the daemon path import it.
- Added \`rootDir: string\` to \`BuildAgentClientsArgs\` and threaded it through both call sites (boot-time validation + per-wake \`resolveClients\`).
- In \`buildAgentClients\`, when \`cli === \"claude\"\`, write \`<rootDir>/.murmuration/spirit-mcp.json\` and pass \`mcpConfigPath\` to \`createSubscriptionCliClient\`. Codex/gemini fall through (no \`--mcp-config\` analogue today).
- Added 4 unit tests for the extracted \`writeSpiritMcpConfig\`.

Bumps all packages 0.6.2 → 0.6.3.

## Live verification

Single \`analytics-agent --once --now\` wake on EP, local v0.6.3-candidate build:

\`\`\`
claude -p --output-format json --model claude-sonnet-4-6 --mcp-config /Users/.../spirit-mcp.json
\`\`\`

✅ \`spirit-mcp.json\` written under \`<rootDir>/.murmuration/\` 
✅ \`--mcp-config\` flag in claude-cli argv 
✅ Wake completed in 5m27s, \$0.65 shadow cost 
✅ Two real GitHub comments landed during the wake window (\`22:31\`–\`22:36\`):
   - [\`xeeban/emergent-praxis#552\`](https://github.com/xeeban/emergent-praxis/issues/552) (Bundle strategy): bundle math + metrics framework
   - [\`xeeban/emergent-praxis#553\`](https://github.com/xeeban/emergent-praxis/issues/553) (Label drift): enforcement mechanism input

Cache stats from the wake.cost record showed sustained-context caching kicking in:
- \`inputTokens: 13\` (just the new message)
- \`cacheReadTokens: 694,963\` (full system prompt + signal bundle cached)
- \`cacheWriteTokens: 57,560\`
- \`outputTokens: 15,349\`

## Known telemetry gap (not blocking)

\`tool_calls: 0\` in the wake digest because the runner's counter only sees Vercel-SDK-mediated calls. Spirit MCP tool invocations happen inside claude-cli's native discovery layer, invisible to the runner. Will file as a follow-up — the value (real GitHub writes during the wake) is delivered; only the metric is wrong.

## Test plan

- [x] Build, typecheck, lint, format:check all green
- [x] Full suite: 780 passed / 1 skipped (55 files), 4 new for \`writeSpiritMcpConfig\`
- [x] Live wake against EP — comments landed, cache caching working

## Out of scope

- Codex/Gemini MCP wiring (no \`--mcp-config\` analogue today; future work)
- Telemetry visibility for MCP tool calls (will file follow-up)
- harness#293 (Spirit REPL session resume) — independent, filed separately