### PR TITLE
fix(daemon,runner): idle-wake skip + honest tool description for subscription-CLI agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/src/agents/agents.test.ts
+++ b/packages/core/src/agents/agents.test.ts
@@ -138,6 +138,45 @@ describe("AgentStateStore", () => {
     store.register("c", 3000);
     expect(store.getAllAgents()).toHaveLength(3);
   });
+
+  // -------------------------------------------------------------------
+  // Idle-wake skip — harness#297
+  // -------------------------------------------------------------------
+
+  it("recordFiredContextHash stores the hash and resets idleSkipStreak", () => {
+    const store = new AgentStateStore();
+    store.register("agent", 1000);
+    expect(store.getAgent("agent")?.lastFiredContextHash).toBeNull();
+    expect(store.getAgent("agent")?.idleSkipStreak).toBe(0);
+
+    // Simulate a few skips first.
+    store.recordIdleSkip("agent");
+    store.recordIdleSkip("agent");
+    expect(store.getAgent("agent")?.idleSkipStreak).toBe(2);
+
+    // A real fire records the hash and zeros the streak.
+    store.recordFiredContextHash("agent", "abc123");
+    expect(store.getAgent("agent")?.lastFiredContextHash).toBe("abc123");
+    expect(store.getAgent("agent")?.idleSkipStreak).toBe(0);
+  });
+
+  it("recordIdleSkip increments idleSkipStreak monotonically", () => {
+    const store = new AgentStateStore();
+    store.register("agent", 1000);
+
+    store.recordIdleSkip("agent");
+    expect(store.getAgent("agent")?.idleSkipStreak).toBe(1);
+    store.recordIdleSkip("agent");
+    store.recordIdleSkip("agent");
+    expect(store.getAgent("agent")?.idleSkipStreak).toBe(3);
+  });
+
+  it("idle-skip methods are no-ops for unknown agentId", () => {
+    const store = new AgentStateStore();
+    expect(() => store.recordFiredContextHash("ghost", "x")).not.toThrow();
+    expect(() => store.recordIdleSkip("ghost")).not.toThrow();
+    expect(store.getAgent("ghost")).toBeUndefined();
+  });
 });
 
 describe("AgentStateStore persistence", () => {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -56,6 +56,22 @@ export interface AgentRecord {
   readonly idleWakes: number;
   readonly currentWakeId: string | null;
   readonly currentWakeStartedAt: string | null; // ISO
+  /**
+   * SHA-256 of the wake context that was passed to the executor on
+   * the most recent **fired** wake (skipped wakes don't update this).
+   * Idle-wake skip (harness#297) compares this against the about-to-
+   * be-fired context to decide whether the LLM call is redundant.
+   * `null` if no wake has fired yet.
+   */
+  readonly lastFiredContextHash: string | null;
+  /**
+   * Number of consecutive idle-wake skips since the last actual fire.
+   * Counted separately from {@link idleWakes} (which counts wakes the
+   * runner judged ineffective). Bounded growth: at some threshold the
+   * daemon force-fires anyway to guard against indefinite skipping
+   * (see `MAX_IDLE_SKIP_STREAK` in daemon).
+   */
+  readonly idleSkipStreak: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +87,19 @@ export interface IAgentStateStore {
     outcome: WakeOutcome,
     options?: { errorMessage?: string; costMicros?: number; artifactCount?: number },
   ): void;
+  /**
+   * Record the context hash for a wake that DID fire (the LLM ran).
+   * Called by the daemon after `executor.spawn` so the next cron tick
+   * can compare against it for idle-wake skip (harness#297). Resets
+   * `idleSkipStreak` to 0.
+   */
+  recordFiredContextHash(agentId: string, contextHash: string): void;
+  /**
+   * Record an idle-wake skip — the daemon decided not to fire the LLM
+   * because the context hash matched the last fire and the last
+   * outcome was successful. Increments `idleSkipStreak`.
+   */
+  recordIdleSkip(agentId: string): void;
   getAgent(agentId: string): AgentRecord | undefined;
   getAllAgents(): readonly AgentRecord[];
   getRecentWakes(agentId: string, limit?: number): readonly AgentWakeInstance[];
@@ -125,7 +154,17 @@ export class AgentStateStore implements IAgentStateStore {
       };
       if (data.agents) {
         for (const [id, record] of Object.entries(data.agents)) {
-          this.#agents.set(id, record);
+          // Backfill fields added after this state.json was first written
+          // so older operator state files still load. We re-type the
+          // entry as Partial because on-disk state may be older than
+          // the current AgentRecord shape — fields added in newer
+          // releases will be missing from older state.json files.
+          const partial = record as Partial<AgentRecord>;
+          this.#agents.set(id, {
+            ...record,
+            lastFiredContextHash: partial.lastFiredContextHash ?? null,
+            idleSkipStreak: partial.idleSkipStreak ?? 0,
+          });
         }
       }
       if (data.wakes) {
@@ -166,6 +205,8 @@ export class AgentStateStore implements IAgentStateStore {
       idleWakes: 0,
       currentWakeId: null,
       currentWakeStartedAt: null,
+      lastFiredContextHash: null,
+      idleSkipStreak: 0,
     });
     if (!this.#wakesByAgent.has(agentId)) {
       this.#wakesByAgent.set(agentId, []);
@@ -278,6 +319,39 @@ export class AgentStateStore implements IAgentStateStore {
         currentWakeStartedAt: null,
       });
     }
+    void this.#persist();
+  }
+
+  /**
+   * Record the context hash for a wake that DID fire (LLM invoked).
+   * Resets `idleSkipStreak` to 0 since this counts as fresh activity.
+   */
+  public recordFiredContextHash(agentId: string, contextHash: string): void {
+    this.#guardWrite("recordFiredContextHash");
+    const agent = this.#agents.get(agentId);
+    if (!agent) return;
+    this.#agents.set(agentId, {
+      ...agent,
+      lastFiredContextHash: contextHash,
+      idleSkipStreak: 0,
+    });
+    void this.#persist();
+  }
+
+  /**
+   * Record an idle-wake skip — the daemon decided not to fire the LLM
+   * because the context hash matched the last fire and the prior wake
+   * succeeded. Increments `idleSkipStreak` so the daemon can choose to
+   * force-fire after a configured number of consecutive skips.
+   */
+  public recordIdleSkip(agentId: string): void {
+    this.#guardWrite("recordIdleSkip");
+    const agent = this.#agents.get(agentId);
+    if (!agent) return;
+    this.#agents.set(agentId, {
+      ...agent,
+      idleSkipStreak: agent.idleSkipStreak + 1,
+    });
     void this.#persist();
   }
 

--- a/packages/core/src/daemon/daemon.test.ts
+++ b/packages/core/src/daemon/daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { AgentStateStore } from "../agents/index.js";
 import { makeAgentId, makeGroupId } from "../execution/index.js";
 import { SubprocessExecutor } from "../execution/subprocess.js";
 import { makeSecretKey, makeSecretValue } from "../secrets/index.js";
@@ -436,6 +437,109 @@ describe("Daemon", () => {
 
     daemon.start();
     await waitFor(() => logs.filter((l) => l.event === "daemon.heartbeat").length >= 2, 500);
+    await daemon.stop();
+  });
+
+  // -------------------------------------------------------------------
+  // Idle-wake skip — harness#297
+  //
+  // Verifies the daemon skips repeat wakes on identical context.
+  // Uses an interval trigger (kind: "scheduled") so the skip gate is
+  // active — delay-once and --now both produce kind: "manual" which
+  // is exempt by design (operator override).
+  // -------------------------------------------------------------------
+
+  it("skips a second cron-triggered wake when context hash matches the prior successful fire (harness#297)", async () => {
+    // Stable bundle — both interval ticks produce the same hash.
+    const stableAggregator: SignalAggregator = {
+      capabilities: (): SignalAggregatorCapabilities => ({
+        id: "stable-fake",
+        displayName: "Stable Aggregator",
+        version: "0.0.0-test",
+        activeSources: ["private-note"],
+        totalCap: 50,
+      }),
+      // eslint-disable-next-line @typescript-eslint/require-await -- async to match the interface
+      aggregate: async (ctx: SignalAggregationContext): Promise<SignalAggregationResult> => ({
+        ok: true,
+        bundle: {
+          wakeId: ctx.wakeId,
+          assembledAt: ctx.now,
+          signals: [
+            {
+              kind: "private-note",
+              id: "private-note:stable.md",
+              trust: "trusted",
+              fetchedAt: ctx.now,
+              path: "/stable/note.md",
+              summary: "stable summary",
+            },
+          ],
+          actionItems: [],
+          warnings: [],
+        },
+      }),
+    };
+
+    // Subprocess that exits success quickly so wake.completed fires
+    // and AgentStateStore.recordWakeOutcome runs.
+    const executor = new SubprocessExecutor({
+      resolveCommand: () => ({
+        command: "node",
+        args: ["-e", "process.stdout.write('::wake-summary:: stable\\n'); process.exit(0);"],
+      }),
+    });
+
+    const intervalAgent: RegisteredAgent = {
+      ...helloWorld,
+      // 250ms interval — second tick should arrive while we're watching.
+      // Interval kind => wakeReason.kind === "scheduled" (NOT manual).
+      trigger: { kind: "interval", intervalMs: 250 },
+    };
+
+    const stateStore = new AgentStateStore();
+    const { logger, logs } = makeCapturingLogger();
+    const daemon = new Daemon({
+      executor,
+      agents: [intervalAgent],
+      logger,
+      heartbeatMs: 60_000,
+      signalAggregator: stableAggregator,
+      agentStateStore: stateStore,
+    });
+
+    daemon.start();
+
+    // Wait for the FIRST wake to complete (no prior hash → fires).
+    await waitFor(() => logs.some((l) => l.event === "daemon.wake.completed"), 3000);
+
+    const firstFire = logs.find((l) => l.event === "daemon.wake.fire");
+    const firstCompleted = logs.find((l) => l.event === "daemon.wake.completed");
+    expect(firstFire).toBeDefined();
+    expect(firstCompleted?.data.outcome).toBe("completed");
+
+    // After completion, agent state should now have the context hash.
+    const recordAfterFire = stateStore.getAgent("hello-world");
+    expect(recordAfterFire?.lastFiredContextHash).toBeTruthy();
+    expect(recordAfterFire?.lastFiredContextHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(recordAfterFire?.idleSkipStreak).toBe(0);
+
+    // Wait for the SECOND interval tick to either fire or skip.
+    // Should skip — same context, same hash, last outcome was success.
+    await waitFor(() => logs.some((l) => l.event === "daemon.wake.skipped"), 3000);
+
+    const skipped = logs.find((l) => l.event === "daemon.wake.skipped");
+    expect(skipped).toBeDefined();
+    expect(skipped?.data.reason).toBe("idle");
+    expect(skipped?.data.agentId).toBe("hello-world");
+    expect(skipped?.data.contextHash).toBe(recordAfterFire?.lastFiredContextHash);
+
+    // The skip should have incremented idleSkipStreak but NOT changed
+    // the recorded hash — only actual fires update lastFiredContextHash.
+    const recordAfterSkip = stateStore.getAgent("hello-world");
+    expect(recordAfterSkip?.lastFiredContextHash).toBe(recordAfterFire?.lastFiredContextHash);
+    expect(recordAfterSkip?.idleSkipStreak).toBeGreaterThanOrEqual(1);
+
     await daemon.stop();
   });
 });

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -11,7 +11,7 @@
  * Spec §4 architecture diagram, §15 Phase 1 gate.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { resolve, dirname } from "node:path";
 import cronParser from "cron-parser";
 import { formatUSDMicros } from "../cost/usd.js";
@@ -63,6 +63,46 @@ import {
 
 /** Circuit breaker: skip wakes after this many consecutive failures. */
 const CIRCUIT_BREAKER_THRESHOLD = 3;
+
+/**
+ * Idle-wake skip ceiling. After this many consecutive skips (context
+ * unchanged + last wake successful), force-fire on the next trigger
+ * regardless of hash match. Guards against indefinite skipping if a
+ * signal change is somehow invisible to the hash (e.g., upstream
+ * agent's digest changed but the bundle hash stayed identical).
+ *
+ * 12 = roughly an hour at the typical 5min cron cadence — long enough
+ * to see real cost wins, short enough to surface staleness.
+ */
+const MAX_IDLE_SKIP_STREAK = 12;
+
+/**
+ * Hash the wake context's stable shape for idle-wake skip (harness#297).
+ * Captures everything that should cause the LLM to behave differently
+ * across wakes:
+ *   - all signal fields except `fetchedAt` (which is just Date.now()
+ *     on each aggregation and would defeat any cache hit)
+ *   - action items
+ *   - signal warnings (a new transport error ought to fire a wake)
+ *   - identity frontmatter (catches role.md / soul edits between wakes)
+ *
+ * Volatile fields (wakeId, fetchedAt) are excluded so a cron tick on
+ * unchanged content produces the same hash as the prior tick.
+ */
+const stripVolatile = <T extends { fetchedAt?: unknown }>(obj: T): Omit<T, "fetchedAt"> => {
+  const { fetchedAt: _drop, ...rest } = obj;
+  return rest;
+};
+
+const hashWakeContext = (context: AgentSpawnContext): string => {
+  const sig = {
+    signals: context.signals.signals.map(stripVolatile),
+    actionItems: context.signals.actionItems.map(stripVolatile),
+    warnings: context.signals.warnings,
+    identity: context.identity.frontmatter,
+  };
+  return createHash("sha256").update(JSON.stringify(sig)).digest("hex");
+};
 
 // ---------------------------------------------------------------------------
 // Agent registry (Phase 1A: hardcoded inline; Phase 1B: loaded from disk)
@@ -719,6 +759,42 @@ export class Daemon {
     // injection needed. Agents see directives as github-issue signals
     // with the "source-directive" label and respond in their wake output.
 
+    // Idle-wake skip (harness#297): if the bound context hashes equal
+    // to what we fired last time AND the last wake succeeded AND we
+    // haven't been skipping for too long, drop the LLM call entirely.
+    // The hash captures signal IDs + their updatedAt + action items +
+    // identity frontmatter, so any meaningful change forces a fire.
+    // Manual triggers (`--now`, scheduler kind === "manual") always
+    // fire — operators expect that override to actually run.
+    const contextHash = hashWakeContext(context);
+    const isManualTrigger = event.wakeReason.kind === "manual";
+    if (this.#agentStateStore && !isManualTrigger) {
+      const record = this.#agentStateStore.getAgent(agent.agentId);
+      // The first guard is `record?.lastFiredContextHash === contextHash`,
+      // which short-circuits when record is undefined (?. yields undefined,
+      // never equal to a string hash). Once that passes, `record` is
+      // narrowed to defined and the rest of the conditions can use plain
+      // dot access without `?.` (TS no-unnecessary-condition).
+      if (
+        record?.lastFiredContextHash === contextHash &&
+        record.lastOutcome === "success" &&
+        record.idleSkipStreak < MAX_IDLE_SKIP_STREAK
+      ) {
+        this.#agentStateStore.recordIdleSkip(agent.agentId);
+        this.#logger.info("daemon.wake.skipped", {
+          agentId: agent.agentId,
+          wakeId: event.wakeId.value,
+          reason: "idle",
+          contextHash,
+          idleSkipStreak: record.idleSkipStreak + 1,
+          maxIdleSkipStreak: MAX_IDLE_SKIP_STREAK,
+          lastFiredAt: record.lastWokenAt,
+          signalCount: context.signals.signals.length,
+        });
+        return;
+      }
+    }
+
     this.#logger.info("daemon.wake.fire", {
       agentId: agent.agentId,
       wakeId: event.wakeId.value,
@@ -729,6 +805,9 @@ export class Daemon {
 
     try {
       this.#agentStateStore?.transition(agent.agentId, "waking", event.wakeId.value);
+      // Record the hash on fire (not on skip — keeps the comparator
+      // anchored to the last actually-LLM-processed context).
+      this.#agentStateStore?.recordFiredContextHash(agent.agentId, contextHash);
       const handle = await this.#executor.spawn(context);
       this.#agentStateStore?.transition(agent.agentId, "running", event.wakeId.value);
       const result = await this.#executor.waitForCompletion(handle);

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -116,7 +116,14 @@ export interface DefaultRunnerClients {
      * reads is declared here; the underlying `LLMClient` interface
      * surfaces more.
      */
-    capabilities(): { readonly supportsToolUse: boolean };
+    capabilities(): {
+      readonly supportsToolUse: boolean;
+      /** Optional provider id (e.g. "claude-cli", "anthropic"); used to
+       *  describe the runtime in the prompt when no per-request tools
+       *  are advertised. Narrowed locally; full LLMClient capabilities
+       *  surface this and more. */
+      readonly provider?: string | undefined;
+    };
   };
   /** MCP tool loader — connects to MCP servers and returns tool definitions. */
   readonly mcpToolLoader?: {
@@ -394,14 +401,17 @@ export function createDefaultRunner(
     //
     // When the bound client reports `supportsToolUse: false`
     // (subscription-CLI family, ADR-0034 / ADR-0038), per-request
-    // tool delivery is disabled. The prompt must NOT advertise tools
-    // the agent can't actually call — doing so produces the
-    // narrative-only-claim regression observed across May 1's
-    // engineering circle wakes (5 of 6 raised this as a TENSION).
-    // We collapse to the "_None._" fallback in that case so the
-    // agent stays text-only and routes capability gaps through
-    // GOVERNANCE_EVENT instead of pretending to call missing tools.
-    const supportsRequestTools = clients.llm.capabilities().supportsToolUse;
+    // tool delivery is disabled. We do not pass `request.tools` and
+    // do not list per-request tools in the prompt — but we MUST tell
+    // the agent it has its runtime's own tool ecosystem (Bash incl.
+    // `gh`, file editing, code search, plus any MCP servers wired
+    // via the subprocess's --mcp-config). The previous "_None._"
+    // fallback caused 18 agents in a single round (live run
+    // 2026-05-03) to file convergent TENSION/PROPOSAL issues
+    // complaining their declared capabilities (e.g. "Comment on
+    // issues: YES") didn't match the prompt's empty tools list.
+    const llmCaps = clients.llm.capabilities();
+    const supportsRequestTools = llmCaps.supportsToolUse;
     const mcpConfigs = supportsRequestTools ? (spawn.mcpServerConfigs ?? []) : [];
     const allTools: RunnerToolDefinition[] = [];
     if (supportsRequestTools) {
@@ -446,6 +456,15 @@ export function createDefaultRunner(
               ", ",
             )}) to check whether the repo is already indexed. Skip indexing when state is current — re-indexing dumps massive confirmation payloads into your context (verified: 1M+ tokens for one needless re-index).`
         : "";
+    // The "no per-request tools" message branches on whether the
+    // client runs its own tool loop. Subscription-CLI clients do —
+    // their runtime (claude-cli, codex-cli, gemini-cli) provides
+    // Bash, file editing, gh CLI, etc. natively, plus any MCP
+    // servers wired via --mcp-config. API-tool clients with no
+    // tools loaded truly have nothing.
+    const noPerRequestToolsBlock = supportsRequestTools
+      ? `\n### Tools you can call this wake\n_None._ If your task requires a tool you don't have, file a GOVERNANCE_EVENT requesting the capability rather than narrating fictional completion.`
+      : `\n### Tools you can call this wake\nPer-request tools are not advertised — your runtime${llmCaps.provider ? ` (\`${llmCaps.provider}\`)` : ""} runs its own tool loop and provides them directly: shell access (use \`gh\` for GitHub operations matching your declared capabilities above), file editing, code search, and any MCP servers configured for your subprocess. **Use them to act on issues** — do not narrate "I will comment on #N" or "I would post Y." Call the tool. If a capability you need is genuinely missing from your runtime, file a GOVERNANCE_EVENT naming the specific gap.`;
     const toolsBlock =
       tools && tools.length > 0
         ? `\n### Tools you can call this wake\n${tools
@@ -453,7 +472,7 @@ export function createDefaultRunner(
             .join(
               "\n",
             )}\n\nThese are real tool calls. **Use them** — do not narrate "I will read X" or "I would post Y." Either call the tool to do the work, or file a GOVERNANCE_EVENT explaining the specific blocker that prevents the call. Narrating an action without calling its tool is a Boundary 5 hallucination and will be flagged in your wake artifacts.${setupDisciplineBlock}`
-        : `\n### Tools you can call this wake\n_None._ If your task requires a tool you don't have, file a GOVERNANCE_EVENT requesting the capability rather than narrating fictional completion.`;
+        : noPerRequestToolsBlock;
     const capsBlock = caps
       ? `\n\n## Your Capabilities\nIf any capability you need to fulfill your role is missing, file a GOVERNANCE_EVENT requesting it.\n### GitHub\n- Commit files: ${caps.github.canCommit ? `YES (paths: ${caps.github.commitPaths.join(", ")})` : "NO"}\n- Comment on issues: ${caps.github.canCommentIssues ? "YES" : "NO"}\n- Create issues: ${caps.github.canCreateIssues ? "YES" : "NO"}\n- Label issues: ${caps.github.canLabelIssues ? "YES" : "NO"}${caps.cliTools.length > 0 ? `\n### CLI Tools\n${caps.cliTools.map((t) => `- ${t}`).join("\n")}` : ""}${caps.mcpServers.length > 0 ? `\n### MCP Servers\n${caps.mcpServers.map((s) => `- ${s}`).join("\n")}` : ""}\n### Signal Sources\n${caps.signalSources.map((s) => `- ${s}`).join("\n") || "- (none configured)"}${toolsBlock}`
       : toolsBlock;

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -253,6 +253,51 @@ describe("createDefaultRunner", () => {
     expect(llmCalls[0]?.maxSteps).toBeUndefined();
   });
 
+  it("prompt for supportsToolUse=false agent describes runtime-native tools, not '_None._' (live regression 2026-05-03)", async () => {
+    // Live run on EP (2026-05-03 18:46–18:56 PDT) saw 18 of 22
+    // completing claude-cli agents independently file convergent
+    // TENSION/PROPOSAL issues complaining the wake prompt said
+    // "Tools you can call this wake: None" while their declared
+    // capabilities said "Comment on issues: YES". The runner now
+    // tells subscription-CLI agents that their runtime provides
+    // tools natively (Bash, gh, file edit, MCP via --mcp-config)
+    // so they stop concluding they can't act.
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const llm = makeLlmClient("Got it.", { supportsToolUse: false });
+
+    await runner({
+      spawn: makeSpawn(), // no mcpServerConfigs
+      clients: { llm },
+    });
+
+    const llmCalls = (llm as unknown as { _calls: { messages?: { content: string }[] }[] })._calls;
+    const prompt = llmCalls[0]?.messages?.[0]?.content ?? "";
+
+    // The misleading "_None._" line must not be in the prompt for
+    // a client that runs its own tool loop.
+    expect(prompt).not.toMatch(/Tools you can call this wake\n_None\._/);
+    // The replacement must tell the agent it has runtime-native tools.
+    expect(prompt).toContain("runs its own tool loop");
+    expect(prompt).toMatch(/shell access|gh.*GitHub/i);
+    expect(prompt).toContain("Use them to act on issues");
+  });
+
+  it("prompt still says '_None._' for supportsToolUse=true clients with no tools loaded (preserves existing behavior)", async () => {
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const llm = makeLlmClient("Nothing to do.", { supportsToolUse: true });
+
+    await runner({
+      spawn: makeSpawn(), // no mcpServerConfigs
+      clients: { llm },
+    });
+
+    const llmCalls = (llm as unknown as { _calls: { messages?: { content: string }[] }[] })._calls;
+    const prompt = llmCalls[0]?.messages?.[0]?.content ?? "";
+
+    expect(prompt).toMatch(/Tools you can call this wake\n_None\._/);
+    expect(prompt).not.toContain("runs its own tool loop");
+  });
+
   it("does not load tools when no mcpServerConfigs", async () => {
     const runner = createDefaultRunner("test-agent", [], {}, rootDir);
     const llm = makeLlmClient("No tools needed.");

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
Bundled into v0.6.4. Two distinct fixes that ship together; both verified live on EP.

## 1. Idle-wake skip (closes harness#297)

Cron-triggered wakes now skip the LLM when the wake context hash matches the prior **fired** hash AND the prior outcome was `success`. Bounds growth via `MAX_IDLE_SKIP_STREAK = 12` (after which the agent force-fires regardless). Manual triggers (`delay-once`, `--now`, directives) are exempt — the operator's hand always wins.

**Verified live (chronicler-agent, 60s interval):**
- T+60s `wake.fire` (no prior hash → fires, records hash `157411cb…`)
- T+120s `wake.skipped` (hash matched, streak=1)
- T+135s first wake completed
- streak=2 on third tick

## 2. Honest tool description for subscription-CLI agents

Live regression 2026-05-03 18:46–18:56 PDT: 18 of 22 completing claude-cli agents on EP independently filed convergent TENSION/PROPOSAL issues (#769–#786) — all complaining the wake prompt said *"Tools you can call this wake: None"* while their declared capabilities said *"Comment on issues: YES"*.

Root cause: v0.6.2 correctly skipped per-request tool advertising for subscription-CLI clients (CF-A guard), but the fallback message lied — claude-cli has Bash, `gh`, file editing, code search natively, plus any MCP servers wired via `--mcp-config`. Prompt now describes those instead of denying tools exist.

**Verified post-fix:** a single design-agent wake comments on #552, **closes its own previous "missing tools" tension #769** ("tool access was available all along"), and files an amended write_scopes proposal on #529 — three concrete actions where the prior identical wake produced zero.

## Tests

- 3 unit tests for `AgentStateStore` idle-skip methods
- Integration test in `daemon.test.ts` proving cron→fire→skip path with real `Daemon` + `AgentStateStore`
- 2 runner tests asserting the new prompt branch (subscription-CLI gets runtime-native description; API-tool clients still see `_None._`)
- 786 / 787 tests passing (1 pre-existing skip)

## Test plan
- [x] CI green (20.x + 22.x)
- [x] Full unit suite passes
- [x] Live verification: chronicler-agent fire → skip on real GitHub signals
- [x] Live verification: design-agent uses tools instead of filing missing-tools tension