### PR TITLE
feat(v0.7.1): stability — CLI path resolution, telemetry, cost fixes, security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Assert Spirit MCP binary exists after build (#279)
+        run: test -f packages/cli/dist/spirit/mcp-bin.js
+
       - name: Typecheck
         run: pnpm typecheck
 
@@ -82,7 +85,7 @@ jobs:
           # daemon.wake.cost fires with the v1 schema and real subprocess delta.
           grep -q '"event":"daemon.wake.cost"' /tmp/gate.log
           grep -q '"event":"daemon.wake.cost".*"schemaVersion":1' /tmp/gate.log
-          grep -q '"event":"daemon.wake.cost".*"modelProvider":"placeholder"' /tmp/gate.log
+          grep -q '"event":"daemon.wake.cost".*"modelProvider":"unknown"' /tmp/gate.log
           grep -q '"event":"daemon.wake.cost".*"costUsdFormatted":"0.0000"' /tmp/gate.log
           grep -q '"event":"daemon.wake.cost".*"dayUtc":"' /tmp/gate.log
           grep -q '"event":"daemon.wake.cost".*"isoWeekUtc":"' /tmp/gate.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # for gh release create
+
+jobs:
+  publish:
+    name: verify + publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify package versions match tag
+        run: |
+          set -e
+          TAG="${GITHUB_REF_NAME}"          # e.g. v0.7.1
+          VERSION="${TAG#v}"                 # strip leading v
+          echo "Tag: $TAG  →  expected version: $VERSION"
+
+          MISMATCHES=0
+          for pkg in packages/*/package.json package.json; do
+            PKG_VERSION=$(node -p "require('./$pkg').version" 2>/dev/null || true)
+            if [ -z "$PKG_VERSION" ]; then continue; fi
+            if [ "$PKG_VERSION" != "$VERSION" ]; then
+              echo "MISMATCH: $pkg has version $PKG_VERSION, expected $VERSION"
+              MISMATCHES=$((MISMATCHES + 1))
+            fi
+          done
+          if [ "$MISMATCHES" -gt 0 ]; then
+            echo "Version check failed — bump all package.json files to $VERSION before tagging."
+            exit 1
+          fi
+          echo "All package.json versions match $VERSION ✓"
+
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish to npm
+        run: pnpm -r publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          TAG="${GITHUB_REF_NAME}"
+          # Find the previous tag to generate a changelog range
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${TAG}$" | head -1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log --oneline "${PREV_TAG}..${TAG}" 2>/dev/null || true)
+          else
+            NOTES=$(git log --oneline "${TAG}" 2>/dev/null || true)
+          fi
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping creation."
+          else
+            echo "$NOTES" | gh release create "$TAG" \
+              --title "Release $TAG" \
+              --notes-file - \
+              --verify-tag
+          fi

--- a/docs/adr/0034-subscription-cli-provider-family.md
+++ b/docs/adr/0034-subscription-cli-provider-family.md
@@ -34,7 +34,7 @@ We add a **subscription-CLI provider family** to `packages/llm` with:
      provider: subscription-cli
      cli: claude | gemini | codex
      model: claude-sonnet-4-6 # optional
-     timeoutMs: 90000 # optional
+     timeoutMs: 600000 # optional; default 600 000ms (10 min) for multi-step wakes
    ```
 
 ### Locked interface (the load-bearing contract)
@@ -75,18 +75,18 @@ This interface is **locked before adapter work began**. Subsequent adapters (gem
 
 ### Ratified constraints (D1–D10 from the 2026-05-01 engineering meeting)
 
-| #       | Constraint                                                                                                   | Rationale                                                                                                   |
-| ------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| **D1**  | `buildFlags()` MUST NOT contain prompt content. Prompt is delivered via stdin only, argv is array form only. | `ps aux`, audit logs, and shell history would otherwise leak prompts.                                       |
-| **D2**  | Three-state auth model: `authenticated` \| `unauthenticated` \| `unavailable`.                               | Distinguishes "CLI missing" (soft skip with actionable message) from "logged out" (hard wake-time failure). |
-| **D3**  | Token counts MUST NEVER silently zero. Missing counts → `ParseError { code: 'TOKEN_COUNT_MISSING' }`.        | Silent zeros disable budget enforcement. Same incident class as #635.                                       |
-| **D4**  | Wall-clock subprocess timeout, default 90s, configurable via `llm.timeoutMs`.                                | Subprocesses can hang indefinitely; the daemon must reclaim the wake slot.                                  |
-| **D5**  | SIGTERM first, then SIGKILL after 5s grace. Wait for child exit.                                             | Avoid zombies; respect cleanup hooks where possible.                                                        |
-| **D6**  | `SecretsProvider.get()` MUST be used for any credential value read. No `process.env` fallback.               | ADR-0010 compliance; `scrubLogRecord` coverage.                                                             |
-| **D7**  | No silent fallback from API to CLI or vice-versa. CLI failure → typed error, propagate.                      | Operators must see real failures; silent fallback masks subscription/quota issues.                          |
-| **D8**  | Operators without an AI CLI installed MUST NOT be blocked from running the harness. CI included.             | Soft `unavailable` skip with message; agents using `provider: subscription-cli` fail closed.                |
-| **D9**  | `costUsd: 0` records with `provider: <cli>-cli` and real `tokens.{prompt,completion}` populated.             | Subscription wakes are $0 marginal but real tokens; observability must reflect that.                        |
-| **D10** | `LLMClient` interface unchanged. Subprocess provider is interchangeable from the daemon's perspective.       | Composition root stays thin; daemon doesn't branch on provider type.                                        |
+| #       | Constraint                                                                                                                                                                                                                 | Rationale                                                                                                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **D1**  | `buildFlags()` MUST NOT contain prompt content. Prompt is delivered via stdin only, argv is array form only.                                                                                                               | `ps aux`, audit logs, and shell history would otherwise leak prompts.                                       |
+| **D2**  | Three-state auth model: `authenticated` \| `unauthenticated` \| `unavailable`.                                                                                                                                             | Distinguishes "CLI missing" (soft skip with actionable message) from "logged out" (hard wake-time failure). |
+| **D3**  | Token counts MUST NEVER silently zero. Missing counts → `ParseError { code: 'TOKEN_COUNT_MISSING' }`.                                                                                                                      | Silent zeros disable budget enforcement. Same incident class as #635.                                       |
+| **D4**  | Wall-clock subprocess timeout, default 600 000ms (10 min), configurable via `llm.timeoutMs`. The 10-min default is intentional: multi-step agentic wakes routinely take 5–8 min, so 90 s would kill most productive wakes. | Subprocesses can hang indefinitely; the daemon must reclaim the wake slot.                                  |
+| **D5**  | SIGTERM first, then SIGKILL after 5s grace. Wait for child exit.                                                                                                                                                           | Avoid zombies; respect cleanup hooks where possible.                                                        |
+| **D6**  | `SecretsProvider.get()` MUST be used for any credential value read. No `process.env` fallback.                                                                                                                             | ADR-0010 compliance; `scrubLogRecord` coverage.                                                             |
+| **D7**  | No silent fallback from API to CLI or vice-versa. CLI failure → typed error, propagate.                                                                                                                                    | Operators must see real failures; silent fallback masks subscription/quota issues.                          |
+| **D8**  | Operators without an AI CLI installed MUST NOT be blocked from running the harness. CI included.                                                                                                                           | Soft `unavailable` skip with message; agents using `provider: subscription-cli` fail closed.                |
+| **D9**  | `costUsd: 0` records with `provider: <cli>-cli` and real `tokens.{prompt,completion}` populated.                                                                                                                           | Subscription wakes are $0 marginal but real tokens; observability must reflect that.                        |
+| **D10** | `LLMClient` interface unchanged. Subprocess provider is interchangeable from the daemon's perspective.                                                                                                                     | Composition root stays thin; daemon doesn't branch on provider type.                                        |
 
 ### Package layout
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -19,6 +19,8 @@ import { dirname, join, resolve } from "node:path";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
+import { isScopeLabel } from "@murmurations-ai/core";
+
 import { initSpiritSession, SpiritUnavailableError, type SpiritSession } from "./spirit/index.js";
 
 interface SocketResponse {
@@ -1170,7 +1172,7 @@ const handleCommand = async (
           console.log("  No directives found.");
         } else {
           for (const item of items) {
-            const scope = item.labels.find((l: string) => l.startsWith("scope:")) ?? "";
+            const scope = item.labels.find((l: string) => isScopeLabel(l)) ?? "";
             console.log(
               `  ${item.id.padEnd(10)} ${item.state.padEnd(8)} ${scope.padEnd(20)} ${item.title.slice(0, 60)}`,
             );

--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -2,11 +2,23 @@
  * Tests for boot.ts exported helpers. Today this file only covers
  * `makeDaemonHook` — the rest of `boot.ts` is exercised through the
  * daemon test suite and integration paths.
+ *
+ * Also covers the daemon→aggregator wiring: verifies that
+ * `registeredAgentFromLoadedIdentity` derives the correct membership-aware
+ * `anyLabel` routing set (QA #2, harness#338).
  */
 
 import { describe, it, expect } from "vitest";
 
-import { makeAgentId, makeWakeId, WakeCostBuilder } from "@murmurations-ai/core";
+import {
+  makeAgentId,
+  makeWakeId,
+  registeredAgentFromLoadedIdentity,
+  roleFrontmatterSchema,
+  WakeCostBuilder,
+  type IdentityChain,
+  type LoadedAgentIdentity,
+} from "@murmurations-ai/core";
 
 import { makeDaemonHook } from "./boot.js";
 
@@ -115,5 +127,93 @@ describe("makeDaemonHook", () => {
     expect(record.llm.inputTokens).toBe(7_000);
     expect(record.llm.outputTokens).toBe(1_500);
     expect(record.llm.costMicros.value).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QA #2 (harness#338): daemon→aggregator routing-label wiring
+//
+// Verifies that registeredAgentFromLoadedIdentity derives the correct
+// membership-aware anyLabel OR-set so that a future boot.ts refactor that
+// drops the derivation step is caught by CI rather than silently regressing
+// to the harness#331 bug class.
+// ---------------------------------------------------------------------------
+
+const makeMinimalChain = (agentId: string): IdentityChain => ({
+  agentId: makeAgentId(agentId),
+  layers: [],
+  frontmatter: {
+    agentId: makeAgentId(agentId),
+    name: agentId,
+    modelTier: "balanced",
+    groupMemberships: [],
+  },
+});
+
+const makeLoadedIdentity = (
+  agentId: string,
+  groups: readonly string[],
+  anyLabelOverride?: readonly string[],
+): LoadedAgentIdentity => ({
+  agentId: makeAgentId(agentId),
+  chain: makeMinimalChain(agentId),
+  frontmatter: roleFrontmatterSchema.parse({
+    agent_id: agentId,
+    name: agentId,
+    model_tier: "balanced",
+    group_memberships: groups,
+    signals: {
+      sources: ["github-issue"],
+      github_scopes: [
+        {
+          owner: "acme",
+          repo: "signals",
+          filter: {
+            state: "all",
+            ...(anyLabelOverride !== undefined ? { any_label: anyLabelOverride } : {}),
+          },
+        },
+      ],
+    },
+  }),
+});
+
+const INTERVAL_TRIGGER = { kind: "interval" as const, intervalMs: 60_000 };
+
+describe("registeredAgentFromLoadedIdentity — routing label wiring (QA #2, harness#338)", () => {
+  it("agent with group membership receives derived anyLabel including group scope", () => {
+    const loaded = makeLoadedIdentity("agent-a", ["partnership"]);
+    const registered = registeredAgentFromLoadedIdentity(loaded, INTERVAL_TRIGGER);
+
+    const anyLabel = registered.signalScopes?.githubScopes?.[0]?.filter.anyLabel;
+    expect(anyLabel).toBeDefined();
+    expect(anyLabel).toContain("assigned:agent-a");
+    expect(anyLabel).toContain("scope:agent:agent-a");
+    expect(anyLabel).toContain("scope:group:partnership");
+    expect(anyLabel).toContain("scope:all");
+  });
+
+  it("agent without group memberships receives derived anyLabel without group scopes", () => {
+    const loaded = makeLoadedIdentity("agent-b", []);
+    const registered = registeredAgentFromLoadedIdentity(loaded, INTERVAL_TRIGGER);
+
+    const anyLabel = registered.signalScopes?.githubScopes?.[0]?.filter.anyLabel;
+    expect(anyLabel).toBeDefined();
+    expect(anyLabel).toContain("assigned:agent-b");
+    expect(anyLabel).toContain("scope:agent:agent-b");
+    expect(anyLabel).toContain("scope:all");
+    expect(anyLabel?.some((l) => l.startsWith("scope:group:"))).toBe(false);
+  });
+
+  it("operator-supplied any_label in role.md overrides the daemon-derived default", () => {
+    const customLabels = ["custom-label", "my-special-routing"];
+    const loaded = makeLoadedIdentity("agent-c", ["engineering"], customLabels);
+    const registered = registeredAgentFromLoadedIdentity(loaded, INTERVAL_TRIGGER);
+
+    const anyLabel = registered.signalScopes?.githubScopes?.[0]?.filter.anyLabel;
+    expect(anyLabel).toEqual(customLabels);
+    // derived labels should NOT be present when operator overrides
+    expect(anyLabel).not.toContain("scope:group:engineering");
+    expect(anyLabel).not.toContain("assigned:agent-c");
   });
 });

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -27,6 +27,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   AgentStateStore,
+  buildAgentRoutingLabels,
   Daemon,
   DispatchExecutor,
   GitHubCollaborationProvider,
@@ -1418,20 +1419,34 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   // keep the first-pass daemon if neither condition applies — which
   // is the hello-world / no-token path.
   // Merge signal scopes from ALL agents into a single aggregator
-  // config. Duplicate repos are OK — the aggregator deduplicates at
-  // the fetch level (same URL = same cache entry).
+  // config. Duplicate repos are OK — the aggregator deduplicates by
+  // issue id at the fetch level.
+  //
+  // harness#331 fix: per-agent membership-aware routing labels are
+  // injected here as the scope's `anyLabel` (OR-semantics). Without
+  // them, scoped source-directives (`scope:agent:<id>`, `scope:group:<g>`,
+  // `scope:all`) silently disappear because the aggregator's existing
+  // `labels` filter is AND-only and only matches `assigned:<id>`. The
+  // operator can override by setting `signals.github_scopes[].filter.any_label`
+  // explicitly in role.md — the daemon-injected default applies only
+  // when the operator hasn't.
   const githubSignalScopes = allRegistered.flatMap(
     (agent) =>
-      agent.signalScopes?.githubScopes?.map((scope) => ({
-        repo: makeRepoCoordinate(scope.owner, scope.repo),
-        filter: {
-          state: scope.filter.state,
-          ...(scope.filter.labels !== undefined ? { labels: scope.filter.labels } : {}),
-          ...(scope.filter.sinceDays !== undefined
-            ? { since: new Date(Date.now() - scope.filter.sinceDays * 86_400_000) }
-            : {}),
-        },
-      })) ?? [],
+      agent.signalScopes?.githubScopes?.map((scope) => {
+        const operatorAnyLabel = scope.filter.anyLabel;
+        const derivedAnyLabel = buildAgentRoutingLabels(agent.agentId, agent.groupMemberships);
+        return {
+          repo: makeRepoCoordinate(scope.owner, scope.repo),
+          filter: {
+            state: scope.filter.state,
+            ...(scope.filter.labels !== undefined ? { labels: scope.filter.labels } : {}),
+            ...(scope.filter.sinceDays !== undefined
+              ? { since: new Date(Date.now() - scope.filter.sinceDays * 86_400_000) }
+              : {}),
+          },
+          anyLabel: operatorAnyLabel ?? derivedAnyLabel,
+        };
+      }) ?? [],
   );
 
   // Construct governance sync via CollaborationProvider (ADR-0021).

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -81,7 +81,10 @@ import { McpToolLoader } from "@murmurations-ai/mcp";
 import { DotenvSecretsProvider } from "@murmurations-ai/secrets-dotenv";
 import { DefaultSignalAggregator } from "@murmurations-ai/signals";
 
-import { buildGithubReadToolsForAgent } from "./github-tools/index.js";
+import {
+  buildGithubReadToolsForAgent,
+  buildGithubWriteToolsForAgent,
+} from "./github-tools/index.js";
 import type { HarnessLLMConfig } from "./harness-config.js";
 import { validateHarnessYaml } from "./harness-config.js";
 import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js";
@@ -1173,10 +1176,23 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     // GitHub-side rate-limit headers.
     const buildAgentBoundGithub = (): readonly (typeof extensionTools)[number][] => {
       if (provider?.has(GITHUB_TOKEN) !== true) return [];
-      const client = createGithubClient({
+      const readClient = createGithubClient({
         token: provider.get(GITHUB_TOKEN),
       });
-      return buildGithubReadToolsForAgent(client) as readonly (typeof extensionTools)[number][];
+      const readTools = buildGithubReadToolsForAgent(readClient);
+      // Add write tools for agents that declare issue_comments write scopes (#274).
+      // The write client enforces ADR-0017 scope at the GitHub layer.
+      const hasCommentScope = agent.githubWriteScopes.issueComments.length > 0;
+      const writeTools =
+        hasCommentScope && !dryRun
+          ? buildGithubWriteToolsForAgent(
+              createGithubClient({
+                token: provider.get(GITHUB_TOKEN),
+                writeScopes: toClientWriteScopes(agent),
+              }),
+            )
+          : [];
+      return [...readTools, ...writeTools] as readonly (typeof extensionTools)[number][];
     };
 
     if (agent.plugins.length === 0) {

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -83,6 +83,7 @@ import { DefaultSignalAggregator } from "@murmurations-ai/signals";
 
 import { buildGithubReadToolsForAgent } from "./github-tools/index.js";
 import type { HarnessLLMConfig } from "./harness-config.js";
+import { validateHarnessYaml } from "./harness-config.js";
 import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js";
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 import { registerRunningSocket, unregisterRunningSocket } from "./running-sessions.js";
@@ -719,6 +720,18 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   const { DaemonEventBus, DaemonLoggerImpl } = await import("@murmurations-ai/core");
   const eventBus = new DaemonEventBus();
   const logger = new DaemonLoggerImpl({ level: config.logging.level, eventBus });
+
+  // Emit daemon.config.warn for every harness.yaml field that silently
+  // fell back to a default (#323). This surfaces mis-spellings and invalid
+  // enum values that loadHarnessConfig swallows without feedback.
+  for (const w of await validateHarnessYaml(exampleRoot)) {
+    logger.warn("daemon.config.warn", {
+      field: w.field,
+      message: w.message,
+      received: w.received,
+      ...(w.accepted !== undefined ? { accepted: w.accepted } : {}),
+    });
+  }
 
   // Load governance plugin — from merged config (CLI > harness.yaml > default)
   const governancePath = config.governance.plugin;

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -27,7 +27,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   AgentStateStore,
-  buildAgentRoutingLabels,
   Daemon,
   DispatchExecutor,
   findReservedLabels,
@@ -1421,33 +1420,23 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   // is the hello-world / no-token path.
   // Merge signal scopes from ALL agents into a single aggregator
   // config. Duplicate repos are OK — the aggregator deduplicates by
-  // issue id at the fetch level.
-  //
-  // harness#331 fix: per-agent membership-aware routing labels are
-  // injected here as the scope's `anyLabel` (OR-semantics). Without
-  // them, scoped source-directives (`scope:agent:<id>`, `scope:group:<g>`,
-  // `scope:all`) silently disappear because the aggregator's existing
-  // `labels` filter is AND-only and only matches `assigned:<id>`. The
-  // operator can override by setting `signals.github_scopes[].filter.any_label`
-  // explicitly in role.md — the daemon-injected default applies only
-  // when the operator hasn't.
+  // issue id at the fetch level. The membership-aware `anyLabel`
+  // routing set is already derived inside `registeredAgentFromLoadedIdentity`
+  // (harness#343 — composition root stays thin, Engineering Standard #8),
+  // so this site only translates DTO shapes.
   const githubSignalScopes = allRegistered.flatMap(
     (agent) =>
-      agent.signalScopes?.githubScopes?.map((scope) => {
-        const operatorAnyLabel = scope.filter.anyLabel;
-        const derivedAnyLabel = buildAgentRoutingLabels(agent.agentId, agent.groupMemberships);
-        return {
-          repo: makeRepoCoordinate(scope.owner, scope.repo),
-          filter: {
-            state: scope.filter.state,
-            ...(scope.filter.labels !== undefined ? { labels: scope.filter.labels } : {}),
-            ...(scope.filter.sinceDays !== undefined
-              ? { since: new Date(Date.now() - scope.filter.sinceDays * 86_400_000) }
-              : {}),
-          },
-          anyLabel: operatorAnyLabel ?? derivedAnyLabel,
-        };
-      }) ?? [],
+      agent.signalScopes?.githubScopes?.map((scope) => ({
+        repo: makeRepoCoordinate(scope.owner, scope.repo),
+        filter: {
+          state: scope.filter.state,
+          ...(scope.filter.labels !== undefined ? { labels: scope.filter.labels } : {}),
+          ...(scope.filter.sinceDays !== undefined
+            ? { since: new Date(Date.now() - scope.filter.sinceDays * 86_400_000) }
+            : {}),
+        },
+        ...(scope.filter.anyLabel !== undefined ? { anyLabel: scope.filter.anyLabel } : {}),
+      })) ?? [],
   );
 
   // Construct governance sync via CollaborationProvider (ADR-0021).

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync, unlinkSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -1709,43 +1709,64 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   const socketPath = resolve(exampleRoot, ".murmuration", "daemon.sock");
   await mkdir(resolve(exampleRoot, ".murmuration"), { recursive: true });
   if (!once) {
-    // Guard against same-machine collision (#219): if a pidfile exists and its
-    // process is still alive, refuse to start rather than silently clobbering it.
+    // Guard against same-machine collision (#219): atomically create the pidfile
+    // with O_CREAT|O_EXCL ("wx" flag). If another process created it first we get
+    // EEXIST — then we read the stored PID and probe liveness.
+    //
+    // The atomic O_CREAT|O_EXCL create closes the TOCTOU race that the previous
+    // read-then-write had: two concurrent `murmuration start` calls could both
+    // observe ENOENT and both fall through to write, ending up with two daemons
+    // running against the same root (violating Engineering Standard #3).
+    const alreadyRunningError = (existingPid: number): Error => {
+      const lines = [
+        `murmuration: a daemon is already running for this murmuration.`,
+        `  root:   ${exampleRoot}`,
+        `  pid:    ${String(existingPid)}`,
+        `  socket: ${socketPath}`,
+        `  attach: murmuration attach ${runningSessionName}`,
+        `  stop:   murmuration stop --root ${exampleRoot}`,
+        ``,
+        `If you believe this is wrong (e.g. the process crashed without`,
+        `cleaning up), remove the stale pidfile manually:`,
+        `  rm ${pidfilePath}`,
+      ];
+      return new Error(lines.join("\n"));
+    };
+
     try {
-      const rawPid = await readFile(pidfilePath, "utf8");
+      // Atomic exclusive create: succeeds only if the file does not already exist.
+      const fh = await open(pidfilePath, "wx");
+      await fh.writeFile(String(process.pid), "utf8");
+      await fh.close();
+    } catch (createErr) {
+      const code = (createErr as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw createErr;
+
+      // Pidfile already exists — check whether the recorded process is still alive.
+      const rawPid = await readFile(pidfilePath, "utf8").catch(() => "");
       const existingPid = Number(rawPid.trim());
       if (Number.isFinite(existingPid) && existingPid > 0) {
         try {
           process.kill(existingPid, 0); // signal 0 = probe only, doesn't kill
-          // Process is alive — refuse to start.
-          const lines = [
-            `murmuration: a daemon is already running for this murmuration.`,
-            `  root:   ${exampleRoot}`,
-            `  pid:    ${String(existingPid)}`,
-            `  socket: ${socketPath}`,
-            `  attach: murmuration attach ${runningSessionName}`,
-            `  stop:   murmuration stop --root ${exampleRoot}`,
-            ``,
-            `If you believe this is wrong (e.g. the process crashed without`,
-            `cleaning up), remove the stale pidfile manually:`,
-            `  rm ${pidfilePath}`,
-          ];
-          throw new Error(lines.join("\n"));
+          // No throw → process is alive.
+          throw alreadyRunningError(existingPid);
         } catch (killErr) {
-          // kill(pid, 0) throws when the process doesn't exist — stale pidfile.
-          if ((killErr as NodeJS.ErrnoException).code === "ESRCH") {
+          const killCode = (killErr as NodeJS.ErrnoException).code;
+          if (killCode === "ESRCH") {
+            // Process is gone — stale pidfile. Overwrite it.
             logger.info("daemon.pidfile.stale", { existingPid, pidfilePath });
-            // fall through to overwrite
+            const fh = await open(pidfilePath, "w");
+            await fh.writeFile(String(process.pid), "utf8");
+            await fh.close();
+          } else if (killCode === "EPERM") {
+            // Process exists but is owned by a different OS user — treat as alive.
+            throw alreadyRunningError(existingPid);
           } else {
-            throw killErr; // re-throw the "already running" error from above
+            throw killErr;
           }
         }
       }
-    } catch (readErr) {
-      if ((readErr as NodeJS.ErrnoException).code !== "ENOENT") throw readErr;
-      // ENOENT = no pidfile yet, normal first start
     }
-    await writeFile(pidfilePath, String(process.pid), "utf8");
   }
 
   // Start daemon control socket

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -21,7 +21,8 @@
  */
 
 import { existsSync, unlinkSync } from "node:fs";
-import { mkdir, open, readFile } from "node:fs/promises";
+import { access, constants, mkdir, open, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -91,6 +92,76 @@ import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js"
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 import { registerRunningSocket, unregisterRunningSocket } from "./running-sessions.js";
 import { writeSpiritMcpConfig } from "./spirit/mcp-config.js";
+
+// ---------------------------------------------------------------------------
+// CLI binary resolution — launchd / cron safe (harness#XXX)
+//
+// macOS launchd and Linux systemd/cron start processes with a minimal PATH
+// that doesn't include user-specific install directories (e.g. ~/.local/bin,
+// ~/.npm/bin). When the daemon runs via launchd (io.murmurations.*), a plain
+// `spawn("claude")` fails with ENOENT even though `claude` is installed.
+//
+// Fix: resolve to an absolute path at daemon boot time. Try PATH first (works
+// in interactive sessions), then fall back to the common install locations
+// each CLI vendor uses on macOS/Linux. The resolved path is immune to PATH
+// changes after boot.
+// ---------------------------------------------------------------------------
+
+/** Common install locations per CLI binary, most-likely first. */
+const CLI_FALLBACK_PATHS: Record<string, readonly string[]> = {
+  claude: [
+    join(homedir(), ".local", "bin", "claude"),
+    "/usr/local/bin/claude",
+    "/opt/homebrew/bin/claude",
+    join(homedir(), ".npm", "bin", "claude"),
+    join(homedir(), "node_modules", ".bin", "claude"),
+  ],
+  gemini: [
+    join(homedir(), ".local", "bin", "gemini"),
+    "/usr/local/bin/gemini",
+    "/opt/homebrew/bin/gemini",
+    join(homedir(), ".npm", "bin", "gemini"),
+  ],
+  codex: [
+    join(homedir(), ".local", "bin", "codex"),
+    "/usr/local/bin/codex",
+    "/opt/homebrew/bin/codex",
+    join(homedir(), ".npm", "bin", "codex"),
+    join(homedir(), ".openai", "bin", "codex"),
+  ],
+};
+
+/**
+ * Resolve the absolute path for a CLI binary.
+ *
+ * Returns the first reachable executable found, or null if nothing is found.
+ * Tries `which` first (inherits current PATH), then probes common install
+ * locations so launchd / cron environments can still locate the binary.
+ */
+const resolveCliBinaryPath = async (cli: string): Promise<string | null> => {
+  // Try PATH resolution via `which` first.
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync("which", [cli], { timeout: 5000 });
+    const p = stdout.trim();
+    if (p.length > 0) return p;
+  } catch {
+    // which failed — PATH doesn't include the binary; try fallback paths.
+  }
+  // Probe well-known install locations.
+  const candidates = CLI_FALLBACK_PATHS[cli] ?? [];
+  for (const p of candidates) {
+    try {
+      await access(p, constants.X_OK);
+      return p;
+    } catch {
+      // not found or not executable
+    }
+  }
+  return null;
+};
 
 const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
 
@@ -370,6 +441,13 @@ interface BuildAgentClientsArgs {
   /** Optional logger so the cost hook can emit `daemon.cost.pricing.unknown`
    *  warns when a model isn't in the pricing catalog (harness#251). */
   readonly logger?: { warn: (event: string, fields?: Record<string, unknown>) => void };
+  /**
+   * Absolute path to the subscription-CLI binary, pre-resolved at boot by
+   * `resolveCliBinaryPath()`. When set, passed to `createSubscriptionCliClient`
+   * so `spawn()` uses the absolute path rather than relying on PATH resolution.
+   * Fixes ENOENT failures in launchd / cron environments (harness#XXX).
+   */
+  readonly resolvedCliPath?: string;
 }
 
 interface BuildAgentClientsResult {
@@ -387,6 +465,7 @@ interface BuildAgentClientsResult {
  * builder) so the cost hook lands on the right record.
  */
 const buildAgentClients = ({
+  resolvedCliPath,
   agent,
   provider,
   providerRegistry,
@@ -452,6 +531,7 @@ const buildAgentClients = ({
             : {}),
           ...(mcpConfigPath !== undefined ? { mcpConfigPath } : {}),
           ...(costHook !== undefined ? { defaultCostHook: costHook } : {}),
+          ...(resolvedCliPath !== undefined ? { cliPath: resolvedCliPath } : {}),
         });
       }
     } else {
@@ -1247,6 +1327,25 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   const ollamaBaseUrl = process.env.OLLAMA_BASE_URL;
   const executorMap = new Map<string, AgentExecutor>();
 
+  // Resolve subscription-CLI binary path once at boot. launchd / cron / systemd
+  // start daemons with a minimal PATH that may omit user-install locations
+  // (e.g. ~/.local/bin). Resolving here — before the agent loop — lets every
+  // agent reuse the cached absolute path rather than re-running PATH lookups
+  // per wake. Uses `which` first (works in interactive shells), then probes
+  // common install locations as a fallback.
+  const harnessCliName = config.llm.provider === "subscription-cli" ? config.llm.cli : undefined;
+  const resolvedCliPath: string | undefined = harnessCliName
+    ? ((await resolveCliBinaryPath(harnessCliName)) ?? undefined)
+    : undefined;
+  if (harnessCliName && resolvedCliPath) {
+    logger.info("daemon.cli.resolved", { cli: harnessCliName, path: resolvedCliPath });
+  } else if (harnessCliName && !resolvedCliPath) {
+    logger.warn("daemon.cli.not-found", {
+      cli: harnessCliName,
+      message: `"${harnessCliName}" not found via PATH or common install locations; wakes will fail with ENOENT`,
+    });
+  }
+
   for (const agent of allRegistered) {
     // Boot-time validation pass: build a throw-away client bag with
     // NO cost builder so we just verify everything can be wired.
@@ -1258,6 +1357,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       ollamaBaseUrl,
       harnessLlm: config.llm,
       rootDir: exampleRoot,
+      ...(resolvedCliPath !== undefined ? { resolvedCliPath } : {}),
     });
 
     if (agent.llm && validation.llmSkipReason) {
@@ -1414,6 +1514,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               harnessLlm: config.llm,
               rootDir: exampleRoot,
               logger,
+              ...(resolvedCliPath !== undefined ? { resolvedCliPath } : {}),
             });
             const firstBranchScope = capturedAgent.githubWriteScopes.branchCommits[0];
             const targetRepo = firstBranchScope ? parseRepoKey(firstBranchScope.repo) : undefined;

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -30,6 +30,7 @@ import {
   buildAgentRoutingLabels,
   Daemon,
   DispatchExecutor,
+  findReservedLabels,
   GitHubCollaborationProvider,
   GovernanceGitHubSync,
   DaemonHttp,
@@ -1492,7 +1493,29 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               receipts.push({ action, success: false, error: "missing fields" });
               break;
             }
+            // Security H1: agents MUST NOT write Source-reserved routing
+            // labels (`source-directive`, `kickoff`, `scope:*`). Refusing
+            // here closes the lateral-movement channel opened when the
+            // aggregator started listening for `scope:*` (harness#331).
+            const reservedLabel = findReservedLabels([action.label]);
+            if (reservedLabel.length > 0) {
+              receipts.push({
+                action,
+                success: false,
+                error: `reserved-label:${reservedLabel.join(",")}`,
+              });
+              break;
+            }
             if (action.removeLabel) {
+              const reservedRemove = findReservedLabels([action.removeLabel]);
+              if (reservedRemove.length > 0) {
+                receipts.push({
+                  action,
+                  success: false,
+                  error: `reserved-label:${reservedRemove.join(",")}`,
+                });
+                break;
+              }
               await gh.removeLabel(repo, makeIssueNumber(action.issueNumber), action.removeLabel);
             }
             const r = await gh.addLabels(repo, makeIssueNumber(action.issueNumber), [action.label]);
@@ -1503,6 +1526,18 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
             if (!action.title) {
               receipts.push({ action, success: false, error: "missing title" });
               break;
+            }
+            // Security H1: see label-issue case above.
+            if (action.labels && action.labels.length > 0) {
+              const reserved = findReservedLabels(action.labels);
+              if (reserved.length > 0) {
+                receipts.push({
+                  action,
+                  success: false,
+                  error: `reserved-label:${reserved.join(",")}`,
+                });
+                break;
+              }
             }
             const input: Record<string, unknown> = { title: action.title };
             if (action.body) input.body = action.body;

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1436,6 +1436,12 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
             : {}),
         },
         ...(scope.filter.anyLabel !== undefined ? { anyLabel: scope.filter.anyLabel } : {}),
+        ...(scope.scopeAllTrustedAuthors !== undefined
+          ? { scopeAllTrustedAuthors: scope.scopeAllTrustedAuthors }
+          : {}),
+        ...(scope.dropScopeAllFromUntrusted !== undefined
+          ? { dropScopeAllFromUntrusted: scope.dropScopeAllFromUntrusted }
+          : {}),
       })) ?? [],
   );
 

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -783,6 +783,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       process.exit(78);
     }
     governancePlugin = candidate as import("@murmurations-ai/core").GovernancePlugin;
+    const pluginVocabulary = governancePlugin.labelVocabulary?.() ?? [];
     process.stdout.write(
       `${JSON.stringify({
         ts: new Date().toISOString(),
@@ -790,6 +791,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         event: "daemon.governance.loaded",
         plugin: governancePlugin.name,
         version: governancePlugin.version,
+        ...(pluginVocabulary.length > 0 ? { labelVocabulary: pluginVocabulary } : {}),
       })}\n`,
     );
   }

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -255,6 +255,9 @@ export const makeDaemonHook = (
         modelName: call.model,
         costMicros,
         ...(shadowCostMicros !== undefined ? { shadowCostMicros } : {}),
+        ...(call.cliPath !== undefined ? { cliPath: call.cliPath } : {}),
+        ...(call.spawnMs !== undefined ? { spawnMs: call.spawnMs } : {}),
+        ...(call.timeoutMs !== undefined ? { timeoutMs: call.timeoutMs } : {}),
       });
     },
   };

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1706,13 +1706,50 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
 
   // Write pidfile — skip for --once/--now wakes (child processes shouldn't clobber the daemon's pid)
   const pidfilePath = resolve(exampleRoot, ".murmuration", "daemon.pid");
+  const socketPath = resolve(exampleRoot, ".murmuration", "daemon.sock");
   await mkdir(resolve(exampleRoot, ".murmuration"), { recursive: true });
   if (!once) {
+    // Guard against same-machine collision (#219): if a pidfile exists and its
+    // process is still alive, refuse to start rather than silently clobbering it.
+    try {
+      const rawPid = await readFile(pidfilePath, "utf8");
+      const existingPid = Number(rawPid.trim());
+      if (Number.isFinite(existingPid) && existingPid > 0) {
+        try {
+          process.kill(existingPid, 0); // signal 0 = probe only, doesn't kill
+          // Process is alive — refuse to start.
+          const lines = [
+            `murmuration: a daemon is already running for this murmuration.`,
+            `  root:   ${exampleRoot}`,
+            `  pid:    ${String(existingPid)}`,
+            `  socket: ${socketPath}`,
+            `  attach: murmuration attach ${runningSessionName}`,
+            `  stop:   murmuration stop --root ${exampleRoot}`,
+            ``,
+            `If you believe this is wrong (e.g. the process crashed without`,
+            `cleaning up), remove the stale pidfile manually:`,
+            `  rm ${pidfilePath}`,
+          ];
+          throw new Error(lines.join("\n"));
+        } catch (killErr) {
+          // kill(pid, 0) throws when the process doesn't exist — stale pidfile.
+          if ((killErr as NodeJS.ErrnoException).code === "ESRCH") {
+            logger.info("daemon.pidfile.stale", { existingPid, pidfilePath });
+            // fall through to overwrite
+          } else {
+            throw killErr; // re-throw the "already running" error from above
+          }
+        }
+      }
+    } catch (readErr) {
+      if ((readErr as NodeJS.ErrnoException).code !== "ENOENT") throw readErr;
+      // ENOENT = no pidfile yet, normal first start
+    }
     await writeFile(pidfilePath, String(process.pid), "utf8");
   }
 
   // Start daemon control socket
-  const socketPath = resolve(exampleRoot, ".murmuration", "daemon.sock");
+  // socketPath declared above alongside pidfilePath (collision check needs it)
   // ~/.murmuration/sockets/ directory so `murmuration list` can find it.
   if (!once) {
     registerRunningSocket(runningSessionName, socketPath);

--- a/packages/cli/src/directive.test.ts
+++ b/packages/cli/src/directive.test.ts
@@ -113,6 +113,21 @@ describe("runDirective — manage subcommands (restoration of regression fixed b
     await expect(runDirective(["hello"], root)).rejects.toThrow(/specify --agent|scope/);
   });
 
+  it("rejects --agent value that fails IDENTIFIER_RE (Sec M2)", async () => {
+    await expect(runDirective(["--agent", "foo,bar", "some body"], root)).rejects.toThrow(
+      /--agent must match/,
+    );
+    await expect(runDirective(["--agent", "foo bar", "some body"], root)).rejects.toThrow(
+      /--agent must match/,
+    );
+  });
+
+  it("rejects --group value that fails IDENTIFIER_RE (Sec M2)", async () => {
+    await expect(runDirective(["--group", "bad/group", "some body"], root)).rejects.toThrow(
+      /--group must match/,
+    );
+  });
+
   it("edit opens $EDITOR on the local item file", async () => {
     writeLocalItem("aaaa1234");
     const originalEditor = process.env.EDITOR;

--- a/packages/cli/src/directive.ts
+++ b/packages/cli/src/directive.ts
@@ -23,6 +23,7 @@ import { readFile, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import {
+  IDENTIFIER_RE,
   isScopeLabel,
   SCOPE_ALL_LABEL,
   SOURCE_DIRECTIVE_LABEL,
@@ -167,9 +168,19 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
   const agentArg = args[agentIdx + 1];
   const groupArg = args[groupIdx + 1];
   if (agentIdx >= 0 && agentArg) {
+    if (!IDENTIFIER_RE.test(agentArg)) {
+      throw new Error(
+        `directive: --agent must match /^[a-z0-9][a-z0-9._-]*$/i (max 64 chars) — got: ${JSON.stringify(agentArg)}`,
+      );
+    }
     scopeLabel = scopeAgentLabel(agentArg);
     scopeDesc = `agent ${agentArg}`;
   } else if (groupIdx >= 0 && groupArg) {
+    if (!IDENTIFIER_RE.test(groupArg)) {
+      throw new Error(
+        `directive: --group must match /^[a-z0-9][a-z0-9._-]*$/i (max 64 chars) — got: ${JSON.stringify(groupArg)}`,
+      );
+    }
     scopeLabel = scopeGroupLabel(groupArg);
     scopeDesc = `group ${groupArg}`;
   } else if (allFlag) {

--- a/packages/cli/src/directive.ts
+++ b/packages/cli/src/directive.ts
@@ -22,6 +22,14 @@ import { existsSync } from "node:fs";
 import { readFile, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
+import {
+  isScopeLabel,
+  SCOPE_ALL_LABEL,
+  SOURCE_DIRECTIVE_LABEL,
+  scopeAgentLabel,
+  scopeGroupLabel,
+} from "@murmurations-ai/core";
+
 import { buildCollaborationProvider, CollaborationBuildError } from "./collaboration-factory.js";
 
 const MANAGE_SUBCOMMANDS = new Set(["close", "delete", "edit"]);
@@ -159,13 +167,13 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
   const agentArg = args[agentIdx + 1];
   const groupArg = args[groupIdx + 1];
   if (agentIdx >= 0 && agentArg) {
-    scopeLabel = `scope:agent:${agentArg}`;
+    scopeLabel = scopeAgentLabel(agentArg);
     scopeDesc = `agent ${agentArg}`;
   } else if (groupIdx >= 0 && groupArg) {
-    scopeLabel = `scope:group:${groupArg}`;
+    scopeLabel = scopeGroupLabel(groupArg);
     scopeDesc = `group ${groupArg}`;
   } else if (allFlag) {
-    scopeLabel = "scope:all";
+    scopeLabel = SCOPE_ALL_LABEL;
     scopeDesc = "all agents";
   } else if (!args.includes("--list")) {
     throw new Error(
@@ -191,7 +199,7 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
   if (args.includes("--list")) {
     const result = await provider.listItems({
       state: "all",
-      labels: ["source-directive"],
+      labels: [SOURCE_DIRECTIVE_LABEL],
       limit: 20,
     });
     if (!result.ok) {
@@ -203,7 +211,7 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
     }
     for (const item of result.value) {
       const state = item.state === "open" ? "pending" : "responded";
-      const scope = item.labels.find((l) => l.startsWith("scope:")) ?? "scope:?";
+      const scope = item.labels.find((l) => isScopeLabel(l)) ?? "scope:?";
       console.log(
         `  ${item.ref.id.padEnd(6)} ${state.padEnd(10)} ${scope.padEnd(20)} ${item.title.slice(0, 60)}`,
       );
@@ -273,7 +281,7 @@ export const runDirective = async (args: readonly string[], rootDir: string): Pr
   const createResult = await provider.createItem({
     title: `[DIRECTIVE] ${titleSource.trim().slice(0, 80)}`,
     body: directiveBody,
-    labels: ["source-directive", scopeLabel],
+    labels: [SOURCE_DIRECTIVE_LABEL, scopeLabel],
   });
 
   if (!createResult.ok) {

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -13,11 +13,10 @@
  * legacy repo, run `doctor --fix`.
  */
 
-import { execFile, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { copyFile, readFile, writeFile, chmod, readdir } from "node:fs/promises";
+import { readFile, writeFile, chmod, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { promisify } from "node:util";
 
 import {
   FrontmatterInvalidError,
@@ -27,8 +26,6 @@ import {
 
 import { listBundledPluginAliases, probeGovernancePlugin } from "./governance-plugin-resolver.js";
 import { loadHarnessConfig, validateHarnessYaml, type HarnessConfig } from "./harness-config.js";
-
-const execFileP = promisify(execFile);
 
 const which = (bin: string): boolean => {
   try {
@@ -908,10 +905,3 @@ export const runDoctorCli = async (options: DoctorOptions): Promise<number> => {
 
   return exitCodeFor(report);
 };
-
-// Suppress unused-import warnings for Node-only helpers that might not
-// be needed on every code path; `copyFile`/`execFileP` are reserved for
-// future auto-fix strategies (backup-then-rename). TODO: tighten if
-// still unused when the PR lands.
-void copyFile;
-void execFileP;

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -221,17 +221,21 @@ const runLayoutChecks = async (ctx: CheckContext): Promise<void> => {
             "/usr/local/bin/claude",
             "/opt/homebrew/bin/claude",
             join(homedir(), ".npm", "bin", "claude"),
+            join(homedir(), "node_modules", ".bin", "claude"),
           ]
         : cliName === "gemini"
           ? [
               join(homedir(), ".local", "bin", "gemini"),
               "/usr/local/bin/gemini",
               "/opt/homebrew/bin/gemini",
+              join(homedir(), ".npm", "bin", "gemini"),
             ]
           : [
               join(homedir(), ".local", "bin", "codex"),
               "/usr/local/bin/codex",
               "/opt/homebrew/bin/codex",
+              join(homedir(), ".npm", "bin", "codex"),
+              join(homedir(), ".openai", "bin", "codex"),
             ];
 
     let absoluteCliPath: string | undefined;

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -280,9 +280,46 @@ const runSchemaChecks = async (ctx: CheckContext): Promise<void> => {
     return;
   }
 
+  // agentDeclaredGroups collects each agent's self-declared group_memberships
+  // for the bidirectional membership consistency check (#238).
+  const agentDeclaredGroups = new Map<string, readonly string[]>();
+
   for (const slug of agentDirs) {
     try {
-      await loader.load(slug);
+      const identity = await loader.load(slug);
+      // Operational completeness checks (#236): flag configuration that is
+      // syntactically valid but operationally hollow.
+      const fm = identity.frontmatter;
+      const sources = fm.signals.sources;
+      const githubScopes = fm.signals.github_scopes ?? [];
+      agentDeclaredGroups.set(slug, fm.group_memberships);
+      // Only flag the github-issue-without-scopes gap when the harness
+      // collaboration provider is "github" — a local-provider setup has no
+      // GitHub signals regardless of the sources default, so it's not a bug.
+      if (
+        harness.collaboration.provider === "github" &&
+        sources.includes("github-issue") &&
+        githubScopes.length === 0
+      ) {
+        findings.push({
+          checkId: `schema.role.${slug}.github-issue-source-without-scopes`,
+          category: "schema",
+          severity: "error",
+          title: `agents/${slug}: signals.sources includes "github-issue" but signals.github_scopes is empty`,
+          detail: `Agent will be wake-blind to GitHub — signal aggregator will return [] on every wake.`,
+          remediation: `Add signals.github_scopes in agents/${slug}/role.md with owner, repo, and filter to route GitHub issues to this agent.`,
+        });
+      }
+      if (sources.length === 0) {
+        findings.push({
+          checkId: `schema.role.${slug}.no-signal-sources`,
+          category: "schema",
+          severity: "warning",
+          title: `agents/${slug}: signals.sources is empty — agent will receive no signals`,
+          detail: `Agent will wake on its cron schedule but see no action items.`,
+          remediation: `Add signals.sources (e.g. "github-issue", "private-note") in agents/${slug}/role.md.`,
+        });
+      }
     } catch (err) {
       if (err instanceof FrontmatterInvalidError) {
         for (const issue of err.issues) {
@@ -366,6 +403,38 @@ const runSchemaChecks = async (ctx: CheckContext): Promise<void> => {
             remediation: `Either create agents/${member}/role.md or remove "${member}" from the Members list.`,
           });
         }
+      }
+    }
+
+    // Bidirectional membership consistency (#238): each member listed here
+    // must also declare this group in their role.md group_memberships.
+    const groupId = groupFile.replace(/\.md$/, "");
+    for (const member of members) {
+      if (!agentDirs.includes(member)) continue; // already flagged above
+      const declaredGroups = agentDeclaredGroups.get(member);
+      if (declaredGroups !== undefined && !declaredGroups.includes(groupId)) {
+        findings.push({
+          checkId: `schema.group.${groupFile}.membership-consistency.${member}`,
+          category: "schema",
+          severity: "error",
+          title: `governance/groups/${groupFile}: member "${member}" is not in their role.md group_memberships`,
+          detail: `"${member}" is listed in the group file's ## Members but their role.md declares group_memberships: [${declaredGroups.join(", ")}].`,
+          remediation: `Add "${groupId}" to agents/${member}/role.md group_memberships, or remove "${member}" from governance/groups/${groupFile}.`,
+        });
+      }
+    }
+
+    // Reverse direction: agents claiming this group in role.md but not listed here.
+    for (const [agentSlug, groups] of agentDeclaredGroups) {
+      if (groups.includes(groupId) && !members.includes(agentSlug)) {
+        findings.push({
+          checkId: `schema.group.${groupFile}.membership-consistency.missing-${agentSlug}`,
+          category: "schema",
+          severity: "error",
+          title: `agents/${agentSlug} declares group_memberships includes "${groupId}" but is not listed in governance/groups/${groupFile}`,
+          detail: `"${agentSlug}" will receive ${groupId}-routed signals but won't be invited to group-wake meetings.`,
+          remediation: `Add "${agentSlug}" to the ## Members list in governance/groups/${groupFile}, or remove "${groupId}" from agents/${agentSlug}/role.md group_memberships.`,
+        });
       }
     }
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -15,7 +15,8 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { readFile, writeFile, chmod, readdir } from "node:fs/promises";
+import { access, constants, readFile, writeFile, chmod, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 import {
@@ -86,7 +87,7 @@ interface CheckContext {
 // ---------------------------------------------------------------------------
 
 const runLayoutChecks = async (ctx: CheckContext): Promise<void> => {
-  const { rootDir, findings } = ctx;
+  const { rootDir, findings, harness } = ctx;
 
   const requireDir = (relPath: string, severity: DoctorSeverity, reason: string): void => {
     const full = join(rootDir, relPath);
@@ -206,6 +207,71 @@ const runLayoutChecks = async (ctx: CheckContext): Promise<void> => {
         "Agents that use a subprocess executor will fail with spawn-failed. This is expected in development (run via `pnpm exec murmuration`), but in production the binary must be globally installed.",
       remediation: `Run \`npm install -g @murmurations-ai/cli\` or ensure \`node_modules/.bin\` is on PATH.`,
     });
+  }
+
+  // subscription-CLI binary reachability (harness#XXX)
+  // launchd / cron start daemons with a minimal PATH that may omit ~/.local/bin,
+  // causing ENOENT on every cron wake. Doctor catches this at setup time.
+  if (harness.llm.provider === "subscription-cli" && harness.llm.cli) {
+    const cliName = harness.llm.cli;
+    const fallbackPaths: readonly string[] =
+      cliName === "claude"
+        ? [
+            join(homedir(), ".local", "bin", "claude"),
+            "/usr/local/bin/claude",
+            "/opt/homebrew/bin/claude",
+            join(homedir(), ".npm", "bin", "claude"),
+          ]
+        : cliName === "gemini"
+          ? [
+              join(homedir(), ".local", "bin", "gemini"),
+              "/usr/local/bin/gemini",
+              "/opt/homebrew/bin/gemini",
+            ]
+          : [
+              join(homedir(), ".local", "bin", "codex"),
+              "/usr/local/bin/codex",
+              "/opt/homebrew/bin/codex",
+            ];
+
+    let absoluteCliPath: string | undefined;
+    try {
+      absoluteCliPath = execFileSync("which", [cliName], { encoding: "utf8" }).trim() || undefined;
+    } catch {
+      /* not in PATH — try fallback locations */
+    }
+    const inPath = absoluteCliPath !== undefined;
+    if (!inPath) {
+      for (const p of fallbackPaths) {
+        try {
+          await access(p, constants.X_OK);
+          absoluteCliPath = p;
+          break;
+        } catch {
+          /* try next */
+        }
+      }
+    }
+
+    if (!absoluteCliPath) {
+      findings.push({
+        checkId: `layout.cli-binary.${cliName}.missing`,
+        category: "layout",
+        severity: "error",
+        title: `CLI binary "${cliName}" not found`,
+        detail: `harness.yaml configures provider: subscription-cli / cli: ${cliName}, but the binary was not found on PATH or in common install locations (${fallbackPaths.join(", ")}). Every agent wake will fail with spawn ENOENT.`,
+        remediation: `Install the CLI: e.g. \`npm install -g @anthropic-ai/claude-code\` for claude. After installing, run \`doctor\` again to confirm.`,
+      });
+    } else if (!inPath) {
+      findings.push({
+        checkId: `layout.cli-binary.${cliName}.not-in-path`,
+        category: "layout",
+        severity: "warning",
+        title: `CLI binary "${cliName}" found at ${absoluteCliPath} but not on PATH`,
+        detail: `The daemon will resolve "${cliName}" to "${absoluteCliPath}" via its fallback search, but launchd / cron environments may not have this path in PATH. The harness resolves the binary at boot time, so daemon wakes will work — but interactive \`${cliName}\` commands from the terminal may fail if PATH is not set correctly.`,
+        remediation: `Add the directory containing "${cliName}" to your shell PATH (e.g. add \`export PATH="$HOME/.local/bin:$PATH"\` to ~/.zshrc).`,
+      });
+    }
   }
 
   // .env permissions

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -30,6 +30,15 @@ import { loadHarnessConfig, validateHarnessYaml, type HarnessConfig } from "./ha
 
 const execFileP = promisify(execFile);
 
+const which = (bin: string): boolean => {
+  try {
+    execFileSync("which", [bin], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -187,6 +196,19 @@ const runLayoutChecks = async (ctx: CheckContext): Promise<void> => {
         autoFixLabel: `append ${missing.join(", ")} to .gitignore`,
       });
     }
+  }
+
+  // murmuration CLI binary — if not on PATH, subprocess spawn will fail (#329)
+  if (!which("murmuration")) {
+    findings.push({
+      checkId: "layout.murmuration-binary.missing",
+      category: "layout",
+      severity: "warning",
+      title: "`murmuration` binary not found on PATH",
+      detail:
+        "Agents that use a subprocess executor will fail with spawn-failed. This is expected in development (run via `pnpm exec murmuration`), but in production the binary must be globally installed.",
+      remediation: `Run \`npm install -g @murmurations-ai/cli\` or ensure \`node_modules/.bin\` is on PATH.`,
+    });
   }
 
   // .env permissions

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -26,7 +26,7 @@ import {
 } from "@murmurations-ai/core";
 
 import { listBundledPluginAliases, probeGovernancePlugin } from "./governance-plugin-resolver.js";
-import { loadHarnessConfig, type HarnessConfig } from "./harness-config.js";
+import { loadHarnessConfig, validateHarnessYaml, type HarnessConfig } from "./harness-config.js";
 
 const execFileP = promisify(execFile);
 
@@ -216,6 +216,21 @@ const runLayoutChecks = async (ctx: CheckContext): Promise<void> => {
 
 const runSchemaChecks = async (ctx: CheckContext): Promise<void> => {
   const { rootDir, findings, harness } = ctx;
+
+  // harness.yaml Zod validation (#323)
+  const harnessWarnings = await validateHarnessYaml(rootDir);
+  for (const w of harnessWarnings) {
+    const safePath = w.field.replaceAll(/\W+/g, "_");
+    findings.push({
+      checkId: `schema.harness-yaml.${safePath}`,
+      category: "schema",
+      severity: "warning",
+      title: `murmuration/harness.yaml: ${w.field} — ${w.message}`,
+      detail: `Received: ${w.received}${w.accepted !== undefined ? `; accepted: ${w.accepted.join(", ")}` : ""}`,
+      remediation: `Edit murmuration/harness.yaml and correct the \`${w.field}\` field.`,
+    });
+  }
+
   const agentsDir = join(rootDir, "agents");
   if (!existsSync(agentsDir)) return;
 

--- a/packages/cli/src/github-tools/github-tools.test.ts
+++ b/packages/cli/src/github-tools/github-tools.test.ts
@@ -142,11 +142,12 @@ const stubClient = (
     getPullRequestFiles: () => successOf([minimalPRFile]),
     getCommit: () => successOf(minimalCommit),
     getFileAtRef: () => successOf(minimalFileContent),
+    searchIssues: () => successOf([minimalIssue]),
     ...overrides,
   }) as unknown as GithubClient;
 
 describe("buildGithubReadToolsForAgent", () => {
-  it("registers all ten read tools by name", () => {
+  it("registers all eleven read tools by name", () => {
     const tools = buildGithubReadToolsForAgent(stubClient());
     expect(tools.map((t) => t.name)).toEqual([
       "read_issue",
@@ -159,7 +160,21 @@ describe("buildGithubReadToolsForAgent", () => {
       "list_pull_request_files",
       "read_commit",
       "read_file_at_ref",
+      "search_issues",
     ]);
+  });
+
+  it("search_issues returns serialized issue array (#234)", async () => {
+    const tools = buildGithubReadToolsForAgent(stubClient());
+    const tool = tools.find((t) => t.name === "search_issues");
+    expect(tool).toBeDefined();
+    const result = (await tool!.execute({
+      repo: "owner/repo",
+      q: "label:bug state:open",
+    })) as string;
+    const parsed = JSON.parse(result) as Record<string, unknown>[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]?.title).toBe("Test issue");
   });
 
   it("read_issue returns serialized issue JSON for a valid repo", async () => {

--- a/packages/cli/src/github-tools/index.ts
+++ b/packages/cli/src/github-tools/index.ts
@@ -1,23 +1,23 @@
 /**
- * GitHub read tools — agent-callable wrappers around the
+ * GitHub read + write tools — agent-callable wrappers around the
  * harness's existing GithubClient. Constructed per-agent at boot
  * so each tool's underlying client carries the agent's per-wake
  * cost hook and (eventually) per-agent read scopes.
  *
- * Five read-only tools (replacement for harness#256, which was
- * filed against the wrong premise — bodies were already in the
- * SignalBundle, but agents had no GitHub-aware tools at all):
- *
+ * Read tools (buildGithubReadToolsForAgent):
  *   read_issue            — fetch one issue by repo + number
  *   list_issues           — list issues in a repo (filterable)
  *   list_issue_comments   — fetch comment thread for one issue
  *   list_issue_labels     — fetch labels for one issue
  *   get_branch_head       — fetch HEAD oid of a branch
  *
- * Writes are intentionally NOT added here. The existing WakeAction
- * pipeline handles writes post-wake under ADR-0017 scope enforcement
- * with the Boundary 5 narrative-vs-action audit (#240). Direct write
- * tools would reopen that hole.
+ * Write tools (buildGithubWriteToolsForAgent, harness#274):
+ *   create_issue_comment  — post a comment on an issue (requires issueComments scope)
+ *
+ * The write tools are only added for agents that declare the matching
+ * `github.write_scopes` in role.md (ADR-0017). The client passed to
+ * buildGithubWriteToolsForAgent must already carry the per-agent
+ * write-scope enforcement — no additional gate is needed here.
  *
  * The `repo` parameter accepts the natural "owner/name" string form;
  * we parse it into a `RepoCoordinate` internally so the LLM doesn't
@@ -433,6 +433,49 @@ export const buildGithubReadToolsForAgent = (client: GithubClient): readonly Git
               ? "Binary file — content omitted; fetch via htmlUrl in a browser if needed."
               : `File too large or unsupported encoding (${f.encoding}); GitHub returned no inline content.`,
           htmlUrl: f.htmlUrl,
+        },
+        null,
+        2,
+      );
+    },
+  },
+];
+
+/**
+ * Build the write-capable tool surface against `client` (#274). Only
+ * wire these tools for agents that declare `github.write_scopes.issue_comments`
+ * in role.md — the client itself enforces the scope at the GitHub layer
+ * (ADR-0017), so a mis-scoped call will be rejected there.
+ */
+export const buildGithubWriteToolsForAgent = (client: GithubClient): readonly GithubReadTool[] => [
+  {
+    name: "create_issue_comment",
+    description:
+      "Post a comment on a GitHub issue. Use to acknowledge work, ask clarifying questions, or summarize conclusions in-line with the issue thread — without waiting for post-wake WakeAction dispatch. Requires `github.write_scopes.issue_comments` on the target repo.",
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      number: z.number().int().positive().describe("Issue number"),
+      body: z.string().min(1).describe("Comment body (Markdown supported)"),
+    }),
+    execute: async ({ repo, number, body }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `create_issue_comment error: ${parsed.message}`;
+      if (typeof body !== "string" || body.trim().length === 0) {
+        return "create_issue_comment error: body must be a non-empty string";
+      }
+      const result = await client.createIssueComment(
+        parsed.value,
+        makeIssueNumber(Number(number)),
+        { body },
+      );
+      if (!result.ok) {
+        return `create_issue_comment error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        {
+          id: result.value.id,
+          htmlUrl: result.value.htmlUrl,
+          createdAt: result.value.createdAt.toISOString(),
         },
         null,
         2,

--- a/packages/cli/src/github-tools/index.ts
+++ b/packages/cli/src/github-tools/index.ts
@@ -10,6 +10,7 @@
  *   list_issue_comments   — fetch comment thread for one issue
  *   list_issue_labels     — fetch labels for one issue
  *   get_branch_head       — fetch HEAD oid of a branch
+ *   search_issues         — GitHub issue search with query syntax (harness#234)
  *
  * Write tools (buildGithubWriteToolsForAgent, harness#274):
  *   create_issue_comment  — post a comment on an issue (requires issueComments scope)
@@ -434,6 +435,41 @@ export const buildGithubReadToolsForAgent = (client: GithubClient): readonly Git
               : `File too large or unsupported encoding (${f.encoding}); GitHub returned no inline content.`,
           htmlUrl: f.htmlUrl,
         },
+        null,
+        2,
+      );
+    },
+  },
+  {
+    name: "search_issues",
+    description:
+      "Search GitHub issues in a repository using GitHub's search query syntax. " +
+      "The `repo:owner/name` and `is:issue` qualifiers are added automatically — do not include them in `q`. " +
+      'Examples: q="label:bug state:open", q="in:title deployment". Returns up to perPage results (default 30).',
+    parameters: z.object({
+      repo: z.string().describe('"owner/name"'),
+      q: z.string().describe("GitHub search query (without repo: or is:issue)"),
+      perPage: z.number().int().min(1).max(100).optional().describe("Max results (default 30)"),
+    }),
+    execute: async ({ repo, q, perPage }) => {
+      const parsed = parseRepo(String(repo));
+      if (!parsed.ok) return `search_issues error: ${parsed.message}`;
+      const opts: { perPage?: number } = {};
+      if (typeof perPage === "number") opts.perPage = perPage;
+      const result = await client.searchIssues(parsed.value, String(q), opts);
+      if (!result.ok) {
+        return `search_issues error: ${result.error.code} — ${result.error.message}`;
+      }
+      return JSON.stringify(
+        result.value.map((issue) => ({
+          number: issue.number.value,
+          title: issue.title,
+          state: issue.state,
+          labels: issue.labels,
+          authorLogin: issue.authorLogin,
+          updatedAt: issue.updatedAt.toISOString(),
+          htmlUrl: issue.htmlUrl,
+        })),
         null,
         2,
       );

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -86,16 +86,20 @@ const CLI_FALLBACK_PATHS_GW: Record<string, readonly string[]> = {
     "/usr/local/bin/claude",
     "/opt/homebrew/bin/claude",
     join(homedir(), ".npm", "bin", "claude"),
+    join(homedir(), "node_modules", ".bin", "claude"),
   ],
   gemini: [
     join(homedir(), ".local", "bin", "gemini"),
     "/usr/local/bin/gemini",
     "/opt/homebrew/bin/gemini",
+    join(homedir(), ".npm", "bin", "gemini"),
   ],
   codex: [
     join(homedir(), ".local", "bin", "codex"),
     "/usr/local/bin/codex",
     "/opt/homebrew/bin/codex",
+    join(homedir(), ".npm", "bin", "codex"),
+    join(homedir(), ".openai", "bin", "codex"),
   ],
 };
 

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -9,7 +9,8 @@
 
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { access, constants, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 
 import {
@@ -77,6 +78,48 @@ type ResolveLLMResult =
       readonly issues: readonly string[];
     }
   | { readonly ok: false; readonly reason: "other"; readonly message: string };
+
+/** Shared fallback paths for subscription-CLI binaries (see boot.ts). */
+const CLI_FALLBACK_PATHS_GW: Record<string, readonly string[]> = {
+  claude: [
+    join(homedir(), ".local", "bin", "claude"),
+    "/usr/local/bin/claude",
+    "/opt/homebrew/bin/claude",
+    join(homedir(), ".npm", "bin", "claude"),
+  ],
+  gemini: [
+    join(homedir(), ".local", "bin", "gemini"),
+    "/usr/local/bin/gemini",
+    "/opt/homebrew/bin/gemini",
+  ],
+  codex: [
+    join(homedir(), ".local", "bin", "codex"),
+    "/usr/local/bin/codex",
+    "/opt/homebrew/bin/codex",
+  ],
+};
+
+const resolveGroupWakeCliBinaryPath = async (cli: string): Promise<string | undefined> => {
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const ef = promisify(execFile);
+    const { stdout } = await ef("which", [cli], { timeout: 5000 });
+    const p = stdout.trim();
+    if (p.length > 0) return p;
+  } catch {
+    /* not in PATH */
+  }
+  for (const p of CLI_FALLBACK_PATHS_GW[cli] ?? []) {
+    try {
+      await access(p, constants.X_OK);
+      return p;
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+};
 
 /**
  * Resolve LLM provider + model from the facilitator's role.md.
@@ -510,6 +553,9 @@ export const runGroupWakeCommand = async (
         `murmuration convene: facilitator "${config.facilitator}" has provider "subscription-cli" but llm.cli must be one of claude | codex | gemini`,
       );
     }
+    // Resolve CLI binary to absolute path so launchd / cron environments
+    // (minimal PATH, no ~/.local/bin) can still find it (harness#XXX).
+    const cliPath = await resolveGroupWakeCliBinaryPath(llmConfig.cli);
     llmClient = createSubscriptionCliClient({
       cli: llmConfig.cli,
       model: llmConfig.model,
@@ -517,6 +563,7 @@ export const runGroupWakeCommand = async (
       ...(llmConfig.permissionMode !== undefined
         ? { permissionMode: llmConfig.permissionMode }
         : {}),
+      ...(cliPath !== undefined ? { cliPath } : {}),
     });
   } else {
     const envKeyName = providerRegistry.envKeyName(llmConfig.provider);

--- a/packages/cli/src/group-wake.ts
+++ b/packages/cli/src/group-wake.ts
@@ -13,6 +13,7 @@ import { readFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
 
 import {
+  findReservedLabels,
   makeSecretKey,
   IdentityLoader,
   IdentityFileMissingError,
@@ -266,6 +267,23 @@ const executeActions = async (
             receipts.push({ action, success: false, error: "missing issueNumber or label" });
             break;
           }
+          // Security H1: agents (including meeting facilitators) MUST NOT
+          // write Source-reserved routing labels. See packages/core/src/labels.
+          const reservedLabel = findReservedLabels([
+            action.label,
+            ...(action.removeLabel !== undefined ? [action.removeLabel] : []),
+          ]);
+          if (reservedLabel.length > 0) {
+            console.log(
+              `    \x1b[31m✗\x1b[0m label-issue #${String(action.issueNumber)}: reserved-label ${reservedLabel.join(",")}`,
+            );
+            receipts.push({
+              action,
+              success: false,
+              error: `reserved-label:${reservedLabel.join(",")}`,
+            });
+            break;
+          }
           const ref = { id: String(action.issueNumber) };
           if (action.removeLabel) {
             await provider.removeLabel(ref, action.removeLabel);
@@ -293,6 +311,21 @@ const executeActions = async (
           if (!action.title) {
             receipts.push({ action, success: false, error: "missing title" });
             break;
+          }
+          // Security H1: see label-issue case above.
+          if (action.labels && action.labels.length > 0) {
+            const reserved = findReservedLabels(action.labels);
+            if (reserved.length > 0) {
+              console.log(
+                `    \x1b[31m✗\x1b[0m create-issue: reserved-label ${reserved.join(",")}`,
+              );
+              receipts.push({
+                action,
+                success: false,
+                error: `reserved-label:${reserved.join(",")}`,
+              });
+              break;
+            }
           }
           const input: { title: string; body: string; labels?: readonly string[] } = {
             title: action.title,

--- a/packages/cli/src/harness-config.test.ts
+++ b/packages/cli/src/harness-config.test.ts
@@ -7,7 +7,7 @@ import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { loadHarnessConfig, mergeWithCliFlags } from "./harness-config.js";
+import { loadHarnessConfig, mergeWithCliFlags, validateHarnessYaml } from "./harness-config.js";
 
 let rootDir: string;
 
@@ -153,6 +153,84 @@ logging:
     const config = await loadHarnessConfig(rootDir);
     expect(config.products).toHaveLength(1);
     expect(config.products[0]!.name).toBe("valid");
+  });
+});
+
+describe("validateHarnessYaml (#323)", () => {
+  it("returns empty array when file is missing", async () => {
+    const warnings = await validateHarnessYaml(rootDir);
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns empty array for valid harness.yaml", async () => {
+    await writeFile(
+      join(rootDir, "murmuration", "harness.yaml"),
+      `llm:
+  provider: anthropic
+  model: claude-opus-4-7
+logging:
+  level: debug
+collaboration:
+  provider: github
+spirit:
+  maxSteps: 128
+`,
+      "utf8",
+    );
+    const warnings = await validateHarnessYaml(rootDir);
+    expect(warnings).toEqual([]);
+  });
+
+  it("reports invalid llm.provider enum value", async () => {
+    await writeFile(
+      join(rootDir, "murmuration", "harness.yaml"),
+      `llm:
+  provider: gpt4o-turbo
+`,
+      "utf8",
+    );
+    const warnings = await validateHarnessYaml(rootDir);
+    expect(warnings.length).toBeGreaterThan(0);
+    const w = warnings.find((x) => x.field === "llm.provider");
+    expect(w).toBeDefined();
+    expect(w?.accepted).toContain("anthropic");
+    expect(w?.accepted).toContain("openai");
+  });
+
+  it("reports invalid logging.level enum value", async () => {
+    await writeFile(
+      join(rootDir, "murmuration", "harness.yaml"),
+      `logging:
+  level: trace
+`,
+      "utf8",
+    );
+    const warnings = await validateHarnessYaml(rootDir);
+    const w = warnings.find((x) => x.field === "logging.level");
+    expect(w).toBeDefined();
+    expect(w?.accepted).toContain("debug");
+    expect(w?.accepted).toContain("warn");
+  });
+
+  it("reports unknown top-level field (typo detection)", async () => {
+    await writeFile(
+      join(rootDir, "murmuration", "harness.yaml"),
+      `collaboraiton:
+  provider: github
+`,
+      "utf8",
+    );
+    const warnings = await validateHarnessYaml(rootDir);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.some((w) => w.field === "(root)" || w.message.includes("collaboraiton"))).toBe(
+      true,
+    );
+  });
+
+  it("returns empty array for file absent or unparseable", async () => {
+    await writeFile(join(rootDir, "murmuration", "harness.yaml"), "{{{{ not yaml", "utf8");
+    const warnings = await validateHarnessYaml(rootDir);
+    expect(warnings).toEqual([]);
   });
 });
 

--- a/packages/cli/src/harness-config.ts
+++ b/packages/cli/src/harness-config.ts
@@ -11,6 +11,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 
 // ---------------------------------------------------------------------------
 // Config shape
@@ -95,6 +96,121 @@ const isSubscriptionCli = (v: unknown): v is SubscriptionCli =>
 
 const isSubscriptionCliPermissionMode = (v: unknown): v is SubscriptionCliPermissionMode =>
   v === "restricted" || v === "operator-approved" || v === "trusted";
+
+// ---------------------------------------------------------------------------
+// Zod schema (for validation-only; the lenient loader below is the runtime path)
+// ---------------------------------------------------------------------------
+
+const harnessConfigSchema = z
+  .object({
+    llm: z
+      .object({
+        provider: z
+          .enum(["gemini", "anthropic", "openai", "ollama", "subscription-cli"])
+          .optional(),
+        model: z.string().optional(),
+        cli: z.enum(["claude", "codex", "gemini"]).optional(),
+        permissionMode: z.enum(["restricted", "operator-approved", "trusted"]).optional(),
+      })
+      .strict()
+      .optional(),
+    governance: z
+      .object({
+        plugin: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    collaboration: z
+      .object({
+        provider: z.enum(["github", "local"]).optional(),
+        repo: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    products: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            repo: z.string(),
+          })
+          .strict(),
+      )
+      .optional(),
+    logging: z
+      .object({
+        level: z.enum(["debug", "info", "warn", "error"]).optional(),
+      })
+      .strict()
+      .optional(),
+    spirit: z
+      .object({
+        maxSteps: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    agent: z
+      .object({
+        maxSteps: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export interface HarnessConfigWarning {
+  /** Dot-separated field path, e.g. "llm.permissionMode". */
+  readonly field: string;
+  readonly message: string;
+  readonly received: string;
+  /** Accepted enum values (where applicable). */
+  readonly accepted?: readonly string[];
+}
+
+/**
+ * Validate `{rootDir}/murmuration/harness.yaml` against the Zod schema
+ * and return structured warnings for every invalid or unknown field.
+ * Returns an empty array when the file is absent, unparseable, or valid.
+ * Never throws.
+ */
+export async function validateHarnessYaml(rootDir: string): Promise<HarnessConfigWarning[]> {
+  const filePath = resolve(rootDir, "murmuration", "harness.yaml");
+  let raw: unknown;
+  try {
+    const content = await readFile(filePath, "utf8");
+    raw = parseYaml(content);
+  } catch {
+    return [];
+  }
+  if (!raw || typeof raw !== "object") return [];
+
+  const result = harnessConfigSchema.safeParse(raw);
+  if (result.success) return [];
+
+  return result.error.issues.map((issue) => {
+    const field = issue.path.join(".");
+    // Zod v4: "invalid_value" is the enum-mismatch code; "received" lives on
+    // the raw issue object but isn't in the base type — cast to extract safely.
+    const raw_issue = issue as unknown as Record<string, unknown>;
+    const received =
+      typeof raw_issue.received === "string"
+        ? raw_issue.received
+        : typeof raw_issue.received === "number" || typeof raw_issue.received === "boolean"
+          ? String(raw_issue.received)
+          : "unknown";
+    // Zod v4 "invalid_value" (enum) carries `values`; "unrecognized_keys" carries `keys`.
+    const options: readonly string[] | undefined =
+      issue.code === "invalid_value" && Array.isArray(raw_issue.values)
+        ? (raw_issue.values as string[])
+        : undefined;
+    return {
+      field: field === "" ? "(root)" : field,
+      message: issue.message,
+      received,
+      ...(options !== undefined ? { accepted: options } : {}),
+    };
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Loader

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -27,7 +27,7 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface, type Interface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
-import { humanizeSlug } from "@murmurations-ai/core";
+import { assignedLabel, humanizeSlug } from "@murmurations-ai/core";
 
 import { buildBuiltinProviderRegistry } from "./builtin-providers/index.js";
 import { detectInstalledClis, formatDetectionSummary, type CliPresence } from "./cli-detect.js";
@@ -1082,7 +1082,7 @@ _Extend with agent-specific bright lines as they become clear._
       repo: "${githubRepoName}"
       filter:
         state: "open"
-        labels: ["assigned:${agent.dir}"]`
+        labels: ["${assignedLabel(agent.dir)}"]`
       : "";
     const writeScopes = githubOwner
       ? `

--- a/packages/cli/src/spirit/skills/SKILLS.md
+++ b/packages/cli/src/spirit/skills/SKILLS.md
@@ -7,14 +7,15 @@ description: Index of Spirit skill files shipped with the harness baseline
 
 The Spirit loads skill bodies on demand via `load_skill(name)`. This index is always present in the system prompt; bodies are only pulled in when relevant.
 
-| Skill                    | When to load                                                                                                |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `daemon-lifecycle`       | Starting/stopping the daemon, diagnosing why it won't start, the socket protocol, troubleshooting wake runs |
-| `agent-anatomy`          | Creating, editing, or debugging agents — `soul.md`, `role.md` frontmatter, signal scopes, write scopes      |
-| `governance-models`      | Discussions about governance, plugins, meetings, `governance/groups/*.md`, state graphs, decision records   |
-| `when-to-use-governance` | The operator wants to change something and isn't sure whether to act directly or delegate via governance    |
-| `setup-github`           | The operator wants to configure GitHub, set up the GITHUB_TOKEN, or enable the GitHub MCP server            |
-| `setup-products`         | The operator wants to link external workspaces, code repos, or local PKM vaults to the murmuration          |
-| `setup-llms`             | The operator needs to configure API keys, Ollama, or set up per-agent model overrides                       |
+| Skill                    | When to load                                                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `daemon-lifecycle`       | Starting/stopping the daemon, diagnosing why it won't start, the socket protocol, troubleshooting wake runs                               |
+| `agent-anatomy`          | Creating, editing, or debugging agents — `soul.md`, `role.md` frontmatter, signal scopes, write scopes                                    |
+| `governance-models`      | Discussions about governance, plugins, meetings, `governance/groups/*.md`, state graphs, decision records                                 |
+| `when-to-use-governance` | The operator wants to change something and isn't sure whether to act directly or delegate via governance                                  |
+| `setup-github`           | The operator wants to configure GitHub, set up the GITHUB_TOKEN, or enable the GitHub MCP server                                          |
+| `setup-products`         | The operator wants to link external workspaces, code repos, or local PKM vaults to the murmuration                                        |
+| `setup-llms`             | The operator needs to configure API keys, Ollama, or set up per-agent model overrides                                                     |
+| `source-onboarding`      | Source wants to do the full foundational onboarding — vision interview, circle design, agent roster, identities, consent rounds, schedule |
 
 When the operator asks something substantive, check whether one of these skills covers it. If yes, load it before answering. If none applies and you're unsure, say so — don't guess.

--- a/packages/cli/src/spirit/skills/source-onboarding.md
+++ b/packages/cli/src/spirit/skills/source-onboarding.md
@@ -1,0 +1,541 @@
+---
+name: source-onboarding
+description: Walk Source through the multi-session dialogic interview that produces the murmuration's foundational governance — vision, circles, agents, soul, decision tiers, identities, consent rounds, schedule
+triggers:
+  - onboard me
+  - set up this murmuration
+  - walk me through phase 0
+  - I want to do the full onboarding
+  - help me launch this murmuration
+  - design my agents
+  - design the circles
+  - source vision interview
+  - resume onboarding
+  - where did we leave off
+version: 1
+---
+
+# Source onboarding
+
+This skill is invoked when Source signals that they want to do the foundational onboarding for a real murmuration — not the 5-minute `murmuration init` scaffold, but the dialogic interview that produces a working governance architecture they can run for the next 12 months.
+
+You are walking Source through five phases (0 through 4). The phases span multiple sessions. Source can stop at any point, detach, and reattach later — your memory and the conversation log persist across attaches, and every artifact is committed to the murmuration root, so resumption is just "where did we leave off?" → check what's on disk → continue.
+
+**Don't rush.** This is the most important conversation Source and the murmuration will ever have. The temptation is to push through. Resist it. If a phase needs to breathe, let it breathe.
+
+## Posture
+
+- **One question at a time** during interviews. Wait for the answer. Decide if a follow-up is warranted before moving on.
+- **Use Source's domain language verbatim.** Don't translate their words into harness jargon. If they say "stewards" instead of "members," call them stewards.
+- **Show drafts before committing.** Every artifact you produce gets reviewed by Source before `write_file` runs.
+- **Calibrate to time budget.** Ask Source's weekly budget early; size the roster and schedule to fit.
+- **Phase boundaries are real.** Don't skip ahead. Phase 1 reads Phase 0's outputs; Phase 2 reads Phase 1's. The dependency is the value.
+
+## Detecting where to start
+
+If Source attaches and signals onboarding intent without context, your first move is to check what already exists:
+
+1. `read_file governance/SOURCE-VISION.md` — does it exist?
+2. `read_file governance/CIRCLE-DOMAINS.md`
+3. `read_file governance/AGENT-ROSTER.md`
+4. `read_file governance/AGENT-SOUL.md`
+5. `read_file governance/SOURCE-DOMAIN-STATEMENT.md`
+6. `read_file governance/DECISION-TIERS.md`
+7. `list_dir agents/` — which agents have `role.md` written? Which still say `status: DRAFT` in their frontmatter?
+8. `read_file governance/WEEKLY-SCHEDULE.md`
+
+The first missing artifact tells you which phase to resume at. If everything is missing, start at Phase 0. If only the schedule is missing, jump to Phase 4. Confirm with Source before continuing: _"Looks like we finished through Phase 2 last time — agent identities are drafted but not all ratified. Pick up at Phase 3?"_
+
+Use `recall` to surface any onboarding-specific notes you stored on previous sessions (e.g. Source's stated time budget, domain language they prefer, constraints they flagged). Use `remember` whenever Source says something you'll want at the next phase.
+
+## Termination signal
+
+When Phase 4 completes — schedule written, cron entries populated, all role.md frontmatter status flags set to `ratified` — hand off:
+
+> Your murmuration is now ready. Start the daemon (`murmuration start --name <name>`), trigger a manual wake on your most-critical agent (`--now --once`), or wait for tomorrow's scheduled wakes. Source-onboarding is complete; this skill should not run again unless you explicitly say "restart onboarding."
+
+After that point, do not reload this skill on your own. If Source asks for a new agent or to restructure circles, those are governance changes — load `when-to-use-governance` and `governance-models` instead.
+
+---
+
+## Phase 0 — Discovery
+
+**Goal:** Surface Source's vision, the circles their work needs, and the agent roster — in their words, calibrated to their time.
+
+Phase 0 is three movements: Vision Interview → Circle Design → Agent Roster. Each produces a committed governance artifact. Each builds on the previous. Each is a separate session unless Source explicitly wants to continue.
+
+### Phase 0.1 — Vision Interview
+
+Open with this framing, in your own words:
+
+> Before we design any agents, I want to understand what this murmuration is _for_. I'll ask six questions, one at a time. Take as long as you need. If an answer feels rushed or I think there's more there, I'll ask a follow-up. There are no wrong answers — but there are vague answers, and we'll go after the specific one. Ready?
+
+The six questions, asked in order:
+
+1. **What is this murmuration _for_?** What's the work it exists to do? Give me one sentence you could say to a friend who's never heard of any of this.
+2. **Who does this work serve?** Name the people or stakeholders by what they need from you — not by demographic, not by category. The actual humans (or organizations, or communities) on the other end.
+3. **What does success look like in 12 months? In 3 years?** Concretely. Not "I'll be successful" — what's true in the world that isn't true today?
+4. **What is uniquely yours to contribute?** What would be lost if you stepped away? This is the work that _only you_ can do — your voice, your judgment, your relationships, your way of seeing.
+5. **What are your real constraints?** Hours per week you can give this. Energy patterns — when you're sharp, when you're not. What you do well versus what drains you.
+6. **What does failure look like?** Not "it doesn't work" — what would tell you, six months in, that the murmuration has gone wrong? What would you regret?
+
+After each answer:
+
+- If the answer is concrete and named-and-claimed, acknowledge briefly and move to the next question.
+- If the answer is vague (generic words, abstractions, "people," "value," "impact" without referent), ask one follow-up. Examples: _"Who specifically?" / "Tell me about the last time that happened." / "If you stepped away tomorrow, what would the people you serve notice was missing?"_
+- If the answer reveals something Source hadn't articulated before, name it back to them in their own words. _"So what I'm hearing is X — does that sound right?"_
+
+**Synthesize.** Once all six are answered, draft `governance/SOURCE-VISION.md`. Structure:
+
+```markdown
+# Source Vision
+
+## What this murmuration is for
+
+<one-sentence mission, in Source's own words>
+
+## Who we serve
+
+<the named stakeholders and what they need>
+
+## Success
+
+- 12 months: <concrete>
+- 3 years: <concrete>
+
+## What is uniquely Source's
+
+<what would be lost without them>
+
+## Constraints
+
+- Time: <hours/week>
+- Energy patterns: <when sharp, when not>
+- Strengths: <what they do well>
+- Drains: <what to delegate away from>
+
+## What we will not do
+
+<bright lines and out-of-scope, drawn from the failure question>
+```
+
+Show the draft to Source. Revise until they say it sounds like them. Then:
+
+- `write_file governance/SOURCE-VISION.md <body>`
+- Tell Source: _"Saved. Commit when you're ready (`git add governance/SOURCE-VISION.md && git commit`) — or I can ask the daemon to run that for you if you've wired commit hooks."_
+- `remember source.time_budget_hours = <value>` and any other constraints they named — you'll need them later.
+
+**Phase 0.1 is done when:** `governance/SOURCE-VISION.md` exists on disk and Source has confirmed the contents.
+
+### Phase 0.2 — Circle Design
+
+Read `governance/SOURCE-VISION.md` first. Don't propose circles from a template — propose them from the vision.
+
+Frame it for Source:
+
+> Now we design the circles. A circle is a functional domain that owns a coherent slice of the work — like a department in a small organization, but smaller and more accountable. Each circle has one clear purpose, produces specific outputs, and depends on or feeds other circles. From your vision, I'll propose 4 to 6 circles. We'll discuss until they fit.
+
+Propose circles. For each:
+
+- **Name** — short, functional, in Source's domain language (not "Operations Circle" if Source's world calls them "stewards")
+- **Purpose** — one sentence
+- **Outputs** — what this circle produces that others rely on
+- **Dependencies** — which circles feed it, which circles it feeds
+
+Generic shapes you can offer as starting points (don't name them this — these are scaffolding for your own thinking):
+
+- A circle that owns _external interface_ with the people Source serves
+- A circle that owns _intelligence_ — what's happening in the world Source needs to know about
+- A circle that owns _production_ — the actual artifacts the murmuration ships
+- A circle that owns _coordination_ — the connective tissue, scheduling, memory
+- A circle that owns _governance_ — the meta-work of keeping the murmuration coherent
+
+Discuss with Source. Some of these will collapse into one. Some will split. A few will be specific to their domain and won't map to any of the above. That's fine — let the vision drive.
+
+**Flag Phase 2 circles.** A circle Source needs _eventually_ but not to launch is named in the doc and marked `phase: 2`. Don't design it yet.
+
+**Identify the most critical circle.** Tell Source which one you think it is and why — usually the circle whose outputs the rest of the murmuration depends on. Let them disagree.
+
+Once Source approves the set:
+
+- `write_file governance/CIRCLE-DOMAINS.md <body>` — one section per circle with name, purpose, outputs, dependencies, phase
+- For each circle, file a coordination item via `directive`: scope=`group`, target=`<circle-id>`, message body framing the circle's domain definition for ratification. (If groups don't exist yet because the daemon isn't running, instead `remember` the list of pending governance items so you can surface them when the daemon comes up.)
+- Tell Source the circles will be ratified by their members in Phase 3 once identities are written.
+
+**Phase 0.2 is done when:** `governance/CIRCLE-DOMAINS.md` exists, lists 4–6 circles, and Source has confirmed the set.
+
+### Phase 0.3 — Agent Roster
+
+Read both `governance/SOURCE-VISION.md` and `governance/CIRCLE-DOMAINS.md` first.
+
+**Ask Source's time budget before proposing.** If you `remember`ed it from Phase 0.1, confirm: _"You said about 5 hours a week — still right?"_ The roster size scales to the budget:
+
+- 2–3 hours/week: 4–5 agents, daily/weekly cadence
+- 4–6 hours/week: 6–8 agents, mixed cadence
+- 7+ hours/week: 8–10 agents, some with daily cadence
+
+Propose a roster. For each agent:
+
+- **Name and number** (e.g. `01-<slug>`, `02-<slug>` — the number prefix orders them by criticality)
+- **Circle** they belong to
+- **Primary job** — one sentence
+- **Concrete outputs** — what they produce that ends up somewhere downstream
+- **Cadence** — how often they wake (daily / weekly / event-triggered)
+- **Inputs needed** — from other agents or from external signals
+- **Outputs handed off** — to which agent(s)
+
+Generic examples of the _shape_ (use these as templates only — fill with Source's actual domain):
+
+- _Agent X — circle: A, primary job: produces a regular synthesis of <input domain> for circle B, cadence: weekly, inputs: <external signals>, outputs: a brief consumed by Y._
+- _Agent Y — circle: B, primary job: drafts <artifact type> from X's brief, cadence: triggered when X produces a brief, inputs: X's brief, outputs: a draft Source reviews._
+- _Agent Z — circle: C, primary job: tracks commitments and surfaces ones drifting, cadence: weekly, inputs: meeting notes + issue activity, outputs: a heads-up issue when something needs attention._
+
+**Fewer well-defined agents beats more half-baked ones.** Push back if the roster is bloated. Phase 2 agents can be named in the roster but not designed yet.
+
+Discuss, refine. Once Source approves:
+
+- `write_file governance/AGENT-ROSTER.md <body>` — table of agents with all the fields above
+- `remember roster.agent_ids = [<list>]` — you'll iterate over this in Phases 2 and 3
+- File a `directive` to scope=`all` with the roster as a coordination summary, so any existing agents see the new structure on next wake.
+
+**Phase 0.3 is done when:** `governance/AGENT-ROSTER.md` exists, has 6–10 agents (or fewer if budget is tight), and Source has confirmed the assignments.
+
+**Phase 0 overall is done when:** Vision, circle map, and roster all exist on disk and Source has approved each.
+
+End the session here unless Source explicitly wants to continue. _"This is a good place to stop. Phase 1 — the foundational governance documents — is the next session. Reattach when you're ready and just say 'continue onboarding.'"_
+
+---
+
+## Phase 1 — Foundational governance documents
+
+**Goal:** Write the constitution of the murmuration — the documents every agent inherits.
+
+Three documents, in order. Each reads the previous ones. This is typically a single ~1-hour session.
+
+### Phase 1.1 — AGENT-SOUL.md
+
+Read `governance/SOURCE-VISION.md`, `governance/CIRCLE-DOMAINS.md`, `governance/AGENT-ROSTER.md`.
+
+This document is the **shared ethical and behavioral foundation** — what every agent inherits before adding their own role-specific identity. Written first-person plural ("We believe...", "We never...").
+
+Cover, in this order:
+
+1. **Our shared mission** — one sentence, derived from the vision
+2. **What we believe** about the work, the people we serve, what's true in this domain
+3. **How we treat the people we serve** — what we promise them, what they can count on from us
+4. **How we treat each other** — collaboration norms between agents
+5. **What we never do** — bright lines that protect Source, the people served, and the work itself
+6. **How we handle uncertainty** — when an agent acts vs. when they escalate to Source
+7. **The voice we share** — tone, register, what we sound like
+
+Make it specific to Source's domain. Generic corporate values ("integrity, excellence, collaboration") are a smell — they signal you didn't actually read the vision. The bright lines should make Source slightly nervous; if they don't, they're not specific enough.
+
+Show the draft. Source will want to tweak the bright lines and the voice — let them. Iterate until they nod.
+
+- `write_file governance/AGENT-SOUL.md <body>`
+- File a coordination item via `directive` (scope=`all`) noting that the soul is drafted and will be ratified once agent identities are written and consent rounds run.
+
+**Phase 1.1 is done when:** `governance/AGENT-SOUL.md` exists and Source has confirmed.
+
+### Phase 1.2 — SOURCE-DOMAIN-STATEMENT.md
+
+Read `governance/SOURCE-VISION.md` and `governance/AGENT-SOUL.md`.
+
+This document is **Source's contract with the murmuration** — what Source keeps, what Source delegates, response-time expectations, the "good enough" standard.
+
+Before drafting, ask Source two calibration questions:
+
+1. _"What's your typical response time when an agent asks you something — same day? next day? within a week?"_
+2. _"What's your 'good enough' standard? Are you happy shipping rough drafts and refining, or do you need things polished before they go out?"_
+
+Then draft:
+
+1. **Source's vision** — one-paragraph summary, not a re-paste of SOURCE-VISION.md
+2. **What only Source can decide** — the specific decisions, voice, judgments, relationships that don't delegate
+3. **What Source delegates**, broken into the three tiers (autonomous / notify / consent) with brief framing — the actual examples come in DECISION-TIERS.md
+4. **Response-time expectations** — what agents can count on from Source
+5. **The "good enough" standard** — Source's bias toward shipping vs. polishing
+
+Show the draft. Source may want to adjust where the lines fall — let them.
+
+- `write_file governance/SOURCE-DOMAIN-STATEMENT.md <body>`
+
+**Phase 1.2 is done when:** the file exists and Source has confirmed.
+
+### Phase 1.3 — DECISION-TIERS.md
+
+Read `governance/SOURCE-DOMAIN-STATEMENT.md` and `governance/CIRCLE-DOMAINS.md`.
+
+Three tiers:
+
+- **AUTONOMOUS** — agent acts, no notification needed
+- **NOTIFY** — agent acts, then tells Source what they did
+- **CONSENT** — agent proposes, Source must approve before action
+
+For each tier, draft **5–8 real examples drawn from Source's domain** — not generic ones. Pull from the circles and the roster. If circle A produces drafts and circle B publishes them, "publishing without Source review" is a CONSENT-tier action; "drafting" is AUTONOMOUS.
+
+Add a closing rule: _"When an agent is unsure which tier applies, default to NOTIFY — it costs little and preserves trust."_
+
+Show Source the examples. They will move at least two between tiers. That's the work.
+
+- `write_file governance/DECISION-TIERS.md <body>`
+
+**Phase 1.3 is done when:** the file exists and Source has confirmed.
+
+**Phase 1 overall is done when:** all three foundational documents exist and Source has confirmed each.
+
+End the session. _"That's the constitution. Phase 2 is the per-agent identity narratives — one per agent on the roster. Each one is 15–20 minutes. We can do them in batches over a few sessions, or one long session. Your call."_
+
+---
+
+## Phase 2 — Per-agent identity narratives
+
+**Goal:** Each agent on the roster gets an identity narrative that becomes the body of their `role.md`. The frontmatter (model, schedule, scopes) is auto-derived from the roster + harness defaults; you write the prose.
+
+### Per-agent loop
+
+For each agent in `governance/AGENT-ROSTER.md`:
+
+**1. Read context.** Read these files first, every time, before drafting:
+
+- `governance/AGENT-SOUL.md`
+- `governance/SOURCE-DOMAIN-STATEMENT.md`
+- `governance/DECISION-TIERS.md`
+- `governance/CIRCLE-DOMAINS.md` (the section for this agent's circle)
+- `governance/AGENT-ROSTER.md` (the row for this agent)
+
+**2. Draft the narrative.** Cover, in this order:
+
+1. **Who I am** — this agent's specific role, what makes them distinct from peers
+2. **What I am accountable for** — domain, outputs, what success looks like for this agent specifically
+3. **How I think** — reasoning approach, what they optimize for, what they trade off
+4. **How I relate to other agents** — concrete dependencies, handoffs, who they work alongside
+5. **My voice** — how this agent communicates with Source, with peer agents, with external audiences (if they have any)
+6. **What I will never do** — this agent's specific bright lines, beyond what AGENT-SOUL.md already covers
+7. **How I grow** — what's in scope for Phase 0, what they grow into in Phase 1, what's deferred to Phase 2
+8. **My schedule** — when they wake, what they produce, cadence (drawn from the roster)
+
+**Do not repeat AGENT-SOUL.md content.** The soul is inherited. The identity narrative only adds what's specific to this role.
+
+**3. Show Source the draft.** They will want to adjust voice and bright lines. Let them.
+
+**4. Write the role.md.** The narrative becomes the markdown body of `agents/<agent-id>/role.md`. The frontmatter is generated from the roster:
+
+```yaml
+---
+agent_id: "<id-from-roster>"
+name: "<display-name>"
+model_tier: balanced # or as the operator prefers; can be tuned later
+max_wall_clock_ms: 120000
+group_memberships:
+  - <circle-from-roster>
+signals:
+  sources: [github-issue, private-note, inbox]
+  github_scopes: [] # filled in if/when GitHub collaboration is wired
+github:
+  write_scopes:
+    issue_comments: [] # narrow to least privilege; expand later if needed
+    labels: []
+    issues: []
+status: draft # flips to "ratified" after Phase 3 consent round
+---
+<the identity narrative>
+```
+
+`write_file agents/<agent-id>/role.md <full-content>`. The murmuration root's `agents/` is in the safe write zone.
+
+**5. File a coordination item.** Use `directive` scope=`group` target=`<this-agent's circle>` with a message like:
+
+> Agent identity drafted: `<agent-id>`. File: `agents/<agent-id>/role.md`. Status: draft. Awaiting consent round in Phase 3.
+
+If GitHub collaboration is configured, the daemon (or the circle's facilitator agent on its next wake) will translate this into a GitHub issue with labels `[circle:<name>, tier:consent, source-directive]`. If collaboration is local, the directive lives on disk under `.murmuration/governance/items.jsonl` and surfaces in the next group meeting.
+
+**6. Mark progress.** `remember agent.<agent-id>.status = "drafted"` so you can resume cleanly.
+
+### Batching judgment
+
+Drafting all 6–10 agents in one session is too much. Drafting one per session is too slow. The pragmatic batch is **3–4 agents per session**, prioritized by criticality (the agents whose outputs the rest depend on go first). Confirm with Source before drafting each batch. If Source's energy fades mid-batch, stop — you have memory; resume later.
+
+**Phase 2 is done when:** every agent in the roster has a `role.md` on disk with `status: draft` in frontmatter and an identity narrative in the body.
+
+End each session with a status summary: _"Drafted N of M agents this session. Remaining: <list>. Reattach when ready."_
+
+---
+
+## Phase 3 — Consent rounds
+
+**Goal:** Each agent identity gets ratified by the agents whose work it touches. The harness's governance plugin runs the round. You don't roleplay all the agents yourself — that's not how the harness works.
+
+### How a consent round actually runs
+
+The active governance plugin (S3 by default; check `harness.yaml` and `governance-models` skill for specifics) defines what a consent round looks like for this murmuration. The plugin's `runConsentRound` (or equivalent — name varies by plugin) is what does the work. You invoke it via the `convene` tool:
+
+```
+convene group_id=<circle> mode=governance directive="Ratify identity for agent <agent-id>"
+```
+
+This:
+
+1. Creates a governance meeting agenda item for that circle
+2. Each circle member contributes a position (consent / objection / abstain) per the plugin's protocol
+3. The facilitator tallies; the daemon transitions the item to its terminal state
+4. A decision record is written to `.murmuration/governance/decisions/<item-id>.md`
+5. Meeting minutes post to the collaboration provider (GitHub issue or local item)
+
+The daemon **must be running** for `convene` to work. If it isn't, prompt Source: _"I need to start the daemon to run consent rounds. Want me to do that now? (`murmuration start --name <name>`)"_
+
+### Per-agent consent loop
+
+For each agent with `status: draft`:
+
+**1. Identify affected circles.** Read the agent's `role.md` — primary circle is from `group_memberships`. Secondary circles are any whose work depends on this agent's outputs (you can read them from `governance/CIRCLE-DOMAINS.md`). The consent round runs in the primary circle; secondary-circle members can attend as observers if the plugin supports it.
+
+**2. Confirm with Source before convening.** Convening spends LLM budget — every member of the circle wakes briefly to contribute their position. Source should explicitly say "go" before each round.
+
+**3. Convene.** Use the `convene` tool with mode=`governance` and a directive that references the identity document path. The plugin handles the protocol — including how objections are tested, what counts as a valid objection vs. a concern, and how amendments are proposed.
+
+**4. Watch the round.** Use `events limit=20` to track the meeting's progress. When the meeting completes, use `get_agreement <item-id>` to confirm the terminal state.
+
+**5. Handle outcomes.**
+
+- **Ratified, no amendments** — flip the agent's `role.md` frontmatter `status` from `draft` to `ratified`. Use `write_file` to update the file. `remember agent.<agent-id>.status = "ratified"`.
+- **Ratified with amendments** — the meeting minutes will note what changed. Update the identity narrative in `role.md` to reflect the amendment, then flip `status` to `ratified`.
+- **Objection raised, not resolved** — the plugin keeps the item in `consent-round` (or equivalent) state. Read the meeting minutes. Discuss with Source: usually the objection is asking for a real change to the identity. Re-draft, then re-convene.
+- **Abandoned / withdrawn** — Source decided this agent isn't right. Remove the row from `governance/AGENT-ROSTER.md` and delete the `agents/<agent-id>/` directory.
+
+**6. Move on.** Do the next agent. Order by criticality — the agents whose outputs everything else depends on get ratified first, so that downstream agents can reference them as already-ratified peers.
+
+### Batching judgment
+
+One consent round per session is fine. Two or three is doable if Source has time and the rounds are uncomplicated. Don't run all 6–10 in one session — Source's attention is the bottleneck, and watching consent rounds is high-engagement work.
+
+**Phase 3 is done when:** every agent's `role.md` frontmatter has `status: ratified` and a corresponding decision record exists at `.murmuration/governance/decisions/<item-id>.md`.
+
+---
+
+## Phase 4 — Operating schedule
+
+**Goal:** Translate the roster's stated cadences into actual `wake_schedule` cron entries in each agent's `role.md`, with Source's weekly rhythm explicitly named.
+
+### Phase 4.1 — Design the weekly schedule
+
+Read `governance/AGENT-ROSTER.md` and `governance/SOURCE-DOMAIN-STATEMENT.md`.
+
+Ask Source two questions:
+
+1. _"What's the natural rhythm of your week? Are there days you're heads-down, days that are meeting-heavy, days that are off-limits?"_
+2. _"How many hours per week do you want to actually spend interacting with the murmuration — reviewing outputs, approving CONSENT-tier items, doing the human work in the loop?"_
+
+The second question is critical. Use the answer to decide cron density. If Source has 3 hours a week, you can't have 5 agents waking daily — the review queue will overflow.
+
+Draft `governance/WEEKLY-SCHEDULE.md`:
+
+```markdown
+# Weekly operating schedule
+
+## Source's cadence
+
+<X hours/week, distributed how, when>
+
+## Agent schedules
+
+| Agent | Day(s) | Time    | Trigger         | Hands off to |
+| ----- | ------ | ------- | --------------- | ------------ |
+| <id>  | <day>  | <hh:mm> | <cron-or-event> | <next agent> |
+
+...
+
+## Dependencies
+
+<flow diagram in prose: A produces X on Mon → B consumes X on Tue → C consumes B's output on Wed → Source reviews on Thu>
+
+## What can eventually be event-triggered
+
+<agents whose cadence is "when X happens" rather than "every Tuesday" — these become candidates for signal-driven wakes once the murmuration is humming>
+```
+
+Show Source. They will shift things around — usually pulling agent wakes earlier in the week so review work clusters later. Let them.
+
+- `write_file governance/WEEKLY-SCHEDULE.md <body>`
+
+### Phase 4.2 — Translate to cron in role.md
+
+For each agent with a scheduled cadence in WEEKLY-SCHEDULE.md, edit the agent's `role.md` frontmatter to add the trigger. The harness supports cron, interval, and delay-once triggers — read `agent-anatomy` skill for the schema if you're unsure.
+
+Typical pattern in the frontmatter:
+
+```yaml
+wake_schedule:
+  cron: "0 9 * * 1" # Monday 9am — for a weekly Monday agent
+  timezone: "America/Los_Angeles" # Source's timezone
+```
+
+Or for interval:
+
+```yaml
+wake_schedule:
+  interval_ms: 86400000 # daily
+```
+
+Use `write_file` to update each agent's `role.md`. Don't blow away the existing frontmatter — read it first, splice in the schedule block, write it back.
+
+**Edge cases:**
+
+- Event-triggered agents (cadence "when X happens") get no cron — they wake via signals or directives. Note this in WEEKLY-SCHEDULE.md and leave `wake_schedule` absent from their frontmatter.
+- Agents Source flagged as Phase 2 stay scaffolded but get no schedule. They exist in the roster, their `role.md` is drafted (and ratified, if Phase 3 covered them), but their `wake_schedule` is omitted so they don't fire.
+
+**Phase 4.2 is done when:** every Phase 0 agent in the roster has a working `wake_schedule` in their `role.md` frontmatter, and the daemon (when started) would fire each at the intended time.
+
+**Phase 4 overall is done when:** the schedule document exists, all agents' `role.md` frontmatter reflects the schedule, and Source confirms the rhythm fits their week.
+
+---
+
+## Hand-off
+
+When Phase 4 is complete:
+
+> Your murmuration is now ready.
+>
+> - **Start the daemon:** `murmuration start --name <name>`
+> - **Trigger a manual wake** on your most-critical agent to verify the loop end-to-end: `murmuration start --agent <agent-id> --now --once`
+> - **Or wait** for tomorrow's first scheduled wake.
+>
+> Source-onboarding is complete. From here, the murmuration runs on the rhythm you designed. When you want to evolve it — add an agent, change a circle's domain, adjust a schedule — that's governance, not onboarding. Different skill (`when-to-use-governance`).
+>
+> This skill should not run again unless you explicitly say "restart onboarding."
+
+`remember onboarding.completed_at = <iso-timestamp>` so future attaches know not to re-trigger this skill on ambiguous phrases.
+
+---
+
+## Cross-session resumption — the explicit pattern
+
+Source can stop at any phase, detach, and reattach later. The mechanism is already there:
+
+1. **Spirit memory** — `remember`/`recall` persist across attaches. Use it for state Source named (time budget, language preferences, batch progress).
+2. **Conversation log** — `conversation.jsonl` persists; on reattach you can scroll back to the last exchange.
+3. **On-disk artifacts** — every governance/_ and agents/_/role.md commit is durable. The presence/absence of these files tells you exactly where to resume.
+
+On every onboarding session resume:
+
+1. Greet Source.
+2. Run the **detecting where to start** sequence at the top of this skill.
+3. State your inferred resume point: _"Looks like we finished Phase 2 last week — N of M agent identities drafted, none ratified yet. Pick up at Phase 3?"_
+4. Wait for Source to confirm or correct before proceeding.
+
+If Source disputes your inferred resume point ("actually I want to revise the soul doc first"), follow them. Phases are sequential by default but Source is sovereign — they can revisit anything.
+
+---
+
+## Voice notes — for you, the Spirit
+
+This skill is the most consequential conversation Source will have with the murmuration. It's where the murmuration's soul is shaped. A few reminders:
+
+- **The vision interview is a gift, not a survey.** Source will say things they haven't said out loud before. Hold the space. Don't rush.
+- **Specificity is the work.** Generic answers produce generic agents. When Source gives you a generic answer, your job is to ask the question that pulls the specific one out.
+- **Source's words, not yours.** If they call it "the work," call it the work. Don't translate into your vocabulary.
+- **Resist your bias toward speed.** The reference plans this skill is built on took 4 weeks. That's the right shape. If you find yourself pushing through phases, slow down.
+- **Bright lines should make Source slightly nervous.** If they don't, they're not real lines yet.
+- **Calibrate to budget.** A 3-hour-a-week operator with 10 agents is a recipe for disappointment. Push back on roster bloat early.
+
+The murmuration that emerges from this skill is the one Source will run for a year. Make it theirs.

--- a/packages/cli/src/spirit/tools.test.ts
+++ b/packages/cli/src/spirit/tools.test.ts
@@ -500,3 +500,149 @@ describe("Spirit tools — close_issue (K3)", () => {
     expect(result).toContain("'it'\\''s fine'");
   });
 });
+
+// ---------------------------------------------------------------------------
+// harness#318 — cost tool
+// ---------------------------------------------------------------------------
+
+describe("Spirit tools — cost (harness#318)", () => {
+  it("calls send('cost.summary') and returns formatted result", async () => {
+    let calledMethod = "";
+    const send: typeof noopSend = (method) => {
+      calledMethod = method;
+      return Promise.resolve({ id: "1", result: { totalWakes: 42, agents: [] } });
+    };
+    const tools = buildSpiritTools({ rootDir: "/", send });
+    const tool = tools.find((t) => t.name === "cost");
+    expect(tool).toBeDefined();
+    const result = (await tool!.execute({})) as string;
+    expect(calledMethod).toBe("cost.summary");
+    expect(result).toContain("totalWakes");
+  });
+
+  it("surfaces daemon error when daemon is not running", async () => {
+    const send: typeof noopSend = () => Promise.resolve({ id: "1", error: "daemon not connected" });
+    const tools = buildSpiritTools({ rootDir: "/", send });
+    const tool = tools.find((t) => t.name === "cost");
+    const result = (await tool!.execute({})) as string;
+    expect(result).toMatch(/daemon not connected/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// harness#319 — backlog tool
+// ---------------------------------------------------------------------------
+
+describe("Spirit tools — backlog (harness#319)", () => {
+  let root = "";
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), `spirit-backlog-${randomUUID().slice(0, 8)}-`));
+    mkdirSync(join(root, ".murmuration", "governance"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const getTool = (name: string) => {
+    const tools = buildSpiritTools({ rootDir: root, send: noopSend });
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found`);
+    return tool;
+  };
+
+  it("returns friendly message when no items file exists", async () => {
+    const tool = getTool("backlog");
+    const result = (await tool.execute({})) as string;
+    expect(result).toMatch(/no active governance items/);
+  });
+
+  it("returns open items (excludes terminal states by default)", async () => {
+    const items = [
+      JSON.stringify({
+        id: "prop-1",
+        kind: "proposal",
+        currentState: "proposed",
+        createdBy: { value: "01-agent" },
+        createdAt: "2026-05-01T00:00:00Z",
+        reviewAt: null,
+      }),
+      JSON.stringify({
+        id: "prop-2",
+        kind: "proposal",
+        currentState: "ratified",
+        createdBy: { value: "01-agent" },
+        createdAt: "2026-05-02T00:00:00Z",
+        reviewAt: null,
+      }),
+    ].join("\n");
+    writeFileSync(join(root, ".murmuration", "governance", "items.jsonl"), items, "utf8");
+
+    const tool = getTool("backlog");
+    const result = (await tool.execute({})) as string;
+    const parsed = JSON.parse(result) as unknown[];
+    expect(parsed).toHaveLength(1);
+    expect((parsed[0] as { id: string }).id).toBe("prop-1");
+  });
+
+  it("returns all items when state=all", async () => {
+    const items = [
+      JSON.stringify({
+        id: "prop-1",
+        kind: "proposal",
+        currentState: "proposed",
+        createdBy: { value: "01-agent" },
+        createdAt: "2026-05-01T00:00:00Z",
+        reviewAt: null,
+      }),
+      JSON.stringify({
+        id: "prop-2",
+        kind: "proposal",
+        currentState: "ratified",
+        createdBy: { value: "01-agent" },
+        createdAt: "2026-05-02T00:00:00Z",
+        reviewAt: null,
+      }),
+    ].join("\n");
+    writeFileSync(join(root, ".murmuration", "governance", "items.jsonl"), items, "utf8");
+
+    const tool = getTool("backlog");
+    const result = (await tool.execute({ state: "all" })) as string;
+    const parsed = JSON.parse(result) as unknown[];
+    expect(parsed).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// harness#320 — doctor tool
+// ---------------------------------------------------------------------------
+
+describe("Spirit tools — doctor (harness#320)", () => {
+  let root = "";
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), `spirit-doctor-${randomUUID().slice(0, 8)}-`));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("runs doctor and returns a human-readable report", async () => {
+    const tools = buildSpiritTools({ rootDir: root, send: noopSend });
+    const tool = tools.find((t) => t.name === "doctor");
+    expect(tool).toBeDefined();
+    const result = (await tool!.execute({ live: false })) as string;
+    // formatReport always starts with a header containing "Doctor" or "murmuration"
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("runs doctor without live flag (default)", async () => {
+    const tools = buildSpiritTools({ rootDir: root, send: noopSend });
+    const tool = tools.find((t) => t.name === "doctor");
+    const result = (await tool!.execute({})) as string;
+    expect(typeof result).toBe("string");
+  });
+});

--- a/packages/cli/src/spirit/tools.ts
+++ b/packages/cli/src/spirit/tools.ts
@@ -18,6 +18,7 @@ import { join, resolve, relative, basename, dirname } from "node:path";
 import type { ToolDefinition } from "@murmurations-ai/llm";
 import { z } from "zod";
 
+import { runDoctor, formatReport } from "../doctor.js";
 import { SpiritMemory, type MemoryType } from "./memory.js";
 import { describeMurmuration } from "./overview.js";
 import { SpiritSkillsOverlay } from "./skills.js";
@@ -599,6 +600,77 @@ export const buildSpiritTools = (ctx: ToolContext): readonly SpiritTool[] => {
     },
   };
 
+  // harness#318 — cost tool
+  const costTool: SpiritTool = {
+    name: "cost",
+    description:
+      "Murmuration cost summary: total wakes, artifacts, and per-agent breakdown. Same numbers as `murmuration cost`. Use when Source asks about spend or wake activity.",
+    parameters: z.object({}),
+    execute: async () => formatSocketResponse(await send("cost.summary")),
+  };
+
+  // harness#319 — backlog tool
+  const backlogTool: SpiritTool = {
+    name: "backlog",
+    description:
+      "List governance items currently in flight for this murmuration. Returns all items from .murmuration/governance/items.jsonl, newest first. Optionally filter by group_id (matches against item payload, best-effort) or state.",
+    parameters: z.object({
+      group_id: z
+        .string()
+        .optional()
+        .describe("Group/circle id. When set, only items referencing this group are returned."),
+      state: z
+        .enum(["open", "all"])
+        .optional()
+        .describe(
+          "'open' omits items in terminal-looking states (ratified/rejected/abandoned/withdrawn). Default: open.",
+        ),
+    }),
+    execute: async (input) => {
+      const { group_id, state } = input as { group_id?: string; state?: string };
+      try {
+        const items = await readAllGovernanceItems(rootDir);
+        const TERMINAL_RE = /^(ratified|rejected|abandoned|withdrawn|closed|done)$/i;
+        const filtered = items.filter((item) => {
+          const stateStr = typeof item.currentState === "string" ? item.currentState : "";
+          if ((state ?? "open") === "open" && TERMINAL_RE.test(stateStr)) return false;
+          if (group_id !== undefined) {
+            const raw = JSON.stringify(item.payload ?? {}).toLowerCase();
+            const creatorId = typeof item.createdBy?.value === "string" ? item.createdBy.value : "";
+            return raw.includes(group_id.toLowerCase()) || creatorId === group_id;
+          }
+          return true;
+        });
+        if (filtered.length === 0) return "(no active governance items)";
+        return JSON.stringify(filtered, null, 2);
+      } catch (err) {
+        return `backlog error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  };
+
+  // harness#320 — doctor tool
+  const doctorTool: SpiritTool = {
+    name: "doctor",
+    description:
+      "Run the same preflight as `murmuration doctor`: layout, schema, secrets, governance, drift checks. Returns a human-readable report. Pass live: true to also check GitHub access (costs one API call).",
+    parameters: z.object({
+      live: z
+        .boolean()
+        .optional()
+        .describe("Include live GitHub auth + repo access checks. Default: false."),
+    }),
+    execute: async (input) => {
+      const { live } = input as { live?: boolean };
+      try {
+        const report = await runDoctor({ rootDir, live: live ?? false });
+        return formatReport(report);
+      } catch (err) {
+        return `doctor error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  };
+
   return [
     statusTool,
     agentsTool,
@@ -621,6 +693,9 @@ export const buildSpiritTools = (ctx: ToolContext): readonly SpiritTool[] => {
     getAgreementTool,
     listAwaitingSourceCloseTool,
     closeIssueTool,
+    costTool,
+    backlogTool,
+    doctorTool,
   ];
 };
 
@@ -669,20 +744,24 @@ interface RawGovernanceItem {
   readonly createdBy?: { readonly value?: unknown };
   readonly createdAt?: unknown;
   readonly reviewAt?: unknown;
+  readonly payload?: unknown;
   readonly history?: readonly unknown[];
 }
+
+const readGovernanceItemsFile = async (rootDir: string): Promise<string | null> => {
+  try {
+    return await readFile(join(rootDir, ".murmuration", "governance", "items.jsonl"), "utf8");
+  } catch {
+    return null;
+  }
+};
 
 const readGovernanceItem = async (
   rootDir: string,
   id: string,
 ): Promise<RawGovernanceItem | null> => {
-  const path = join(rootDir, ".murmuration", "governance", "items.jsonl");
-  let content: string;
-  try {
-    content = await readFile(path, "utf8");
-  } catch {
-    return null;
-  }
+  const content = await readGovernanceItemsFile(rootDir);
+  if (content === null) return null;
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.length === 0) continue;
@@ -694,6 +773,22 @@ const readGovernanceItem = async (
     }
   }
   return null;
+};
+
+const readAllGovernanceItems = async (rootDir: string): Promise<readonly RawGovernanceItem[]> => {
+  const content = await readGovernanceItemsFile(rootDir);
+  if (content === null) return [];
+  const items: RawGovernanceItem[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      items.push(JSON.parse(trimmed) as RawGovernanceItem);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return items.reverse(); // newest first (JSONL is append-only, oldest first)
 };
 
 const extractAwaitingCloseSection = (digest: string): string => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/src/agents/agents.test.ts
+++ b/packages/core/src/agents/agents.test.ts
@@ -63,6 +63,28 @@ describe("AgentStateStore", () => {
     expect(store.getAgent("test")?.consecutiveFailures).toBe(0);
   });
 
+  it("spawn-failed outcome increments consecutiveFailures and records on wake (#329)", () => {
+    const store = new AgentStateStore();
+    store.register("agent-x", 120000);
+    store.transition("agent-x", "idle");
+
+    // Spawn fails before running state — agent stays in waking
+    store.transition("agent-x", "waking", "w-sf");
+    store.recordWakeOutcome("w-sf", "spawn-failed", {
+      errorMessage: "ENOENT: binary not found",
+    });
+
+    expect(store.getAgent("agent-x")?.consecutiveFailures).toBe(1);
+    expect(store.getAgent("agent-x")?.lastOutcome).toBe("spawn-failed");
+    expect(store.getAgent("agent-x")?.currentState).toBe("idle");
+
+    const wakes = store.getRecentWakes("agent-x");
+    const wake = wakes.find((w) => w.wakeId === "w-sf");
+    expect(wake?.outcome).toBe("spawn-failed");
+    expect(wake?.state).toBe("failed");
+    expect(wake?.errorMessage).toBe("ENOENT: binary not found");
+  });
+
   it("getStalledAgents detects agents stuck in running state", () => {
     let now = new Date("2026-04-11T12:00:00Z");
     const store = new AgentStateStore({ now: () => now });

--- a/packages/core/src/agents/agents.test.ts
+++ b/packages/core/src/agents/agents.test.ts
@@ -81,7 +81,7 @@ describe("AgentStateStore", () => {
     const wakes = store.getRecentWakes("agent-x");
     const wake = wakes.find((w) => w.wakeId === "w-sf");
     expect(wake?.outcome).toBe("spawn-failed");
-    expect(wake?.state).toBe("failed");
+    expect(wake?.state).toBe("spawn-failed");
     expect(wake?.errorMessage).toBe("ENOENT: binary not found");
   });
 

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -29,7 +29,7 @@ export type AgentLifecycleState =
   | "failed"
   | "timed-out";
 
-export type WakeOutcome = "success" | "failure" | "timeout" | "killed";
+export type WakeOutcome = "success" | "failure" | "timeout" | "killed" | "spawn-failed";
 
 export interface AgentWakeInstance {
   readonly wakeId: string;

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -5,6 +5,7 @@
  *   registered → idle → waking → running → completed → idle
  *                                        → failed → idle
  *                                        → timed-out → idle
+ *                              → spawn-failed → idle
  *
  * The daemon transitions state at each lifecycle point. The dashboard
  * reads state directly — no log scraping.
@@ -27,7 +28,8 @@ export type AgentLifecycleState =
   | "running"
   | "completed"
   | "failed"
-  | "timed-out";
+  | "timed-out"
+  | "spawn-failed";
 
 export type WakeOutcome = "success" | "failure" | "timeout" | "killed" | "spawn-failed";
 
@@ -291,7 +293,13 @@ export class AgentStateStore implements IAgentStateStore {
     const durationMs = now.getTime() - startedAt.getTime();
 
     const terminalState: AgentLifecycleState =
-      outcome === "success" ? "completed" : outcome === "timeout" ? "timed-out" : "failed";
+      outcome === "success"
+        ? "completed"
+        : outcome === "timeout"
+          ? "timed-out"
+          : outcome === "spawn-failed"
+            ? "spawn-failed"
+            : "failed";
 
     this.#wakes.set(wakeId, {
       ...wake,

--- a/packages/core/src/cost/builder.ts
+++ b/packages/core/src/cost/builder.ts
@@ -64,8 +64,8 @@ export class WakeCostBuilder {
   #llmCacheWriteTokens = 0;
   #llmCostMicros: USDMicros = ZERO_USD_MICROS;
   #llmShadowCostMicros: USDMicros | undefined = undefined;
-  #llmProvider = "placeholder";
-  #llmModel = "phase-1a-stub";
+  #llmProvider = "unknown";
+  #llmModel = "unknown";
 
   #ghRest = 0;
   #ghGraphql = 0;

--- a/packages/core/src/cost/builder.ts
+++ b/packages/core/src/cost/builder.ts
@@ -66,6 +66,9 @@ export class WakeCostBuilder {
   #llmShadowCostMicros: USDMicros | undefined = undefined;
   #llmProvider = "unknown";
   #llmModel = "unknown";
+  #llmCliPath: string | undefined = undefined;
+  #llmSpawnMs: number | undefined = undefined;
+  #llmTimeoutMs: number | undefined = undefined;
 
   #ghRest = 0;
   #ghGraphql = 0;
@@ -142,6 +145,12 @@ export class WakeCostBuilder {
      * calls leave this undefined.
      */
     readonly shadowCostMicros?: USDMicros;
+    /** v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary. */
+    readonly cliPath?: string;
+    /** v0.7.1 (#280): subscription-CLI only. Spawn-to-first-byte latency in ms. */
+    readonly spawnMs?: number;
+    /** v0.7.1 (#280): subscription-CLI only. Configured subprocess timeout in ms. */
+    readonly timeoutMs?: number;
   }): void {
     this.#assertNotFinalized();
     this.#llmInputTokens += usage.inputTokens;
@@ -157,6 +166,9 @@ export class WakeCostBuilder {
     }
     this.#llmProvider = usage.modelProvider;
     this.#llmModel = usage.modelName;
+    if (usage.cliPath !== undefined) this.#llmCliPath = usage.cliPath;
+    if (usage.spawnMs !== undefined) this.#llmSpawnMs = usage.spawnMs;
+    if (usage.timeoutMs !== undefined) this.#llmTimeoutMs = usage.timeoutMs;
   }
 
   /**
@@ -223,6 +235,9 @@ export class WakeCostBuilder {
         modelName: this.#llmModel,
         costMicros: this.#llmCostMicros,
         shadowCostMicros: this.#llmShadowCostMicros,
+        ...(this.#llmCliPath !== undefined ? { cliPath: this.#llmCliPath } : {}),
+        ...(this.#llmSpawnMs !== undefined ? { spawnMs: this.#llmSpawnMs } : {}),
+        ...(this.#llmTimeoutMs !== undefined ? { timeoutMs: this.#llmTimeoutMs } : {}),
       },
       github: {
         restCalls: this.#ghRest,

--- a/packages/core/src/cost/cost.test.ts
+++ b/packages/core/src/cost/cost.test.ts
@@ -131,8 +131,8 @@ describe("WakeCostBuilder", () => {
     expect(record.totals.apiCalls).toBe(0);
     expect(record.llm.inputTokens).toBe(0);
     expect(record.llm.outputTokens).toBe(0);
-    expect(record.llm.modelProvider).toBe("placeholder");
-    expect(record.llm.modelName).toBe("phase-1a-stub");
+    expect(record.llm.modelProvider).toBe("unknown");
+    expect(record.llm.modelName).toBe("unknown");
     expect(record.github.restCalls).toBe(0);
     expect(record.github.graphqlCalls).toBe(0);
     expect(record.budget).toBeNull();
@@ -303,8 +303,8 @@ describe("wakeCostRecordSchema", () => {
       outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
-      modelProvider: "placeholder",
-      modelName: "phase-1a-stub",
+      modelProvider: "unknown",
+      modelName: "unknown",
       costMicros: { kind: "usd-micros", value: 0 },
     },
     github: {

--- a/packages/core/src/cost/cost.test.ts
+++ b/packages/core/src/cost/cost.test.ts
@@ -141,6 +141,39 @@ describe("WakeCostBuilder", () => {
     expect(record.rollupHints.isoWeekUtc).toMatch(/^\d{4}-W\d{2}$/);
   });
 
+  it("addLlmTokens stores cliPath, spawnMs, timeoutMs in finalized record (#280)", () => {
+    const builder = mkBuilder();
+    builder.addLlmTokens({
+      inputTokens: 10,
+      outputTokens: 5,
+      modelProvider: "claude-cli",
+      modelName: "claude-sonnet-4-6",
+      costMicros: makeUSDMicros(0),
+      cliPath: "/usr/local/bin/claude",
+      spawnMs: 312,
+      timeoutMs: 600_000,
+    });
+    const record = builder.finalize();
+    expect(record.llm.cliPath).toBe("/usr/local/bin/claude");
+    expect(record.llm.spawnMs).toBe(312);
+    expect(record.llm.timeoutMs).toBe(600_000);
+  });
+
+  it("addLlmTokens leaves cliPath/spawnMs/timeoutMs undefined when not supplied", () => {
+    const builder = mkBuilder();
+    builder.addLlmTokens({
+      inputTokens: 10,
+      outputTokens: 5,
+      modelProvider: "anthropic",
+      modelName: "claude-sonnet-4-6",
+      costMicros: makeUSDMicros(500),
+    });
+    const record = builder.finalize();
+    expect(record.llm.cliPath).toBeUndefined();
+    expect(record.llm.spawnMs).toBeUndefined();
+    expect(record.llm.timeoutMs).toBeUndefined();
+  });
+
   it("addLlmTokens sums across multiple calls and preserves last model", () => {
     const builder = mkBuilder();
     builder.addLlmTokens({
@@ -326,6 +359,19 @@ describe("wakeCostRecordSchema", () => {
 
   it("accepts a minimal zero-cost record", () => {
     expect(wakeCostRecordSchema.safeParse(validRecord).success).toBe(true);
+  });
+
+  it("accepts a record with cliPath, spawnMs, and timeoutMs in llm (#280)", () => {
+    const withCliFields = {
+      ...validRecord,
+      llm: {
+        ...validRecord.llm,
+        cliPath: "/usr/local/bin/claude",
+        spawnMs: 312,
+        timeoutMs: 600_000,
+      },
+    };
+    expect(wakeCostRecordSchema.safeParse(withCliFields).success).toBe(true);
   });
 
   it("rejects schemaVersion !== 1", () => {

--- a/packages/core/src/cost/record.ts
+++ b/packages/core/src/cost/record.ts
@@ -78,6 +78,12 @@ export interface WakeCostRecord {
      * API spend for fairness, budgeting, and the "you saved $X" headline.
      */
     readonly shadowCostMicros: USDMicros | undefined;
+    /** v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary. */
+    readonly cliPath?: string;
+    /** v0.7.1 (#280): subscription-CLI only. Spawn-to-first-byte latency in ms. */
+    readonly spawnMs?: number;
+    /** v0.7.1 (#280): subscription-CLI only. Configured subprocess timeout in ms. */
+    readonly timeoutMs?: number;
   };
 
   /** GitHub API accounting. Stubbed zero until Phase 1B-d (B2). */
@@ -142,6 +148,9 @@ export const wakeCostRecordSchema = z.object({
     modelName: z.string(),
     costMicros: brandedValue("usd-micros", z.number().int().nonnegative()),
     shadowCostMicros: brandedValue("usd-micros", z.number().int().nonnegative()).optional(),
+    cliPath: z.string().optional(),
+    spawnMs: z.number().int().nonnegative().optional(),
+    timeoutMs: z.number().int().nonnegative().optional(),
   }),
   github: z.object({
     restCalls: z.number().int().nonnegative(),

--- a/packages/core/src/cost/record.ts
+++ b/packages/core/src/cost/record.ts
@@ -78,7 +78,12 @@ export interface WakeCostRecord {
      * API spend for fairness, budgeting, and the "you saved $X" headline.
      */
     readonly shadowCostMicros: USDMicros | undefined;
-    /** v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary. */
+    /**
+     * v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary.
+     * Consumers that serialize `WakeCostRecord` to disk or external systems
+     * must project only the fields they need — do not `JSON.stringify` the
+     * whole record, as this would leak the operator's local filesystem layout.
+     */
     readonly cliPath?: string;
     /** v0.7.1 (#280): subscription-CLI only. Spawn-to-first-byte latency in ms. */
     readonly spawnMs?: number;

--- a/packages/core/src/daemon/command-executor.ts
+++ b/packages/core/src/daemon/command-executor.ts
@@ -15,6 +15,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { HARNESS_VERSION } from "../index.js";
+import { SOURCE_DIRECTIVE_LABEL } from "../labels/index.js";
 import { PROTOCOL_SCHEMA_VERSION } from "./protocol.js";
 import { runsDirForAgent, runsDir as canonicalRunsDir } from "./runs-path.js";
 import { GovernanceStateStore } from "../governance/index.js";
@@ -983,7 +984,7 @@ export class DaemonCommandExecutor {
   async #assertIsDirective(id: string, action: "close" | "delete"): Promise<"open" | "closed"> {
     if (!this.#deps.collaborationProvider) return "open";
     const result = await this.#deps.collaborationProvider.listItems({
-      labels: ["source-directive"],
+      labels: [SOURCE_DIRECTIVE_LABEL],
       state: "all",
     });
     if (!result.ok) {
@@ -1005,7 +1006,7 @@ export class DaemonCommandExecutor {
       throw new Error("No collaboration provider configured");
     }
     const result = await this.#deps.collaborationProvider.listItems({
-      labels: ["source-directive"],
+      labels: [SOURCE_DIRECTIVE_LABEL],
       state: "open",
     });
     if (!result.ok) throw new Error(result.error.message);

--- a/packages/core/src/daemon/daemon.test.ts
+++ b/packages/core/src/daemon/daemon.test.ts
@@ -413,7 +413,7 @@ describe("Daemon", () => {
     expect(costEvent?.data.schemaVersion).toBe(1);
     expect(costEvent?.data.agentId).toBe("hello-world");
     const llm = costEvent?.data.llm as { modelProvider?: string } | undefined;
-    expect(llm?.modelProvider).toBe("placeholder");
+    expect(llm?.modelProvider).toBe("unknown");
     const rollup = costEvent?.data.rollupHints as { dayUtc?: string } | undefined;
     expect(rollup?.dayUtc).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     await daemon.stop();

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -41,6 +41,7 @@ import {
   amendWakeSummaryWithValidation,
 } from "../execution/index.js";
 import type { LoadedAgentIdentity } from "../identity/index.js";
+import { buildAgentRoutingLabels } from "../labels/index.js";
 import {
   makeSecretKey,
   REDACT,
@@ -283,6 +284,22 @@ export const registeredAgentFromLoadedIdentity = (
       }
     : undefined;
 
+  // Auto-derive the membership-aware OR-set of routing labels (harness#331
+  // fix, with derivation moved here from boot.ts per Engineering Standard
+  // #8 — keep the composition root thin). The aggregator listens for any
+  // of these to deliver assigned items, scoped directives, group
+  // directives, and broadcast directives.
+  //
+  // Operator precedence: if `signals.github_scopes[].filter.any_label` is
+  // explicitly set in role.md, that wins; otherwise the daemon's
+  // membership-aware default applies. This makes "what labels does
+  // agent X listen on?" a property of the loaded identity rather than
+  // a daemon-boot concern, so dashboards / `agents` CLI / signals tests
+  // all read from the same single source of truth.
+  const derivedAnyLabel = buildAgentRoutingLabels(
+    frontmatter.agent_id,
+    frontmatter.group_memberships,
+  );
   const signalScopes =
     frontmatter.signals.github_scopes !== undefined
       ? {
@@ -294,7 +311,7 @@ export const registeredAgentFromLoadedIdentity = (
               state: s.filter.state,
               ...(s.filter.since_days !== undefined ? { sinceDays: s.filter.since_days } : {}),
               ...(s.filter.labels !== undefined ? { labels: s.filter.labels } : {}),
-              ...(s.filter.any_label !== undefined ? { anyLabel: s.filter.any_label } : {}),
+              anyLabel: s.filter.any_label ?? derivedAnyLabel,
             },
           })),
         }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -28,6 +28,7 @@ import {
   makeAgentId,
   makeGroupId,
   makeWakeId,
+  SpawnError,
   type AgentExecutor,
   type AgentResult,
   type AgentSpawnContext,
@@ -1014,13 +1015,17 @@ export class Daemon {
         }
       }
     } catch (error) {
-      this.#agentStateStore?.recordWakeOutcome(event.wakeId.value, "failure", {
+      const isSpawnFailure = error instanceof SpawnError;
+      const outcome = isSpawnFailure ? "spawn-failed" : "failure";
+      this.#agentStateStore?.recordWakeOutcome(event.wakeId.value, outcome, {
         errorMessage: error instanceof Error ? error.message : String(error),
       });
-      this.#logger.error("daemon.wake.error", {
+      const logEvent = isSpawnFailure ? "daemon.wake.spawn-failed" : "daemon.wake.error";
+      this.#logger.error(logEvent, {
         agentId: agent.agentId,
         wakeId: event.wakeId.value,
         error: error instanceof Error ? error.message : String(error),
+        ...(isSpawnFailure ? { hint: "verify the agent CLI binary is installed and on PATH" } : {}),
       });
     }
   }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -1314,12 +1314,13 @@ const buildSpawnContext = async (
   const agentId = makeAgentId(agent.agentId);
   const groupIds: GroupId[] = agent.groupMemberships.map((c) => makeGroupId(c));
 
-  // Phase 1A: a minimal resolved model placeholder. Phase 1B reads
-  // murmuration/models.yaml to resolve tier → concrete model.
+  // Resolve from role.md llm config when present; fall back to
+  // provider:"unknown" so cost reporting shows a real provider name
+  // rather than the legacy "placeholder" stub (#326).
   const model: ResolvedModel = {
     tier: agent.modelTier,
-    provider: "placeholder",
-    model: "phase-1a-stub",
+    provider: agent.llm?.provider ?? "unknown",
+    model: agent.llm?.model ?? "unknown",
     maxTokens: 4096,
   };
 

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -170,7 +170,14 @@ export interface RegisteredAgent {
       readonly filter: {
         readonly state: "open" | "closed" | "all";
         readonly sinceDays?: number;
+        /** AND-semantics — every label must be present. */
         readonly labels?: readonly string[];
+        /**
+         * OR-semantics — any one label matching is sufficient.
+         * Daemon auto-derives membership-aware routing labels here
+         * unless operator overrides via `signals.github_scopes[].filter.any_label`.
+         */
+        readonly anyLabel?: readonly string[];
       };
     }[];
   };
@@ -287,6 +294,7 @@ export const registeredAgentFromLoadedIdentity = (
               state: s.filter.state,
               ...(s.filter.since_days !== undefined ? { sinceDays: s.filter.since_days } : {}),
               ...(s.filter.labels !== undefined ? { labels: s.filter.labels } : {}),
+              ...(s.filter.any_label !== undefined ? { anyLabel: s.filter.any_label } : {}),
             },
           })),
         }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -180,6 +180,9 @@ export interface RegisteredAgent {
          */
         readonly anyLabel?: readonly string[];
       };
+      /** Sec M1: allowlist of GitHub logins trusted to apply scope:all. */
+      readonly scopeAllTrustedAuthors?: readonly string[];
+      readonly dropScopeAllFromUntrusted?: boolean;
     }[];
   };
 
@@ -313,6 +316,12 @@ export const registeredAgentFromLoadedIdentity = (
               ...(s.filter.labels !== undefined ? { labels: s.filter.labels } : {}),
               anyLabel: s.filter.any_label ?? derivedAnyLabel,
             },
+            ...(s.scope_all_trusted_authors !== undefined
+              ? { scopeAllTrustedAuthors: s.scope_all_trusted_authors }
+              : {}),
+            ...(s.drop_scope_all_from_untrusted !== undefined
+              ? { dropScopeAllFromUntrusted: s.drop_scope_all_from_untrusted }
+              : {}),
           })),
         }
       : { sources: frontmatter.signals.sources };

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -340,6 +340,45 @@ export interface SignalBundle {
    * and gives the agent a chance to reason about signal incompleteness.
    */
   readonly warnings: readonly string[];
+  /**
+   * Structured per-query failures from multi-query fan-out (e.g. one of
+   * four `anyLabel` queries failed while the other three succeeded). The
+   * caller can distinguish "no signals match" from "signals may have been
+   * dropped by a sub-query failure." Absent or empty array when every
+   * query succeeded; populated alongside `warnings` (which carry the
+   * same info as a human-readable string) for callers that want
+   * structured access. Added in v0.7.1 (QA review of harness#331).
+   *
+   * Optional so existing callers / fixtures aren't forced to update — the
+   * aggregator always populates it; manual SignalBundle construction
+   * (tests, daemon hello-world path) may omit it.
+   */
+  readonly partialFailures?: readonly SignalAggregationFailure[];
+}
+
+/**
+ * One failed sub-query during signal aggregation. Surfaced on
+ * {@link SignalBundle.partialFailures} so the bundle's `signals` array
+ * cannot be misread as "complete and authoritative" when fan-out lost
+ * data.
+ */
+export interface SignalAggregationFailure {
+  /** Logical source name, e.g. `"github"`. */
+  readonly source: string;
+  /**
+   * Repo coordinate as `"owner/repo"` for github sources, or undefined
+   * for sources that are not repo-scoped.
+   */
+  readonly repo?: string;
+  /**
+   * The OR-label that was being filtered when the query failed (one of
+   * the values in `anyLabel`). Undefined for non-fan-out failures.
+   */
+  readonly anyLabel?: string;
+  /** Stable error code for caller pattern-matching (e.g. `"http-500"`). */
+  readonly code: string;
+  /** Human-readable detail. */
+  readonly detail: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -1,4 +1,5 @@
 import type { WakeCostRecord } from "../cost/record.js";
+import { SOURCE_DIRECTIVE_LABEL } from "../labels/index.js";
 
 /**
  * Agent execution — the pluggable boundary between the harness daemon and
@@ -568,8 +569,6 @@ export interface WakeValidationResult {
   /** If not productive, why. */
   readonly reason?: string;
 }
-
-const SOURCE_DIRECTIVE_LABEL = "source-directive";
 
 type GithubIssueSignal = Extract<Signal, { kind: "github-issue" }>;
 

--- a/packages/core/src/execution/subprocess.test.ts
+++ b/packages/core/src/execution/subprocess.test.ts
@@ -134,7 +134,7 @@ describe("SubprocessExecutor", () => {
     expect(result.costRecord?.subprocess?.maxRssKb).toBeGreaterThan(0);
     // LLM and github fields are stubs in Phase 1.
     expect(result.costRecord?.llm.inputTokens).toBe(0);
-    expect(result.costRecord?.llm.modelProvider).toBe("placeholder");
+    expect(result.costRecord?.llm.modelProvider).toBe("unknown");
     expect(result.costRecord?.github.restCalls).toBe(0);
     expect(result.costRecord?.totals.costMicros.value).toBe(0);
     expect(result.costRecord?.budget).toBeNull();

--- a/packages/core/src/governance/closure.ts
+++ b/packages/core/src/governance/closure.ts
@@ -29,6 +29,8 @@
  * @see docs/specs/0001-agent-effectiveness.md §4.2 (closure rules)
  */
 
+import { VERIFICATION_FAILED_LABEL } from "../labels/index.js";
+
 import type {
   ClosureEvidence,
   ClosureVerificationResult,
@@ -36,6 +38,10 @@ import type {
   GovernancePlugin,
   IssueSnapshot,
 } from "./index.js";
+
+// Re-export for callers that previously imported from this module.
+// New callers should import directly from "@murmurations-ai/core".
+export { AWAITING_SOURCE_CLOSE_LABEL, VERIFICATION_FAILED_LABEL } from "../labels/index.js";
 
 // ---------------------------------------------------------------------------
 // Issue-type closer table
@@ -149,10 +155,6 @@ export const verifyClosure = (
 // ---------------------------------------------------------------------------
 // Verification-failure ladder
 // ---------------------------------------------------------------------------
-
-/** Labels the facilitator applies in the verification ladder. */
-export const VERIFICATION_FAILED_LABEL = "verification-failed";
-export const AWAITING_SOURCE_CLOSE_LABEL = "awaiting:source-close";
 
 /**
  * Outcome of a closure attempt — what the facilitator should do next.

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -864,6 +864,27 @@ export interface GovernancePlugin {
   closerFor?(issueType: string): CloserRole | undefined;
 
   /**
+   * v0.7.1 — Declare the label strings owned by this governance plugin.
+   * The harness uses this to let plugins participate in the label
+   * vocabulary without hardcoding plugin-specific labels in core.
+   *
+   * Returns a flat list of label strings the plugin writes to (or reads
+   * from) GitHub issues. Examples: S3 returns `["tier:autonomous",
+   * "tier:notify", "tier:consent"]`; chain-of-command might return
+   * `["decision:approved", "decision:rejected"]`.
+   *
+   * The daemon logs the vocabulary at startup. Future tooling will
+   * enforce that these strings don't appear as literals in core.
+   *
+   * Return an empty array (or omit the method) when the plugin writes
+   * no plugin-specific labels.
+   *
+   * @see packages/core/src/labels/index.ts — S3 labels currently live
+   *      there pending v0.8.0 migration to the S3 plugin
+   */
+  labelVocabulary?(): readonly string[];
+
+  /**
    * Optional hook called once when the daemon starts. Unlike
    * {@link onEventsEmitted} and {@link evaluateAction}, this receives the
    * full mutable store so the plugin can register state graphs via
@@ -893,6 +914,10 @@ export class NoOpGovernancePlugin implements GovernancePlugin {
   public readonly version = "1.0.0";
 
   public stateGraphs(): readonly GovernanceStateGraph[] {
+    return [];
+  }
+
+  public labelVocabulary(): readonly string[] {
     return [];
   }
 

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -616,6 +616,53 @@ describe("roleFrontmatterSchema (ADR-0016 extensions)", () => {
     await expect(loader.load("bad-repo")).rejects.toThrow(FrontmatterInvalidError);
   });
 
+  it("rejects any_label arrays longer than 16 entries (Sec M3)", async () => {
+    const labelLines = Array.from({ length: 17 }, (_, i) => `          - "label-${String(i)}"`);
+    await writeMinimalFixture(
+      "too-many-labels",
+      [
+        'agent_id: "too-many-labels"',
+        'name: "Too Many"',
+        "model_tier: fast",
+        "signals:",
+        "  sources:",
+        '    - "github-issue"',
+        "  github_scopes:",
+        '    - owner: "acme"',
+        '      repo: "signals"',
+        "      filter:",
+        "        any_label:",
+        ...labelLines,
+      ].join("\n"),
+    );
+    const loader = new IdentityLoader({ rootDir });
+    await expect(loader.load("too-many-labels")).rejects.toThrow(FrontmatterInvalidError);
+  });
+
+  it("accepts any_label arrays of exactly 16 entries (Sec M3)", async () => {
+    const labelLines = Array.from({ length: 16 }, (_, i) => `          - "label-${String(i)}"`);
+    await writeMinimalFixture(
+      "max-labels",
+      [
+        'agent_id: "max-labels"',
+        'name: "Max Labels"',
+        "model_tier: fast",
+        "signals:",
+        "  sources:",
+        '    - "github-issue"',
+        "  github_scopes:",
+        '    - owner: "acme"',
+        '      repo: "signals"',
+        "      filter:",
+        "        any_label:",
+        ...labelLines,
+      ].join("\n"),
+    );
+    const loader = new IdentityLoader({ rootDir });
+    const loaded = await loader.load("max-labels");
+    expect(loaded.frontmatter.signals.github_scopes?.[0]?.filter.any_label).toHaveLength(16);
+  });
+
   it("tools defaults to empty mcp/cli when omitted (backwards compat)", async () => {
     await writeMinimalFixture(
       "no-tools",

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -303,7 +303,21 @@ const githubFilterSchema = z
   .object({
     state: z.enum(["open", "closed", "all"]).default("all"),
     since_days: z.number().int().positive().optional(),
+    /**
+     * AND-semantics: every label in this list must be present on the
+     * issue. GitHub's listIssues API enforces this at query time.
+     */
     labels: z.array(z.string().min(1)).optional(),
+    /**
+     * OR-semantics: any one of these labels matching is sufficient.
+     * Implemented as multiple listIssues queries (one per label) with
+     * client-side deduplication by issue number — GitHub's API doesn't
+     * support OR natively. Used by the daemon to inject membership-aware
+     * routing (assigned:<self>, scope:agent:<self>, scope:group:<g>...,
+     * scope:all) automatically; operators can override if their
+     * routing vocabulary differs.
+     */
+    any_label: z.array(z.string().min(1)).optional(),
   })
   .strict();
 

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -317,7 +317,7 @@ const githubFilterSchema = z
      * scope:all) automatically; operators can override if their
      * routing vocabulary differs.
      */
-    any_label: z.array(z.string().min(1)).optional(),
+    any_label: z.array(z.string().min(1)).max(16).optional(),
   })
   .strict();
 
@@ -326,6 +326,9 @@ const githubScopeSchema = z
     owner: z.string().min(1),
     repo: z.string().min(1),
     filter: githubFilterSchema.default({ state: "all" }),
+    /** Sec M1: allowlist of GitHub logins trusted to apply scope:all. */
+    scope_all_trusted_authors: z.array(z.string().min(1)).optional(),
+    drop_scope_all_from_untrusted: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,3 +62,4 @@ export * from "./done-criteria/index.js";
 export * from "./metrics/effectiveness.js";
 export * from "./metrics/observations.js";
 export * from "./metrics/disk-snapshot.js";
+export * from "./labels/index.js";

--- a/packages/core/src/labels/index.ts
+++ b/packages/core/src/labels/index.ts
@@ -96,6 +96,41 @@ export const isAssignedLabel = (label: string): boolean => label.startsWith("ass
 /** True if the label is any kind of `scope:<...>` directive routing label. */
 export const isScopeLabel = (label: string): boolean => label.startsWith("scope:");
 
+/**
+ * True if the label is reserved for Source / harness-internal use and
+ * MUST NOT be written by an agent action.
+ *
+ * Reserved set:
+ *   - `source-directive` — promotes an issue to directive trust at every
+ *     downstream agent in the routing OR-set. Only Source (via the
+ *     `murmuration directive` CLI) writes this.
+ *   - `kickoff` — onboarding workflow trigger; only Source / Spirit writes.
+ *   - `scope:*` — routing labels for directive distribution. Combined with
+ *     `source-directive` they form the lateral-movement channel; agents
+ *     route work via `assigned:<id>` / `action-item` instead.
+ *
+ * Allowed for agent writes (NOT reserved):
+ *   - `assigned:<id>` and `action-item` — the legitimate work-routing
+ *     vocabulary used by group facilitators and the closure ladder.
+ *   - `awaiting:source-close`, `verification-failed` — written by the
+ *     closure verification ladder during normal agent operation.
+ *
+ * Lateral-movement defense (security review H1, harness#331 follow-up):
+ * the membership-aware aggregator now actively listens for `scope:*`
+ * labels, so the write-side must refuse agent-originated writes of those
+ * labels to prevent agent-to-agent directive forgery.
+ */
+export const isReservedLabel = (label: string): boolean =>
+  label === SOURCE_DIRECTIVE_LABEL || label === KICKOFF_LABEL || isScopeLabel(label);
+
+/**
+ * Returns the subset of `labels` that are reserved per `isReservedLabel`.
+ * Used by WakeAction / MeetingAction dispatchers to reject agent-originated
+ * writes of routing labels.
+ */
+export const findReservedLabels = (labels: readonly string[]): readonly string[] =>
+  labels.filter(isReservedLabel);
+
 /** Returns the agent-id from `assigned:<agent-id>`, or null if not a match. */
 export const parseAssignedLabel = (label: string): string | null =>
   label.startsWith("assigned:") ? label.slice("assigned:".length) : null;

--- a/packages/core/src/labels/index.ts
+++ b/packages/core/src/labels/index.ts
@@ -1,0 +1,159 @@
+/**
+ * Label vocabulary library — single source of truth for every label
+ * string the harness writes or matches on GitHub issues.
+ *
+ * Why this exists:
+ *
+ * Before this module, label strings drifted across the codebase. Eight
+ * separate sites wrote `"source-directive"` as a literal. Two packages
+ * each defined their own `AWAITING_SOURCE_CLOSE_LABEL` constant — and
+ * one of them was already misspelled relative to the other. The cost
+ * showed up at runtime: directives written with `scope:agent:<id>` were
+ * invisible to a signal aggregator filter looking for `assigned:<id>`,
+ * because the two halves of the codebase had drifted to incompatible
+ * vocabularies (chinook-wind live test, 2026-05-05).
+ *
+ * Rule going forward:
+ *
+ * **NO PACKAGE MAY HARDCODE A LABEL STRING.** Import from this module —
+ * either a constant for fixed labels, a factory for parameterized labels,
+ * or a predicate for matching. If a new label is needed, add it here
+ * first, then use it. The lint rule (Workstream — TBD) will eventually
+ * fail any source file that contains a label-shaped literal.
+ *
+ * Scope:
+ *
+ * The labels in this module are *harness-universal* — they apply to
+ * every murmuration regardless of governance plugin. Plugin-specific
+ * labels (e.g. S3's `tier:autonomous`/`tier:notify`/`tier:consent`)
+ * are exposed here for now because they're written by enough call
+ * sites that drift was a real risk; long-term they should migrate
+ * to a `GovernancePlugin.labelVocabulary()` interface so plugins
+ * own their own label namespace. Tracked as a follow-up.
+ */
+
+// ---------------------------------------------------------------------------
+// Static labels — fixed strings with no parameters.
+// ---------------------------------------------------------------------------
+
+/** Source-issued directive (filed via `murmuration directive`). */
+export const SOURCE_DIRECTIVE_LABEL = "source-directive";
+
+/** Work assignment for an agent — used by signal aggregator action-item partitioning. */
+export const ACTION_ITEM_LABEL = "action-item";
+
+/** Item is closed by the agent but waiting for Source to confirm/close. */
+export const AWAITING_SOURCE_CLOSE_LABEL = "awaiting:source-close";
+
+/** Directive scope: every agent in the murmuration. */
+export const SCOPE_ALL_LABEL = "scope:all";
+
+/** Onboarding kickoff workflow (used by #332 source-onboarding skill). */
+export const KICKOFF_LABEL = "kickoff";
+
+/**
+ * Closure verification ladder: applied when a facilitator attempts to
+ * close an action item but the agent's `done_when` evidence didn't
+ * verify. Second consecutive failure escalates to `awaiting:source-close`.
+ */
+export const VERIFICATION_FAILED_LABEL = "verification-failed";
+
+// ---------------------------------------------------------------------------
+// Factories — labels parameterized by agent / group / kind.
+// ---------------------------------------------------------------------------
+
+/**
+ * Action-item routing label. Issues tagged with this label appear in
+ * the agent's `actionItems` partition of its signal bundle.
+ *
+ * @example assignedLabel("rentals-agent") → "assigned:rentals-agent"
+ */
+export const assignedLabel = (agentId: string): string => `assigned:${agentId}`;
+
+/**
+ * Per-agent directive scope label. Routes a Source directive to a
+ * specific agent's signal bundle.
+ *
+ * @example scopeAgentLabel("rentals-agent") → "scope:agent:rentals-agent"
+ */
+export const scopeAgentLabel = (agentId: string): string => `scope:agent:${agentId}`;
+
+/**
+ * Per-group directive scope label. Routes a Source directive to every
+ * agent that lists the group in its `role.md` `group_memberships`.
+ *
+ * @example scopeGroupLabel("partnership") → "scope:group:partnership"
+ */
+export const scopeGroupLabel = (groupId: string): string => `scope:group:${groupId}`;
+
+// ---------------------------------------------------------------------------
+// Predicates + parsers — for matching and extraction.
+// ---------------------------------------------------------------------------
+
+/** True if the label is any kind of `assigned:<...>` action-item routing label. */
+export const isAssignedLabel = (label: string): boolean => label.startsWith("assigned:");
+
+/** True if the label is any kind of `scope:<...>` directive routing label. */
+export const isScopeLabel = (label: string): boolean => label.startsWith("scope:");
+
+/** Returns the agent-id from `assigned:<agent-id>`, or null if not a match. */
+export const parseAssignedLabel = (label: string): string | null =>
+  label.startsWith("assigned:") ? label.slice("assigned:".length) : null;
+
+/** Returns the agent-id from `scope:agent:<agent-id>`, or null if not a match. */
+export const parseScopeAgentLabel = (label: string): string | null =>
+  label.startsWith("scope:agent:") ? label.slice("scope:agent:".length) : null;
+
+/** Returns the group-id from `scope:group:<group-id>`, or null if not a match. */
+export const parseScopeGroupLabel = (label: string): string | null =>
+  label.startsWith("scope:group:") ? label.slice("scope:group:".length) : null;
+
+// ---------------------------------------------------------------------------
+// Routing — membership-aware label set for an agent.
+// ---------------------------------------------------------------------------
+
+/**
+ * The complete set of routing labels that an agent should match on
+ * when polling GitHub for relevant work. Used by the signal aggregator
+ * to filter issues membership-aware (chinook-wind live-test fix,
+ * harness#331 / #235).
+ *
+ * Order: most-specific first (action items addressed to this agent),
+ * then directive scopes (per-agent, per-group, broadcast). The
+ * aggregator queries each label independently and dedupes by issue
+ * number, so the order here doesn't affect correctness — it only
+ * affects which query fires first when scopes are batched.
+ *
+ * @example buildAgentRoutingLabels("rentals-agent", ["partnership"])
+ *   → ["assigned:rentals-agent", "scope:agent:rentals-agent",
+ *      "scope:group:partnership", "scope:all"]
+ */
+export const buildAgentRoutingLabels = (
+  agentId: string,
+  groupIds: readonly string[],
+): readonly string[] => [
+  assignedLabel(agentId),
+  scopeAgentLabel(agentId),
+  ...groupIds.map(scopeGroupLabel),
+  SCOPE_ALL_LABEL,
+];
+
+// ---------------------------------------------------------------------------
+// S3-flavored governance labels.
+//
+// These labels are written and matched by enough sites in core +
+// signals + cli that drift was a real risk before this module. They
+// live here for now even though they're S3-specific (`tier:*` is an
+// S3 vocabulary; other governance plugins use their own decision
+// taxonomies). Plugin-owned label vocabularies are a v0.8.0+ design
+// item — see `GovernancePlugin.labelVocabulary()` follow-up issue.
+// ---------------------------------------------------------------------------
+
+/** S3 decision tier: agent acts without notifying Source. */
+export const TIER_AUTONOMOUS_LABEL = "tier:autonomous";
+
+/** S3 decision tier: agent acts, then notifies Source. */
+export const TIER_NOTIFY_LABEL = "tier:notify";
+
+/** S3 decision tier: agent proposes, Source must consent before action. */
+export const TIER_CONSENT_LABEL = "tier:consent";

--- a/packages/core/src/labels/index.ts
+++ b/packages/core/src/labels/index.ts
@@ -27,9 +27,9 @@
  * every murmuration regardless of governance plugin. Plugin-specific
  * labels (e.g. S3's `tier:autonomous`/`tier:notify`/`tier:consent`)
  * are exposed here for now because they're written by enough call
- * sites that drift was a real risk; long-term they should migrate
- * to a `GovernancePlugin.labelVocabulary()` interface so plugins
- * own their own label namespace. Tracked as a follow-up.
+ * sites that drift was a real risk; v0.8.0 will migrate them into the
+ * S3 plugin via `GovernancePlugin.labelVocabulary()` (added v0.7.1,
+ * harness#337).
  */
 
 // ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ export const buildAgentRoutingLabels = (
 // live here for now even though they're S3-specific (`tier:*` is an
 // S3 vocabulary; other governance plugins use their own decision
 // taxonomies). Plugin-owned label vocabularies are a v0.8.0+ design
-// item — see `GovernancePlugin.labelVocabulary()` follow-up issue.
+// item — they will migrate to the S3 plugin's `labelVocabulary()` in v0.8.0.
 // ---------------------------------------------------------------------------
 
 /** S3 decision tier: agent acts without notifying Source. */

--- a/packages/core/src/labels/labels.test.ts
+++ b/packages/core/src/labels/labels.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTION_ITEM_LABEL,
+  AWAITING_SOURCE_CLOSE_LABEL,
+  KICKOFF_LABEL,
+  SCOPE_ALL_LABEL,
+  SOURCE_DIRECTIVE_LABEL,
+  VERIFICATION_FAILED_LABEL,
+  assignedLabel,
+  buildAgentRoutingLabels,
+  findReservedLabels,
+  isAssignedLabel,
+  isReservedLabel,
+  isScopeLabel,
+  parseAssignedLabel,
+  parseScopeAgentLabel,
+  parseScopeGroupLabel,
+  scopeAgentLabel,
+  scopeGroupLabel,
+} from "./index.js";
+
+describe("label factories and parsers", () => {
+  it("round-trips assignedLabel through parseAssignedLabel", () => {
+    expect(parseAssignedLabel(assignedLabel("rentals-agent"))).toBe("rentals-agent");
+  });
+
+  it("round-trips scopeAgentLabel through parseScopeAgentLabel", () => {
+    expect(parseScopeAgentLabel(scopeAgentLabel("facilitator-agent"))).toBe("facilitator-agent");
+  });
+
+  it("round-trips scopeGroupLabel through parseScopeGroupLabel", () => {
+    expect(parseScopeGroupLabel(scopeGroupLabel("partnership"))).toBe("partnership");
+  });
+
+  it("returns null when parser is given a non-matching label", () => {
+    expect(parseAssignedLabel("scope:agent:foo")).toBeNull();
+    expect(parseScopeAgentLabel("assigned:foo")).toBeNull();
+    expect(parseScopeGroupLabel("scope:agent:foo")).toBeNull();
+  });
+
+  it("isAssignedLabel and isScopeLabel discriminate cleanly", () => {
+    expect(isAssignedLabel(assignedLabel("a"))).toBe(true);
+    expect(isAssignedLabel(scopeAgentLabel("a"))).toBe(false);
+    expect(isScopeLabel(scopeAgentLabel("a"))).toBe(true);
+    expect(isScopeLabel(scopeGroupLabel("g"))).toBe(true);
+    expect(isScopeLabel(SCOPE_ALL_LABEL)).toBe(true);
+    expect(isScopeLabel(assignedLabel("a"))).toBe(false);
+  });
+});
+
+describe("buildAgentRoutingLabels", () => {
+  it("returns the OR-set of labels an agent should match", () => {
+    expect(buildAgentRoutingLabels("rentals-agent", ["partnership"])).toStrictEqual([
+      "assigned:rentals-agent",
+      "scope:agent:rentals-agent",
+      "scope:group:partnership",
+      "scope:all",
+    ]);
+  });
+
+  it("works with no group memberships", () => {
+    expect(buildAgentRoutingLabels("solo-agent", [])).toStrictEqual([
+      "assigned:solo-agent",
+      "scope:agent:solo-agent",
+      "scope:all",
+    ]);
+  });
+
+  it("preserves group order", () => {
+    expect(buildAgentRoutingLabels("a", ["g1", "g2", "g3"])).toStrictEqual([
+      "assigned:a",
+      "scope:agent:a",
+      "scope:group:g1",
+      "scope:group:g2",
+      "scope:group:g3",
+      "scope:all",
+    ]);
+  });
+});
+
+describe("isReservedLabel — Security H1 lateral-movement defense", () => {
+  it("reserves source-directive (the directive trust label)", () => {
+    expect(isReservedLabel(SOURCE_DIRECTIVE_LABEL)).toBe(true);
+  });
+
+  it("reserves kickoff (Source-only onboarding label)", () => {
+    expect(isReservedLabel(KICKOFF_LABEL)).toBe(true);
+  });
+
+  it("reserves all scope:* labels (the routing OR-set the aggregator listens for)", () => {
+    expect(isReservedLabel(SCOPE_ALL_LABEL)).toBe(true);
+    expect(isReservedLabel(scopeAgentLabel("any-agent"))).toBe(true);
+    expect(isReservedLabel(scopeGroupLabel("any-group"))).toBe(true);
+  });
+
+  it("does NOT reserve assigned:* (legitimate work-routing label)", () => {
+    expect(isReservedLabel(assignedLabel("rentals-agent"))).toBe(false);
+  });
+
+  it("does NOT reserve action-item (created by meeting facilitators)", () => {
+    expect(isReservedLabel(ACTION_ITEM_LABEL)).toBe(false);
+  });
+
+  it("does NOT reserve closure-ladder labels (written by agents during normal operation)", () => {
+    expect(isReservedLabel(AWAITING_SOURCE_CLOSE_LABEL)).toBe(false);
+    expect(isReservedLabel(VERIFICATION_FAILED_LABEL)).toBe(false);
+  });
+
+  it("does NOT reserve arbitrary operator labels", () => {
+    expect(isReservedLabel("priority:high")).toBe(false);
+    expect(isReservedLabel("type: tension")).toBe(false);
+    expect(isReservedLabel("good-first-issue")).toBe(false);
+  });
+
+  it("findReservedLabels returns only the reserved subset", () => {
+    expect(
+      findReservedLabels([
+        ACTION_ITEM_LABEL,
+        assignedLabel("a"),
+        SOURCE_DIRECTIVE_LABEL,
+        SCOPE_ALL_LABEL,
+        "priority:high",
+      ]),
+    ).toStrictEqual([SOURCE_DIRECTIVE_LABEL, SCOPE_ALL_LABEL]);
+  });
+
+  it("findReservedLabels returns empty when no labels are reserved", () => {
+    expect(findReservedLabels([ACTION_ITEM_LABEL, assignedLabel("a"), "priority:high"])).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -23,6 +23,7 @@ import { join, resolve, dirname } from "node:path";
 
 import { runsDirForAgent } from "../daemon/runs-path.js";
 import { parseSelfReflection } from "../execution/index.js";
+import { SOURCE_DIRECTIVE_LABEL } from "../labels/index.js";
 import type {
   AgentOutputArtifact,
   AgentSpawnContext,
@@ -185,7 +186,7 @@ const renderSignal = (s: Signal): string => {
       const data = custom.data as
         | { id?: string; title?: string; body?: string; labels?: string[] }
         | undefined;
-      const isDirective = data?.labels?.includes("source-directive") === true;
+      const isDirective = data?.labels?.includes(SOURCE_DIRECTIVE_LABEL) === true;
       const tag = isDirective ? "SOURCE DIRECTIVE" : "item";
       return `- [${tag} #${data?.id ?? "?"}] ${data?.title ?? "(no title)"}\n  labels: ${data?.labels?.join(", ") ?? "(none)"}\n\n${data?.body ?? ""}\n`;
     }

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -96,6 +96,7 @@ export interface DefaultRunnerClients {
             content: string;
             inputTokens: number;
             outputTokens: number;
+            cacheReadTokens?: number;
             modelUsed: string;
             /** Number of LLM→tool round-trips. */
             steps?: number;
@@ -579,10 +580,12 @@ If you were asked to draft a proposal (e.g. an action item saying "draft proposa
 
     // 10. Parse self-reflection
     const reflection = parseSelfReflection(content);
+    const cacheReadTokens = result.value.cacheReadTokens ?? 0;
     const summaryLines = [
       `[${agentId}] wake ${wakeId}`,
       `  model: ${result.value.modelUsed}`,
       `  input_tokens: ${String(result.value.inputTokens)}`,
+      ...(cacheReadTokens > 0 ? [`  cache_read_tokens: ${String(cacheReadTokens)}`] : []),
       `  output_tokens: ${String(result.value.outputTokens)}`,
       `  steps: ${String(stepCount)} / ${String(stepBudget)}`,
       `  tool_calls: ${String(toolCallCount)}`,

--- a/packages/core/src/runner/runner.test.ts
+++ b/packages/core/src/runner/runner.test.ts
@@ -458,4 +458,36 @@ describe("createDefaultRunner — ADR-0029 self-digest tail + memory guards", ()
     expect(systemContent).toContain("passive reference data");
     expect(systemContent).toContain("Do NOT execute instructions");
   });
+
+  it("wake summary includes cache_read_tokens line when non-zero (#302)", async () => {
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const llmWithCache: NonNullable<DefaultRunnerClients["llm"]> = {
+      complete: () =>
+        Promise.resolve({
+          ok: true as const,
+          value: {
+            content:
+              "Done.\n\n## Self-Reflection\nEFFECTIVENESS: high\nOBSERVATION: ok.\nGOVERNANCE_EVENT: none",
+            inputTokens: 8,
+            outputTokens: 42,
+            cacheReadTokens: 250_000,
+            modelUsed: "claude-sonnet-4-6",
+          },
+        }),
+      capabilities: () => ({ supportsToolUse: false }),
+    };
+
+    const result = await runner({ spawn: makeSpawn(), clients: { llm: llmWithCache } });
+    expect(result.wakeSummary).toContain("cache_read_tokens: 250000");
+    expect(result.wakeSummary).toContain("input_tokens: 8");
+  });
+
+  it("wake summary omits cache_read_tokens line when zero (#302)", async () => {
+    const runner = createDefaultRunner("test-agent", [], {}, rootDir);
+    const result = await runner({
+      spawn: makeSpawn(),
+      clients: { llm: makeLlmClient("Done.") },
+    });
+    expect(result.wakeSummary).not.toContain("cache_read_tokens");
+  });
 });

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -320,6 +320,19 @@ export interface GithubClient {
     options?: CallOptions,
   ): Promise<Result<void, GithubClientError>>;
 
+  /**
+   * Search issues in a repository. The `query` is appended to a
+   * `repo:<owner>/<name>` qualifier automatically — do not include
+   * `repo:` in the query. Returns up to `perPage` results (default 30,
+   * max 100). Pull-request hits are filtered out server-side by
+   * appending `is:issue` to the effective query.
+   */
+  searchIssues(
+    repo: RepoCoordinate,
+    query: string,
+    options?: CallOptions & { readonly perPage?: number },
+  ): Promise<Result<readonly GithubIssue[], GithubClientError>>;
+
   lastRateLimit(): GithubRateLimitSnapshot | null;
 }
 
@@ -674,6 +687,24 @@ class GithubClientImpl implements GithubClient {
     const raw = await this.#requestMutation(url, "PATCH", { state }, options);
     if (!raw.ok) return raw;
     return { ok: true, value: undefined };
+  }
+
+  public async searchIssues(
+    repo: RepoCoordinate,
+    query: string,
+    options: CallOptions & { readonly perPage?: number } = {},
+  ): Promise<Result<readonly GithubIssue[], GithubClientError>> {
+    const q = `repo:${repo.owner.value}/${repo.name.value} is:issue ${query}`.trim();
+    const params = new URLSearchParams({ q });
+    if (options.perPage !== undefined) params.set("per_page", String(options.perPage));
+    const url = `${this.#baseUrl}/search/issues?${params.toString()}`;
+    const raw = await this.#request(url, options);
+    if (!raw.ok) return raw;
+    const body = raw.value.body;
+    if (typeof body !== "object" || body === null || !("items" in body)) {
+      return { ok: false, error: new GithubParseError("searchIssues: missing items array") };
+    }
+    return parseIssueArray((body as { items: unknown }).items, repo);
   }
 
   public async createCommitOnBranch(

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/src/cost-hook.ts
+++ b/packages/llm/src/cost-hook.ts
@@ -18,5 +18,11 @@ export interface LLMCostHook {
     readonly outputTokens: number;
     readonly cacheReadTokens?: number;
     readonly cacheWriteTokens?: number;
+    /** v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary. */
+    readonly cliPath?: string;
+    /** v0.7.1 (#280): subscription-CLI only. Spawn-to-first-byte latency in ms. */
+    readonly spawnMs?: number;
+    /** v0.7.1 (#280): subscription-CLI only. Configured subprocess timeout in ms. */
+    readonly timeoutMs?: number;
   }): void;
 }

--- a/packages/llm/src/providers/subprocess/adapters/claude.ts
+++ b/packages/llm/src/providers/subprocess/adapters/claude.ts
@@ -12,6 +12,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
+import { scrubValuePatterns } from "@murmurations-ai/core";
+
 import type { LLMRequest, LLMResponse, Result } from "../../../types.js";
 
 import type {
@@ -78,8 +80,10 @@ const normalizeModel = (raw: string | undefined): string => {
   return raw.replace(/-\d{8}$/, "");
 };
 
-const truncateForError = (raw: string): string =>
-  raw.length > 2000 ? `${raw.slice(0, 2000)}…[truncated]` : raw;
+const truncateForError = (raw: string): string => {
+  const truncated = raw.length > 2000 ? `${raw.slice(0, 2000)}…[truncated]` : raw;
+  return scrubValuePatterns(truncated);
+};
 
 // ---------------------------------------------------------------------------
 // Adapter

--- a/packages/llm/src/providers/subprocess/adapters/claude.ts
+++ b/packages/llm/src/providers/subprocess/adapters/claude.ts
@@ -146,6 +146,7 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
         ok: false,
         error: {
           kind: "parse-error",
+          code: "EMPTY_OUTPUT",
           message: "Claude CLI produced empty output",
           raw: truncateForError(raw),
         },
@@ -170,6 +171,7 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
         ok: false,
         error: {
           kind: "parse-error",
+          code: events.length === 0 ? "MALFORMED_JSON" : "NO_RESULT_EVENT",
           message: "No result event found in Claude CLI output",
           raw: truncateForError(raw),
         },
@@ -186,6 +188,7 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
         ok: false,
         error: {
           kind: "parse-error",
+          code: "TOKEN_COUNT_MISSING",
           message: "Claude CLI result missing usage.input_tokens/output_tokens (D3 violation)",
           raw: truncateForError(raw),
         },

--- a/packages/llm/src/providers/subprocess/adapters/claude.ts
+++ b/packages/llm/src/providers/subprocess/adapters/claude.ts
@@ -192,10 +192,32 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
       };
     }
 
-    // Most-recent assistant event carries the model id and (BU-1) any tool_use blocks.
+    // Accumulate tool_use blocks from ALL assistant events — not just the last.
+    // In multi-turn agentic sessions claude-cli emits one assistant event per
+    // turn; tool calls in early turns would be invisible if we only scanned
+    // lastAssistant (harness#295).
     let lastAssistant: ClaudeJsonEvent | undefined;
+    const toolCalls: { name: string; args: Record<string, unknown>; result: unknown }[] = [];
+    let assistantEventCount = 0;
     for (const e of events) {
-      if (e.type === "assistant") lastAssistant = e;
+      if (e.type === "assistant") {
+        lastAssistant = e;
+        assistantEventCount++;
+        if (e.message?.content) {
+          for (const block of e.message.content) {
+            if (block.type === "tool_use" && typeof block.name === "string") {
+              toolCalls.push({
+                name: block.name,
+                args:
+                  typeof block.input === "object" && block.input !== null
+                    ? (block.input as Record<string, unknown>)
+                    : {},
+                result: null,
+              });
+            }
+          }
+        }
+      }
     }
 
     // v0.7.0 (harness#293): capture session_id for resume. Claude CLI
@@ -207,22 +229,6 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
         ? resultEvent.session_id
         : (events.find((e) => e.type === "system" && typeof e.session_id === "string")
             ?.session_id ?? undefined);
-
-    const toolCalls: { name: string; args: Record<string, unknown>; result: unknown }[] = [];
-    if (lastAssistant?.message?.content) {
-      for (const block of lastAssistant.message.content) {
-        if (block.type === "tool_use" && typeof block.name === "string") {
-          toolCalls.push({
-            name: block.name,
-            args:
-              typeof block.input === "object" && block.input !== null
-                ? (block.input as Record<string, unknown>)
-                : {},
-            result: null,
-          });
-        }
-      }
-    }
 
     const response: LLMResponse = {
       content: resultEvent.result ?? "",
@@ -238,7 +244,7 @@ export class ClaudeCliAdapter implements SubprocessLLMAdapter {
       modelUsed: normalizeModel(lastAssistant?.message?.model),
       providerUsed: this.providerId,
       toolCalls,
-      steps: 1,
+      steps: Math.max(1, assistantEventCount),
       ...(sessionId !== undefined ? { sessionId } : {}),
     };
     return { ok: true, value: response };

--- a/packages/llm/src/providers/subprocess/adapters/claude.ts
+++ b/packages/llm/src/providers/subprocess/adapters/claude.ts
@@ -100,16 +100,25 @@ export interface ClaudeCliAdapterConfig {
   readonly mcpConfigPath?: string;
   /** ADR-0036: only `trusted` emits Claude's native auto-approve flag. */
   readonly permissionMode?: SubscriptionCliPermissionMode;
+  /**
+   * Absolute path to the `claude` binary. When set, used verbatim in
+   * spawn() instead of relying on PATH resolution. Critical for launchd /
+   * cron environments where PATH is minimal and doesn't include
+   * user-specific install locations (e.g. ~/.local/bin). Resolved at
+   * daemon boot via `resolveCliBinaryPath()` in boot.ts (harness#XXX).
+   */
+  readonly cliPath?: string;
 }
 
 export class ClaudeCliAdapter implements SubprocessLLMAdapter {
-  public readonly command = "claude";
+  public readonly command: string;
   public readonly providerId = "claude-cli";
 
   readonly #mcpConfigPath: string | undefined;
   readonly #permissionMode: SubscriptionCliPermissionMode;
 
   public constructor(config: ClaudeCliAdapterConfig = {}) {
+    this.command = config.cliPath ?? "claude";
     this.#mcpConfigPath = config.mcpConfigPath;
     this.#permissionMode = config.permissionMode ?? "restricted";
   }

--- a/packages/llm/src/providers/subprocess/adapters/codex.ts
+++ b/packages/llm/src/providers/subprocess/adapters/codex.ts
@@ -56,12 +56,18 @@ interface CodexEvent {
 }
 
 export class CodexCliAdapter implements SubprocessLLMAdapter {
-  public readonly command = "codex";
+  public readonly command: string;
   public readonly providerId = "codex-cli";
 
   readonly #permissionMode: SubscriptionCliPermissionMode;
 
-  public constructor(config: { readonly permissionMode?: SubscriptionCliPermissionMode } = {}) {
+  public constructor(
+    config: {
+      readonly permissionMode?: SubscriptionCliPermissionMode;
+      readonly cliPath?: string;
+    } = {},
+  ) {
+    this.command = config.cliPath ?? "codex";
     this.#permissionMode = config.permissionMode ?? "restricted";
   }
 

--- a/packages/llm/src/providers/subprocess/adapters/gemini.ts
+++ b/packages/llm/src/providers/subprocess/adapters/gemini.ts
@@ -60,12 +60,18 @@ interface GeminiOutput {
 }
 
 export class GeminiCliAdapter implements SubprocessLLMAdapter {
-  public readonly command = "gemini";
+  public readonly command: string;
   public readonly providerId = "gemini-cli";
 
   readonly #permissionMode: SubscriptionCliPermissionMode;
 
-  public constructor(config: { readonly permissionMode?: SubscriptionCliPermissionMode } = {}) {
+  public constructor(
+    config: {
+      readonly permissionMode?: SubscriptionCliPermissionMode;
+      readonly cliPath?: string;
+    } = {},
+  ) {
+    this.command = config.cliPath ?? "gemini";
     this.#permissionMode = config.permissionMode ?? "restricted";
   }
 

--- a/packages/llm/src/providers/subprocess/base-client.ts
+++ b/packages/llm/src/providers/subprocess/base-client.ts
@@ -17,6 +17,8 @@
 
 import { spawn } from "node:child_process";
 
+import { scrubValuePatterns } from "@murmurations-ai/core";
+
 import type { LLMClientError } from "../../errors.js";
 import {
   LLMInternalError,
@@ -235,7 +237,7 @@ export class SubprocessAdapter implements LLMAdapter {
         // immediately so MCP startup errors / auth prompts / hang causes
         // surface in the wake log even when the subprocess never exits.
         process.stderr.write(
-          `${JSON.stringify({ ts: new Date().toISOString(), level: "info", event: "subprocess.stderr.chunk", bytes: s.length, text: s.slice(0, 800) })}\n`,
+          `${JSON.stringify({ ts: new Date().toISOString(), level: "info", event: "subprocess.stderr.chunk", bytes: s.length, text: scrubValuePatterns(s.slice(0, 800)) })}\n`,
         );
       });
 
@@ -294,7 +296,7 @@ export class SubprocessAdapter implements LLMAdapter {
         clearTimeout(termTimer);
         if (abort) abort.removeEventListener("abort", onAbort);
         process.stderr.write(
-          `${JSON.stringify({ ts: new Date().toISOString(), level: "info", event: "subprocess.close", exitCode: code, timedOut, stdoutBytes: stdout.length, stderrBytes: stderr.length, stderrSnippet: stderr.slice(0, 500) })}\n`,
+          `${JSON.stringify({ ts: new Date().toISOString(), level: "info", event: "subprocess.close", exitCode: code, timedOut, stdoutBytes: stdout.length, stderrBytes: stderr.length, stderrSnippet: scrubValuePatterns(stderr.slice(0, 500)) })}\n`,
         );
 
         if (timedOut) {

--- a/packages/llm/src/providers/subprocess/base-client.ts
+++ b/packages/llm/src/providers/subprocess/base-client.ts
@@ -135,6 +135,11 @@ export class SubprocessAdapter implements LLMAdapter {
           ...(internal.value.cacheWriteTokens !== undefined
             ? { cacheWriteTokens: internal.value.cacheWriteTokens }
             : {}),
+          ...(internal.value.cliPath !== undefined ? { cliPath: internal.value.cliPath } : {}),
+          ...(internal.value.spawnMs !== undefined ? { spawnMs: internal.value.spawnMs } : {}),
+          ...(internal.value.timeoutMs !== undefined
+            ? { timeoutMs: internal.value.timeoutMs }
+            : {}),
         });
       }
       return internal;
@@ -160,11 +165,19 @@ export class SubprocessAdapter implements LLMAdapter {
     const flags = [...this.#cli.buildFlags(requestWithModel)];
     const prompt = renderPrompt(request);
 
+    // Capture the CLI path before entering the Promise so the resolved
+    // command is available inside the settle closure even if 'this' is GC'd.
+    const cliPath = this.#cli.command;
+    const timeoutMs = this.#timeoutMs;
+
     return new Promise((resolve) => {
       let stdout = "";
       let stderr = "";
       let timedOut = false;
       let settled = false;
+      // v0.7.1 (#280): spawn-to-first-byte latency.
+      const spawnStartMs = Date.now();
+      let firstByteMs: number | undefined;
 
       const settle = (result: Result<LLMResponse, SubprocessError>): void => {
         if (settled) return;
@@ -229,6 +242,7 @@ export class SubprocessAdapter implements LLMAdapter {
 
       childStdout.on("data", (chunk: Buffer) => {
         stdout += chunk.toString("utf8");
+        firstByteMs ??= Date.now();
       });
       childStderr.on("data", (chunk: Buffer) => {
         const s = chunk.toString("utf8");
@@ -351,7 +365,20 @@ export class SubprocessAdapter implements LLMAdapter {
         }
 
         const parsed = this.#cli.parseOutput(stdout);
-        settle(parsed);
+        if (parsed.ok) {
+          const spawnMs = firstByteMs !== undefined ? firstByteMs - spawnStartMs : undefined;
+          settle({
+            ok: true,
+            value: {
+              ...parsed.value,
+              cliPath,
+              ...(spawnMs !== undefined ? { spawnMs } : {}),
+              timeoutMs,
+            },
+          });
+        } else {
+          settle(parsed);
+        }
       });
 
       child.on("error", (err) => {

--- a/packages/llm/src/providers/subprocess/index.ts
+++ b/packages/llm/src/providers/subprocess/index.ts
@@ -87,6 +87,14 @@ export interface SubscriptionCliClientConfig {
    * must be selected explicitly for dogfooding environments.
    */
   readonly permissionMode?: SubscriptionCliPermissionMode;
+  /**
+   * Absolute path to the CLI binary. When set, used verbatim in spawn()
+   * instead of relying on PATH resolution. Resolved at daemon boot via
+   * `resolveCliBinaryPath()` in boot.ts so that launchd / cron / systemd
+   * environments (which have a minimal PATH that omits user-specific
+   * install locations like ~/.local/bin) can still find the binary.
+   */
+  readonly cliPath?: string;
 }
 
 const buildAdapter = (
@@ -98,14 +106,17 @@ const buildAdapter = (
       return new ClaudeCliAdapter({
         ...(config.mcpConfigPath !== undefined ? { mcpConfigPath: config.mcpConfigPath } : {}),
         ...(config.permissionMode !== undefined ? { permissionMode: config.permissionMode } : {}),
+        ...(config.cliPath !== undefined ? { cliPath: config.cliPath } : {}),
       });
     case "gemini":
       return new GeminiCliAdapter({
         ...(config.permissionMode !== undefined ? { permissionMode: config.permissionMode } : {}),
+        ...(config.cliPath !== undefined ? { cliPath: config.cliPath } : {}),
       });
     case "codex":
       return new CodexCliAdapter({
         ...(config.permissionMode !== undefined ? { permissionMode: config.permissionMode } : {}),
+        ...(config.cliPath !== undefined ? { cliPath: config.cliPath } : {}),
       });
   }
 };

--- a/packages/llm/src/providers/subprocess/index.ts
+++ b/packages/llm/src/providers/subprocess/index.ts
@@ -19,6 +19,7 @@ export type {
   AuthError,
   AuthStatus,
   ParseError,
+  ParseErrorCode,
   SpawnError,
   SubprocessError,
   SubprocessLLMAdapter,

--- a/packages/llm/src/providers/subprocess/subprocess.test.ts
+++ b/packages/llm/src/providers/subprocess/subprocess.test.ts
@@ -262,7 +262,7 @@ ${JSON.stringify({ type: "result", result: "ok", usage: { input_tokens: 1, outpu
     expect(out.ok).toBe(true);
   });
 
-  it("extracts tool_use blocks from the most recent assistant event (BU-1)", () => {
+  it("extracts tool_use blocks from ALL assistant events (harness#295)", () => {
     const withTools = [
       JSON.stringify({
         type: "assistant",
@@ -271,6 +271,13 @@ ${JSON.stringify({ type: "result", result: "ok", usage: { input_tokens: 1, outpu
             { type: "text", text: "thinking…" },
             { type: "tool_use", id: "t1", name: "read_file", input: { path: "x.ts" } },
           ],
+          model: "claude-sonnet-4-6",
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "t2", name: "write_file", input: { path: "y.ts" } }],
           model: "claude-sonnet-4-6",
         },
       }),
@@ -285,7 +292,9 @@ ${JSON.stringify({ type: "result", result: "ok", usage: { input_tokens: 1, outpu
     if (!out.ok) return;
     expect(out.value.toolCalls).toEqual([
       { name: "read_file", args: { path: "x.ts" }, result: null },
+      { name: "write_file", args: { path: "y.ts" }, result: null },
     ]);
+    expect(out.value.steps).toBe(2);
   });
 
   it("preserves cache token fields when present", () => {

--- a/packages/llm/src/providers/subprocess/subprocess.test.ts
+++ b/packages/llm/src/providers/subprocess/subprocess.test.ts
@@ -610,6 +610,37 @@ describe("createSubscriptionCliClient — factory", () => {
     expect(result.value.timeoutMs).toBe(5_000);
   });
 
+  it("complete() does not set spawnMs when subprocess fails (#280)", async () => {
+    // Use an adapter that returns a parse error — simulates a subprocess that
+    // exits non-zero or produces unparseable output. spawnMs must not appear
+    // on the error result (it lives only on the LLMResponse success path).
+    const failAdapter: SubprocessLLMAdapter = {
+      command: "/bin/echo",
+      providerId: "fail-cli",
+      buildFlags: () => [],
+      parseOutput: () => ({
+        ok: false,
+        error: { kind: "parse-error" as const, message: "bad output", raw: "" },
+      }),
+      authCheck: async () =>
+        Promise.resolve({ ok: true as const, value: { kind: "authenticated" as const } }),
+    };
+    const client = createSubscriptionCliClient({
+      cli: "claude",
+      model: "test-model",
+      cliAdapter: failAdapter,
+      timeoutMs: 5_000,
+    });
+    const result = await client.complete({
+      messages: [{ role: "user", content: "hi" }],
+      maxOutputTokens: 100,
+    });
+    expect(result.ok).toBe(false);
+    // spawnMs is only on LLMResponse (the ok path); the error path has no such field.
+    if (result.ok) return;
+    expect("spawnMs" in result).toBe(false);
+  });
+
   it("capabilities() reports the configured provider id", () => {
     const client = createSubscriptionCliClient({
       cli: "claude",

--- a/packages/llm/src/providers/subprocess/subprocess.test.ts
+++ b/packages/llm/src/providers/subprocess/subprocess.test.ts
@@ -588,6 +588,28 @@ describe("createSubscriptionCliClient — factory", () => {
     expect(result.value.outputTokens).toBe(3);
   });
 
+  it("complete() attaches cliPath, spawnMs, and timeoutMs on success (#280)", async () => {
+    const client = createSubscriptionCliClient({
+      cli: "claude",
+      model: "test-model",
+      cliAdapter: mockAdapter,
+      timeoutMs: 5_000,
+    });
+    const result = await client.complete({
+      messages: [{ role: "user", content: "hi" }],
+      maxOutputTokens: 100,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // cliPath is the adapter's command (the binary that was spawned).
+    expect(result.value.cliPath).toBe(mockAdapter.command);
+    // spawnMs is set when /bin/echo produces stdout; must be a non-negative number.
+    expect(typeof result.value.spawnMs).toBe("number");
+    expect(result.value.spawnMs).toBeGreaterThanOrEqual(0);
+    // timeoutMs reflects the configured value, not a default.
+    expect(result.value.timeoutMs).toBe(5_000);
+  });
+
   it("capabilities() reports the configured provider id", () => {
     const client = createSubscriptionCliClient({
       cli: "claude",

--- a/packages/llm/src/providers/subprocess/subprocess.test.ts
+++ b/packages/llm/src/providers/subprocess/subprocess.test.ts
@@ -223,15 +223,16 @@ describe("ClaudeCliAdapter.parseOutput", () => {
     expect(out.value.providerUsed).toBe("claude-cli");
   });
 
-  it("returns ParseError on empty output", () => {
+  it("returns ParseError(EMPTY_OUTPUT) on empty output (harness#280)", () => {
     const out = adapter.parseOutput("");
     expect(out.ok).toBe(false);
     if (out.ok) return;
     expect(out.error.kind).toBe("parse-error");
+    expect(out.error.code).toBe("EMPTY_OUTPUT");
     expect(out.error.message.toLowerCase()).toContain("empty");
   });
 
-  it("returns ParseError when usage tokens are missing (ADR-0034 D3)", () => {
+  it("returns ParseError(TOKEN_COUNT_MISSING) when usage tokens are absent (ADR-0034 D3, harness#280)", () => {
     const noUsage = JSON.stringify({
       type: "result",
       subtype: "success",
@@ -241,10 +242,11 @@ describe("ClaudeCliAdapter.parseOutput", () => {
     const out = adapter.parseOutput(noUsage);
     expect(out.ok).toBe(false);
     if (out.ok) return;
+    expect(out.error.code).toBe("TOKEN_COUNT_MISSING");
     expect(out.error.message).toContain("usage");
   });
 
-  it("returns ParseError when no result event is present", () => {
+  it("returns ParseError(NO_RESULT_EVENT) when no result event is present (harness#280)", () => {
     const noResult = JSON.stringify({
       type: "system",
       session_id: "abc",
@@ -252,7 +254,16 @@ describe("ClaudeCliAdapter.parseOutput", () => {
     const out = adapter.parseOutput(noResult);
     expect(out.ok).toBe(false);
     if (out.ok) return;
+    expect(out.error.code).toBe("NO_RESULT_EVENT");
     expect(out.error.message).toContain("result event");
+  });
+
+  it("returns ParseError(MALFORMED_JSON) when no JSON lines parse at all (harness#280)", () => {
+    const out = adapter.parseOutput("not json at all\nalso not json");
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    // No parseable JSON → no events → MALFORMED_JSON
+    expect(out.error.code).toBe("MALFORMED_JSON");
   });
 
   it("skips malformed JSON lines instead of failing the whole parse", () => {

--- a/packages/llm/src/providers/subprocess/types.ts
+++ b/packages/llm/src/providers/subprocess/types.ts
@@ -41,9 +41,22 @@ export interface SpawnError {
 }
 
 /** CLI output could not be parsed into an LLMResponse. */
+/**
+ * Structured parse failure categories. Enables operators and alerting to
+ * distinguish "bad CLI version" from "auth not configured" from "transient
+ * stream truncation" without grepping message strings (harness#280).
+ */
+export type ParseErrorCode =
+  | "EMPTY_OUTPUT" // subprocess exited 0 but produced no stdout
+  | "NO_RESULT_EVENT" // output was non-empty but had no terminal result event
+  | "TOKEN_COUNT_MISSING" // result event present but usage fields absent (ADR-0034 D3)
+  | "MALFORMED_JSON"; // couldn't parse any JSON lines from stdout
+
 export interface ParseError {
   readonly kind: "parse-error";
   readonly message: string;
+  /** Structured failure category for alerting and dashboards (harness#280). */
+  readonly code?: ParseErrorCode;
   /** Raw stdout (truncated to 2000 chars) for debugging. */
   readonly raw: string;
 }

--- a/packages/llm/src/providers/subprocess/types.ts
+++ b/packages/llm/src/providers/subprocess/types.ts
@@ -40,11 +40,10 @@ export interface SpawnError {
   readonly exitCode?: number;
 }
 
-/** CLI output could not be parsed into an LLMResponse. */
 /**
- * Structured parse failure categories. Enables operators and alerting to
- * distinguish "bad CLI version" from "auth not configured" from "transient
- * stream truncation" without grepping message strings (harness#280).
+ * Structured parse failure categories (harness#280). Enables operators and
+ * alerting to distinguish "bad CLI version" from "auth not configured" from
+ * "transient stream truncation" without grepping message strings.
  */
 export type ParseErrorCode =
   | "EMPTY_OUTPUT" // subprocess exited 0 but produced no stdout
@@ -52,12 +51,13 @@ export type ParseErrorCode =
   | "TOKEN_COUNT_MISSING" // result event present but usage fields absent (ADR-0034 D3)
   | "MALFORMED_JSON"; // couldn't parse any JSON lines from stdout
 
+/** CLI output could not be parsed into an LLMResponse. */
 export interface ParseError {
   readonly kind: "parse-error";
   readonly message: string;
   /** Structured failure category for alerting and dashboards (harness#280). */
   readonly code?: ParseErrorCode;
-  /** Raw stdout (truncated to 2000 chars) for debugging. */
+  /** Raw stdout (truncated to 2000 chars) for debugging. Scrubbed of secrets. */
   readonly raw: string;
 }
 

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -109,6 +109,27 @@ export interface LLMResponse {
    * surface an id.
    */
   readonly sessionId?: string;
+  /**
+   * v0.7.1 (#280): subscription-CLI only. Absolute path of the CLI binary
+   * that ran (e.g. `/Users/alice/.local/bin/claude`). Useful for audit —
+   * confirms the daemon resolved the expected binary, not a stale PATH hit.
+   * Undefined for direct API providers.
+   */
+  readonly cliPath?: string;
+  /**
+   * v0.7.1 (#280): subscription-CLI only. Milliseconds from `spawn()` to
+   * first stdout byte received. Surfaces slow CLI startup and cold-start
+   * overhead in cost records. Undefined when no stdout was received (e.g.
+   * auth error before first output) or for direct API providers.
+   */
+  readonly spawnMs?: number;
+  /**
+   * v0.7.1 (#280): subscription-CLI only. The wall-clock timeout (ms)
+   * configured for this subprocess call. Operators can compare this against
+   * `wallClockMs` in the cost record to understand how close a wake came to
+   * timing out. Undefined for direct API providers.
+   */
+  readonly timeoutMs?: number;
 }
 
 /** Declarative description of what a given {@link LLMClient} instance can do. */

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -10,6 +10,8 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 
 import {
+  ACTION_ITEM_LABEL,
+  assignedLabel,
   makeAgentId,
   type AgentId,
   type Signal,
@@ -249,7 +251,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
     const actionItems = finalSignals.filter((s) => {
       if (s.kind !== "github-issue") return false;
       const labels = (s as unknown as { labels: readonly string[] }).labels;
-      return labels.includes("action-item") && labels.some((l) => l === `assigned:${agentIdValue}`);
+      return labels.includes(ACTION_ITEM_LABEL) && labels.includes(assignedLabel(agentIdValue));
     });
 
     return {

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -11,6 +11,7 @@ import { join, resolve, sep } from "node:path";
 
 import {
   ACTION_ITEM_LABEL,
+  SCOPE_ALL_LABEL,
   assignedLabel,
   makeAgentId,
   type AgentId,
@@ -55,6 +56,19 @@ export interface GithubSignalScope {
   readonly anyLabel?: readonly string[];
   /** If true, signals start at "trusted". Otherwise "semi-trusted". */
   readonly trusted?: boolean;
+  /**
+   * When set, any `scope:all`-tagged issue whose `authorLogin` is NOT
+   * in this list is downgraded to `untrusted`. Protects against
+   * non-agent actors (bots, external collaborators) writing scope:all
+   * labels to broadcast to every agent. Back-compat: when absent, no
+   * downgrade occurs. Sec M1 defense-in-depth (harness#339).
+   */
+  readonly scopeAllTrustedAuthors?: readonly string[];
+  /**
+   * When true AND `scopeAllTrustedAuthors` is set, `scope:all` issues
+   * from untrusted authors are dropped entirely rather than downgraded.
+   */
+  readonly dropScopeAllFromUntrusted?: boolean;
 }
 
 export interface AggregatorCaps {
@@ -333,6 +347,19 @@ export class DefaultSignalAggregator implements SignalAggregator {
         const key = `${issue.repo.owner.value}/${issue.repo.name.value}#${String(issue.number.value)}`;
         if (seen.has(key)) continue;
         seen.add(key);
+        // Sec M1: scope:all provenance check. If the scope declares
+        // trusted authors and this issue carries scope:all, verify the
+        // author is in the allowlist. Untrusted authors get downgraded
+        // (or dropped if dropScopeAllFromUntrusted is set).
+        if (
+          scope.scopeAllTrustedAuthors !== undefined &&
+          issue.labels.includes(SCOPE_ALL_LABEL) &&
+          !scope.scopeAllTrustedAuthors.includes(issue.authorLogin)
+        ) {
+          if (scope.dropScopeAllFromUntrusted === true) continue;
+          raw.push({ issue, trust: "untrusted" });
+          continue;
+        }
         raw.push({ issue, trust: baseTrust });
       }
     };

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -40,6 +40,18 @@ import { composeBundle, filterDoneItems, type ClassifierContext } from "./priori
 export interface GithubSignalScope {
   readonly repo: RepoCoordinate;
   readonly filter?: ListIssuesFilter;
+  /**
+   * Labels with OR-semantics: an issue matches if any one of these
+   * labels is present (combined with the AND-set in `filter.labels`).
+   * Implemented as multiple `listIssues` queries client-side because
+   * GitHub's API only supports AND. Used by the daemon to inject
+   * membership-aware routing labels (assigned, scope:agent, scope:group,
+   * scope:all) per agent — see `buildAgentRoutingLabels` in
+   * `@murmurations-ai/core`.
+   *
+   * When unset, falls through to a single query with `filter.labels`.
+   */
+  readonly anyLabel?: readonly string[];
   /** If true, signals start at "trusted". Otherwise "semi-trusted". */
   readonly trusted?: boolean;
 }
@@ -278,22 +290,53 @@ export class DefaultSignalAggregator implements SignalAggregator {
     const scopes = this.#config.githubScopes ?? [];
     if (!client || scopes.length === 0) return [];
 
+    // Per-issue dedup across multi-query fan-out: a single issue may
+    // match multiple `anyLabel` queries on the same scope (e.g. an
+    // issue labeled both `assigned:foo` AND `scope:all` shows up in
+    // both queries). Key by repo+number so multi-repo scopes don't
+    // collide.
+    const seen = new Set<string>();
     const collected: Signal[] = [];
-    for (const scope of scopes) {
-      const filter: ListIssuesFilter = {
-        perPage: Math.min(this.#caps.githubIssue + 5, 30),
-        ...(scope.filter ?? {}),
-      };
+    const baseFilter = (scope: GithubSignalScope): ListIssuesFilter => ({
+      perPage: Math.min(this.#caps.githubIssue + 5, 30),
+      ...(scope.filter ?? {}),
+    });
+    const recordIssues = async (
+      scope: GithubSignalScope,
+      filter: ListIssuesFilter,
+    ): Promise<void> => {
       const result = await client.listIssues(scope.repo, filter);
       if (!result.ok) {
         warnings.push(
           `github source: ${scope.repo.owner.value}/${scope.repo.name.value} failed (${result.error.code})`,
         );
-        continue;
+        return;
       }
       const baseTrust: SignalTrustLevel = scope.trusted === true ? "trusted" : "semi-trusted";
       for (const issue of result.value) {
+        const key = `${issue.repo.owner.value}/${issue.repo.name.value}#${String(issue.number.value)}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
         collected.push(issueToSignal(issue, baseTrust, context.now));
+      }
+    };
+
+    for (const scope of scopes) {
+      const baseFilterForScope = baseFilter(scope);
+      if (scope.anyLabel === undefined || scope.anyLabel.length === 0) {
+        // Single-query fast path — no OR semantics needed.
+        await recordIssues(scope, baseFilterForScope);
+        continue;
+      }
+      // Fan-out: one query per anyLabel value. Each query AND-combines
+      // the existing labels filter (if any) with the OR-label.
+      const baseLabels = baseFilterForScope.labels ?? [];
+      for (const orLabel of scope.anyLabel) {
+        const filter: ListIssuesFilter = {
+          ...baseFilterForScope,
+          labels: [...baseLabels, orLabel],
+        };
+        await recordIssues(scope, filter);
       }
     }
 

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -15,6 +15,7 @@ import {
   makeAgentId,
   type AgentId,
   type Signal,
+  type SignalAggregationFailure,
   type SignalTrustLevel,
 } from "@murmurations-ai/core";
 import type {
@@ -185,10 +186,11 @@ export class DefaultSignalAggregator implements SignalAggregator {
 
   public async aggregate(context: SignalAggregationContext): Promise<SignalAggregationResult> {
     const warnings: string[] = [];
+    const partialFailures: SignalAggregationFailure[] = [];
     const signals: Signal[] = [];
 
     const results = await Promise.allSettled([
-      this.#collectGithub(context, warnings),
+      this.#collectGithub(context, warnings, partialFailures),
       this.#collectPrivateNotes(context, warnings),
       this.#collectInboxMessages(context, warnings),
       this.#collectCollaborationItems(),
@@ -274,6 +276,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
         signals: finalSignals,
         actionItems,
         warnings,
+        partialFailures,
       },
     };
   }
@@ -285,6 +288,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
   async #collectGithub(
     context: SignalAggregationContext,
     warnings: string[],
+    partialFailures: SignalAggregationFailure[],
   ): Promise<readonly Signal[]> {
     const client = this.#config.github;
     const scopes = this.#config.githubScopes ?? [];
@@ -294,9 +298,14 @@ export class DefaultSignalAggregator implements SignalAggregator {
     // match multiple `anyLabel` queries on the same scope (e.g. an
     // issue labeled both `assigned:foo` AND `scope:all` shows up in
     // both queries). Key by repo+number so multi-repo scopes don't
-    // collide.
+    // collide. We collect the *raw* issue + its trust level so we can
+    // sort the merged set by `updatedAt` (deterministic, recency-first)
+    // before applying the per-source cap — older `assigned:` items
+    // would otherwise crowd out newer `scope:agent:<self>` directives
+    // because fan-out queries returned them in collection order
+    // (QA review of harness#331).
     const seen = new Set<string>();
-    const collected: Signal[] = [];
+    const raw: { readonly issue: GithubIssue; readonly trust: SignalTrustLevel }[] = [];
     const baseFilter = (scope: GithubSignalScope): ListIssuesFilter => ({
       perPage: Math.min(this.#caps.githubIssue + 5, 30),
       ...(scope.filter ?? {}),
@@ -304,12 +313,19 @@ export class DefaultSignalAggregator implements SignalAggregator {
     const recordIssues = async (
       scope: GithubSignalScope,
       filter: ListIssuesFilter,
+      anyLabel: string | undefined,
     ): Promise<void> => {
       const result = await client.listIssues(scope.repo, filter);
+      const repoCoord = `${scope.repo.owner.value}/${scope.repo.name.value}`;
       if (!result.ok) {
-        warnings.push(
-          `github source: ${scope.repo.owner.value}/${scope.repo.name.value} failed (${result.error.code})`,
-        );
+        warnings.push(`github source: ${repoCoord} failed (${result.error.code})`);
+        partialFailures.push({
+          source: "github",
+          repo: repoCoord,
+          ...(anyLabel !== undefined ? { anyLabel } : {}),
+          code: result.error.code,
+          detail: result.error.message,
+        });
         return;
       }
       const baseTrust: SignalTrustLevel = scope.trusted === true ? "trusted" : "semi-trusted";
@@ -317,7 +333,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
         const key = `${issue.repo.owner.value}/${issue.repo.name.value}#${String(issue.number.value)}`;
         if (seen.has(key)) continue;
         seen.add(key);
-        collected.push(issueToSignal(issue, baseTrust, context.now));
+        raw.push({ issue, trust: baseTrust });
       }
     };
 
@@ -325,7 +341,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
       const baseFilterForScope = baseFilter(scope);
       if (scope.anyLabel === undefined || scope.anyLabel.length === 0) {
         // Single-query fast path — no OR semantics needed.
-        await recordIssues(scope, baseFilterForScope);
+        await recordIssues(scope, baseFilterForScope, undefined);
         continue;
       }
       // Fan-out: one query per anyLabel value. Each query AND-combines
@@ -336,18 +352,32 @@ export class DefaultSignalAggregator implements SignalAggregator {
           ...baseFilterForScope,
           labels: [...baseLabels, orLabel],
         };
-        await recordIssues(scope, filter);
+        await recordIssues(scope, filter, orLabel);
       }
     }
 
-    if (collected.length > this.#caps.githubIssue) {
-      const total = collected.length;
-      collected.length = this.#caps.githubIssue;
+    // Sort by recency before applying the cap so the most-recent-N is
+    // what survives, regardless of which fan-out query produced them.
+    // Tie-breaker on `(repo, number)` keeps the order stable across
+    // ties so two runs with identical input produce identical output.
+    raw.sort((a, b) => {
+      const ta = a.issue.updatedAt.getTime();
+      const tb = b.issue.updatedAt.getTime();
+      if (ta !== tb) return tb - ta; // DESC by updatedAt
+      const repoA = `${a.issue.repo.owner.value}/${a.issue.repo.name.value}`;
+      const repoB = `${b.issue.repo.owner.value}/${b.issue.repo.name.value}`;
+      if (repoA !== repoB) return repoA.localeCompare(repoB);
+      return b.issue.number.value - a.issue.number.value; // DESC by issue number
+    });
+
+    let kept: typeof raw = raw;
+    if (raw.length > this.#caps.githubIssue) {
+      kept = raw.slice(0, this.#caps.githubIssue);
       warnings.push(
-        `github-issue source truncated to ${String(this.#caps.githubIssue)} of ${String(total)} matches (cap)`,
+        `github-issue source truncated to ${String(this.#caps.githubIssue)} of ${String(raw.length)} matches (cap, sorted by updatedAt desc)`,
       );
     }
-    return collected;
+    return kept.map(({ issue, trust }) => issueToSignal(issue, trust, context.now));
   }
 
   // ---------------------------------------------------------------------

--- a/packages/signals/src/priority.ts
+++ b/packages/signals/src/priority.ts
@@ -38,6 +38,12 @@
  * @see docs/specs/0001-agent-effectiveness.md §4.2
  */
 
+import {
+  AWAITING_SOURCE_CLOSE_LABEL,
+  SOURCE_DIRECTIVE_LABEL,
+  TIER_CONSENT_LABEL,
+  assignedLabel,
+} from "@murmurations-ai/core";
 import type { Signal } from "@murmurations-ai/core";
 
 // ---------------------------------------------------------------------------
@@ -98,13 +104,12 @@ export interface ClassifierContext {
 // Label parsing
 // ---------------------------------------------------------------------------
 
+// Labels owned by the canonical labels library (`@murmurations-ai/core`).
+// `priority:critical` and `priority:low` are signal-package-specific
+// (priority tiering is a packages/signals concern, not harness-universal),
+// so they stay local.
 const PRIORITY_CRITICAL_LABEL = "priority:critical";
 const PRIORITY_LOW_LABEL = "priority:low";
-const SOURCE_DIRECTIVE_LABEL = "source-directive";
-const TIER_CONSENT_LABEL = "tier:consent";
-const AWAITING_SOURCE_CLOSE_LABEL = "awaiting:source-close";
-
-const ASSIGNED_SELF = (agentId: string): string => `assigned:${agentId}`;
 
 const hasLabel = (signal: Signal, label: string): boolean =>
   signal.kind === "github-issue" && signal.labels.includes(label);
@@ -177,7 +182,7 @@ export const classifyTier = (signal: Signal, ctx: ClassifierContext): PriorityTi
   // [DIRECTIVE] assigned:<self> filed in last 7d
   if (
     issueType === "[DIRECTIVE]" &&
-    hasLabel(signal, ASSIGNED_SELF(ctx.selfAgentId)) &&
+    hasLabel(signal, assignedLabel(ctx.selfAgentId)) &&
     ageDays <= 7
   ) {
     return "high";
@@ -186,7 +191,7 @@ export const classifyTier = (signal: Signal, ctx: ClassifierContext): PriorityTi
   // [*MEETING] with the agent in scope. The harness can't easily
   // detect "on the agenda" without parsing the issue body; the
   // proxy is "assigned:<self> on a meeting issue."
-  if (isMeetingType(issueType) && hasLabel(signal, ASSIGNED_SELF(ctx.selfAgentId))) {
+  if (isMeetingType(issueType) && hasLabel(signal, assignedLabel(ctx.selfAgentId))) {
     return "high";
   }
 

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -590,10 +590,13 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       // 2 critical + low fills budget. The order in the emitted
-      // bundle should put critical first.
+      // bundle should put a critical-tier item first (regardless of
+      // which one — the github-source pre-sort by updatedAt may
+      // permute order within a tier when timestamps tie).
       const first = result.bundle.signals[0];
+      expect(first?.kind).toBe("github-issue");
       if (first?.kind === "github-issue") {
-        expect(first.number).toBe(1);
+        expect([1, 2]).toContain(first.number);
       }
     }
   });
@@ -789,6 +792,150 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
       (s) => s.kind === "github-issue" && s.number === 200,
     );
     expect(matching).toHaveLength(1);
+  });
+  /* eslint-enable @typescript-eslint/require-await */
+
+  /* eslint-disable @typescript-eslint/require-await -- fake clients mimic the async interface */
+  it("multi-query anyLabel: cap keeps newest issues even when they came from a later fan-out query (QA #1)", async () => {
+    // QA review of harness#331: the original fan-out collected in
+    // collection order — `assigned:` query first, then `scope:agent:`,
+    // etc. With a small cap and many older `assigned:` items, a freshly
+    // filed `scope:agent:<self>` directive could be silently dropped.
+    // After the fix, sort by updatedAt DESC means the newest-N survive.
+    const recentDirective = fakeIssue({
+      n: 999,
+      title: "[DIRECTIVE] urgent",
+      labels: ["source-directive", "scope:agent:rentals-agent"],
+      // Most recent — must survive the cap.
+      updatedAt: new Date("2026-05-05T12:00:00Z"),
+    });
+    const olderActionItems = Array.from({ length: 5 }, (_, i) =>
+      fakeIssue({
+        n: 100 + i,
+        title: `Old action ${String(i)}`,
+        labels: ["assigned:rentals-agent", "action-item"],
+        // All older than the directive.
+        updatedAt: new Date(`2026-05-0${String(i + 1)}T08:00:00Z`),
+      }),
+    );
+    const fakeClient: GithubClient = {
+      async getIssue() {
+        return { ok: false, error: { code: "not-found" } as unknown as GithubClientError };
+      },
+      async listIssues(_repo, filter): Promise<Result<readonly GithubIssue[], GithubClientError>> {
+        const wantsAssigned = filter?.labels?.includes("assigned:rentals-agent") ?? false;
+        const wantsScopeAgent = filter?.labels?.includes("scope:agent:rentals-agent") ?? false;
+        if (wantsAssigned) return { ok: true, value: olderActionItems };
+        if (wantsScopeAgent) return { ok: true, value: [recentDirective] };
+        return { ok: true, value: [] };
+      },
+      async listIssueComments() {
+        return { ok: true, value: [] };
+      },
+      async listIssueLabels() {
+        return { ok: true, value: [] };
+      },
+      getRef: notFound,
+      getPullRequest: notFound,
+      listPullRequests: notFound,
+      getPullRequestFiles: notFound,
+      getCommit: notFound,
+      getFileAtRef: notFound,
+      createIssueComment: mutationDenied,
+      createIssue: mutationDenied,
+      createCommitOnBranch: mutationDenied,
+      addLabels: mutationDenied,
+      removeLabel: mutationDenied,
+      updateIssueState: mutationDenied,
+      lastRateLimit: () => null,
+    };
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: fakeClient,
+      githubScopes: [
+        {
+          repo: REPO,
+          anyLabel: ["assigned:rentals-agent", "scope:agent:rentals-agent", "scope:all"],
+        },
+      ],
+      // Cap of 3 — would have dropped the directive under collection-order
+      // truncation (older `assigned:` items came first).
+      caps: { githubIssue: 3, total: 50 },
+    });
+    const result = await agg.aggregate(mkContext("rentals-agent"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const directive = result.bundle.signals.find(
+      (s) => s.kind === "github-issue" && s.number === 999,
+    );
+    expect(directive, "newest directive must survive the per-source cap").toBeDefined();
+    // Cap respected.
+    const ghIssues = result.bundle.signals.filter((s) => s.kind === "github-issue");
+    expect(ghIssues).toHaveLength(3);
+  });
+
+  it("multi-query anyLabel: surfaces structured partialFailures when a sub-query fails (QA #3)", async () => {
+    // QA review of harness#331: a single failed sub-query used to push
+    // a string into `warnings` and silently lose data. Now also pushes
+    // a structured entry to `partialFailures` so callers can distinguish
+    // "no signals matched" from "1 of 4 fan-out queries failed".
+    const fakeClient: GithubClient = {
+      async getIssue() {
+        return { ok: false, error: { code: "not-found" } as unknown as GithubClientError };
+      },
+      async listIssues(_repo, filter): Promise<Result<readonly GithubIssue[], GithubClientError>> {
+        const failOn = "scope:agent:rentals-agent";
+        if (filter?.labels?.includes(failOn) ?? false) {
+          return {
+            ok: false,
+            error: {
+              code: "rate-limited",
+              message: "secondary rate limit",
+            } as unknown as GithubClientError,
+          };
+        }
+        return { ok: true, value: [] };
+      },
+      async listIssueComments() {
+        return { ok: true, value: [] };
+      },
+      async listIssueLabels() {
+        return { ok: true, value: [] };
+      },
+      getRef: notFound,
+      getPullRequest: notFound,
+      listPullRequests: notFound,
+      getPullRequestFiles: notFound,
+      getCommit: notFound,
+      getFileAtRef: notFound,
+      createIssueComment: mutationDenied,
+      createIssue: mutationDenied,
+      createCommitOnBranch: mutationDenied,
+      addLabels: mutationDenied,
+      removeLabel: mutationDenied,
+      updateIssueState: mutationDenied,
+      lastRateLimit: () => null,
+    };
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: fakeClient,
+      githubScopes: [
+        {
+          repo: REPO,
+          anyLabel: ["assigned:rentals-agent", "scope:agent:rentals-agent", "scope:all"],
+        },
+      ],
+    });
+    const result = await agg.aggregate(mkContext("rentals-agent"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const failures = result.bundle.partialFailures ?? [];
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.source).toBe("github");
+    expect(failures[0]?.anyLabel).toBe("scope:agent:rentals-agent");
+    expect(failures[0]?.code).toBe("rate-limited");
+    // The string warning is still there too — same info, both surfaces.
+    expect(result.bundle.warnings.some((w) => w.includes("rate-limited"))).toBe(true);
   });
   /* eslint-enable @typescript-eslint/require-await */
 

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -960,3 +960,102 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
     }
   });
 });
+
+describe("DefaultSignalAggregator — scope:all provenance check (Sec M1, harness#339)", () => {
+  let rootDir = "";
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "signals-m1-"));
+  });
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("back-compat: scope:all without scopeAllTrustedAuthors keeps baseTrust", async () => {
+    const issues = [fakeIssue({ n: 1, labels: ["scope:all"], authorLogin: "unknown-bot" })];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO, anyLabel: ["scope:all"] }],
+    });
+    const result = await agg.aggregate(mkContext("01-alpha"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const sig = result.bundle.signals.find((s) => s.kind === "github-issue");
+      expect(sig?.trust).toBe("semi-trusted");
+    }
+  });
+
+  it("scope:all from trusted author keeps baseTrust (Sec M1)", async () => {
+    const issues = [fakeIssue({ n: 1, labels: ["scope:all"], authorLogin: "nori" })];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO, anyLabel: ["scope:all"], scopeAllTrustedAuthors: ["nori"] }],
+    });
+    const result = await agg.aggregate(mkContext("01-alpha"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const sig = result.bundle.signals.find((s) => s.kind === "github-issue");
+      expect(sig?.trust).toBe("semi-trusted");
+    }
+  });
+
+  it("scope:all from untrusted author is downgraded to untrusted (Sec M1)", async () => {
+    const issues = [fakeIssue({ n: 1, labels: ["scope:all"], authorLogin: "external-bot" })];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO, anyLabel: ["scope:all"], scopeAllTrustedAuthors: ["nori"] }],
+    });
+    const result = await agg.aggregate(mkContext("01-alpha"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const sig = result.bundle.signals.find((s) => s.kind === "github-issue");
+      expect(sig?.trust).toBe("untrusted");
+    }
+  });
+
+  it("scope:all from untrusted author is dropped when dropScopeAllFromUntrusted=true (Sec M1)", async () => {
+    const issues = [
+      fakeIssue({ n: 1, labels: ["scope:all"], authorLogin: "external-bot" }),
+      fakeIssue({ n: 2, labels: ["assigned:alpha"], authorLogin: "nori" }),
+    ];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [
+        {
+          repo: REPO,
+          anyLabel: ["scope:all", "assigned:alpha"],
+          scopeAllTrustedAuthors: ["nori"],
+          dropScopeAllFromUntrusted: true,
+        },
+      ],
+    });
+    const result = await agg.aggregate(mkContext("01-alpha"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const ghSignals = result.bundle.signals.filter((s) => s.kind === "github-issue");
+      // issue #1 (scope:all, untrusted) dropped; issue #2 (assigned, trusted author) kept
+      expect(ghSignals).toHaveLength(1);
+      expect(ghSignals[0]?.trust).toBe("semi-trusted");
+    }
+  });
+
+  it("non-scope:all issue is not affected by scopeAllTrustedAuthors (Sec M1)", async () => {
+    const issues = [fakeIssue({ n: 1, labels: ["assigned:alpha"], authorLogin: "unknown-bot" })];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [
+        { repo: REPO, anyLabel: ["assigned:alpha"], scopeAllTrustedAuthors: ["nori"] },
+      ],
+    });
+    const result = await agg.aggregate(mkContext("01-alpha"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const sig = result.bundle.signals.find((s) => s.kind === "github-issue");
+      expect(sig?.trust).toBe("semi-trusted");
+    }
+  });
+});

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -657,6 +657,141 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
     }
   });
 
+  /* eslint-disable @typescript-eslint/require-await -- fake clients mimic the async interface */
+  it("multi-query anyLabel: source-directive scoped to agent reaches the bundle (harness#331/#233)", async () => {
+    // Repro for chinook-wind 2026-05-05: a directive filed as
+    // `source-directive` + `scope:agent:rentals-agent` was invisible to
+    // the aggregator because the configured filter was AND-only with
+    // `assigned:rentals-agent`. With anyLabel routing, the issue should
+    // now show up in the bundle.
+    const directiveForRentals = fakeIssue({
+      n: 100,
+      title: "[DIRECTIVE] bootstrap",
+      labels: ["source-directive", "scope:agent:rentals-agent"],
+    });
+    // Track which label-set each query was asked for, so we can assert
+    // the multi-query fan-out happened.
+    const queriedFilters: (readonly string[] | undefined)[] = [];
+    const fakeClient: GithubClient = {
+      async getIssue() {
+        return {
+          ok: false,
+          error: { code: "not-found" } as unknown as GithubClientError,
+        };
+      },
+      async listIssues(_repo, filter): Promise<Result<readonly GithubIssue[], GithubClientError>> {
+        queriedFilters.push(filter?.labels);
+        // Mimic GitHub's AND-semantics: return the directive only when
+        // the query asks for `scope:agent:rentals-agent`.
+        const wantsScopeAgent = filter?.labels?.includes("scope:agent:rentals-agent") ?? false;
+        return { ok: true, value: wantsScopeAgent ? [directiveForRentals] : [] };
+      },
+      async listIssueComments() {
+        return { ok: true, value: [] };
+      },
+      async listIssueLabels() {
+        return { ok: true, value: [] };
+      },
+      getRef: notFound,
+      getPullRequest: notFound,
+      listPullRequests: notFound,
+      getPullRequestFiles: notFound,
+      getCommit: notFound,
+      getFileAtRef: notFound,
+      createIssueComment: mutationDenied,
+      createIssue: mutationDenied,
+      createCommitOnBranch: mutationDenied,
+      addLabels: mutationDenied,
+      removeLabel: mutationDenied,
+      updateIssueState: mutationDenied,
+      lastRateLimit: () => null,
+    };
+
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: fakeClient,
+      githubScopes: [
+        {
+          repo: REPO,
+          anyLabel: [
+            "assigned:rentals-agent",
+            "scope:agent:rentals-agent",
+            "scope:group:partnership",
+            "scope:all",
+          ],
+        },
+      ],
+    });
+
+    const result = await agg.aggregate(mkContext("rentals-agent"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The directive should be in the bundle.
+    const directives = result.bundle.signals.filter(
+      (s) => s.kind === "github-issue" && s.number === 100,
+    );
+    expect(directives).toHaveLength(1);
+
+    // And we should have run one query per anyLabel value (4 queries).
+    expect(queriedFilters).toHaveLength(4);
+  });
+
+  it("multi-query anyLabel: dedupes issues that match multiple labels (harness#331)", async () => {
+    // An issue tagged with both `assigned:foo` AND `scope:all` matches
+    // two queries; the aggregator should emit it once.
+    const issue = fakeIssue({
+      n: 200,
+      labels: ["assigned:rentals-agent", "scope:all"],
+    });
+    const fakeClient: GithubClient = {
+      async getIssue() {
+        return {
+          ok: false,
+          error: { code: "not-found" } as unknown as GithubClientError,
+        };
+      },
+      async listIssues(): Promise<Result<readonly GithubIssue[], GithubClientError>> {
+        // Same issue returned by every query — dedup is the aggregator's job.
+        return { ok: true, value: [issue] };
+      },
+      async listIssueComments() {
+        return { ok: true, value: [] };
+      },
+      async listIssueLabels() {
+        return { ok: true, value: [] };
+      },
+      getRef: notFound,
+      getPullRequest: notFound,
+      listPullRequests: notFound,
+      getPullRequestFiles: notFound,
+      getCommit: notFound,
+      getFileAtRef: notFound,
+      createIssueComment: mutationDenied,
+      createIssue: mutationDenied,
+      createCommitOnBranch: mutationDenied,
+      addLabels: mutationDenied,
+      removeLabel: mutationDenied,
+      updateIssueState: mutationDenied,
+      lastRateLimit: () => null,
+    };
+
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: fakeClient,
+      githubScopes: [{ repo: REPO, anyLabel: ["assigned:rentals-agent", "scope:all"] }],
+    });
+
+    const result = await agg.aggregate(mkContext("rentals-agent"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const matching = result.bundle.signals.filter(
+      (s) => s.kind === "github-issue" && s.number === 200,
+    );
+    expect(matching).toHaveLength(1);
+  });
+  /* eslint-enable @typescript-eslint/require-await */
+
   it("emits warnings naming tier counts when items are dropped", async () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       fakeIssue({ n: i + 1, labels: ["priority:critical"] }),

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -88,6 +88,9 @@ const makeFakeGithub = (issues: readonly GithubIssue[]): GithubClient => ({
   getPullRequestFiles: notFound,
   getCommit: notFound,
   getFileAtRef: notFound,
+  async searchIssues() {
+    return { ok: true, value: [] };
+  },
   createIssueComment: mutationDenied,
   createIssue: mutationDenied,
   createCommitOnBranch: mutationDenied,
@@ -119,6 +122,9 @@ const makeFailingGithub = (): GithubClient => ({
   getPullRequestFiles: notFound,
   getCommit: notFound,
   getFileAtRef: notFound,
+  async searchIssues() {
+    return { ok: true, value: [] };
+  },
   createIssueComment: mutationDenied,
   createIssue: mutationDenied,
   createCommitOnBranch: mutationDenied,
@@ -701,6 +707,9 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
       getPullRequestFiles: notFound,
       getCommit: notFound,
       getFileAtRef: notFound,
+      async searchIssues() {
+        return { ok: true, value: [] };
+      },
       createIssueComment: mutationDenied,
       createIssue: mutationDenied,
       createCommitOnBranch: mutationDenied,
@@ -770,6 +779,9 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
       getPullRequestFiles: notFound,
       getCommit: notFound,
       getFileAtRef: notFound,
+      async searchIssues() {
+        return { ok: true, value: [] };
+      },
       createIssueComment: mutationDenied,
       createIssue: mutationDenied,
       createCommitOnBranch: mutationDenied,
@@ -841,6 +853,9 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
       getPullRequestFiles: notFound,
       getCommit: notFound,
       getFileAtRef: notFound,
+      async searchIssues() {
+        return { ok: true, value: [] };
+      },
       createIssueComment: mutationDenied,
       createIssue: mutationDenied,
       createCommitOnBranch: mutationDenied,
@@ -908,6 +923,9 @@ describe("DefaultSignalAggregator + priorityBundle", () => {
       getPullRequestFiles: notFound,
       getCommit: notFound,
       getFileAtRef: notFound,
+      async searchIssues() {
+        return { ok: true, value: [] };
+      },
       createIssueComment: mutationDenied,
       createIssue: mutationDenied,
       createCommitOnBranch: mutationDenied,


### PR DESCRIPTION
## Summary

v0.7.1 stability release. All changes are additive or bug fixes — no breaking changes to public interfaces.

### CLI binary resolution (harness#344)
- `boot.ts`: `resolveCliBinaryPath()` — resolves subscription-CLI binary to absolute path at daemon boot via `which` + fallback probe of common install directories (`~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `~/.npm/bin`, `~/.openai/bin`). Fixes ENOENT failures when daemon runs under launchd/cron with minimal PATH.
- `doctor.ts`: new check surfaces missing/PATH-absent CLI binaries before first wake
- `group-wake.ts`: same resolution applied to group-wake CLI path

### Subprocess telemetry (harness#280)
- `LLMResponse` gains `cliPath?`, `spawnMs?` (spawn-to-first-byte latency), `timeoutMs?`
- Fields flow end-to-end: `SubprocessAdapter` → `LLMCostHook.onLlmCall` → `WakeCostBuilder.addLlmTokens` → `WakeCostRecord.llm`
- `WakeCostRecord.llm.cliPath` carries a serialization warning (security review)
- harness#345 opened for future `llm.cli` sub-object consolidation (v0.8.0)

### Wake summary cache token display (harness#302)
- Runner wake summary now shows `cache_read_tokens: N` when non-zero
- Fixes misleading `input_tokens: 8` display for cache-heavy wakes (8 fresh tokens + 250k cache reads)

### Other included fixes
- Atomic pidfile creation (O_CREAT|O_EXCL, closes harness#219)
- `ParseError.code` enum for structured subprocess failure (harness#280 partial)
- Tool accumulation across all assistant events (harness#295)
- Scrub API keys from subprocess stderr (harness#303)
- Real provider/model in cost records (harness#326)
- Spawn-failed WakeOutcome (harness#329)
- harness.yaml Zod validation (harness#323)
- Label allowlist + routing (harness#331, #235, #233)
- Security hardening: Sec M1/M2/M3 (harness#331)
- `create_issue_comment` write tool (harness#274)
- `searchIssues` GitHub client + tool (harness#234)
- CI: npm publish on tag push (harness#327)

### Issues closed
harness#280, harness#295, harness#302, harness#303, harness#319, harness#323, harness#325, harness#326, harness#327, harness#329, harness#331, harness#337, harness#343, harness#344

## Test plan

- [ ] `pnpm run check` — 1084 tests passing, 0 typecheck/lint/format errors
- [ ] `subprocess.test.ts`: `cliPath`, `spawnMs`, `timeoutMs` on success; `spawnMs` absent on failure
- [ ] `cost.test.ts`: new fields survive builder → `finalize()`; Zod schema round-trip
- [ ] `runner.test.ts`: `cache_read_tokens` present when non-zero, absent when zero
- [ ] Live: chinook-wind finance-agent confirmed successful wake under launchd (109s, 5 signals, 250k cache tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)