### PR TITLE
Phase 4 PR 2: assembleExecutionContract + buildSpawnContext wiring

### DIFF
--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -44,6 +44,10 @@ import {
 import type { LoadedAgentIdentity } from "../identity/index.js";
 import { buildAgentRoutingLabels } from "../labels/index.js";
 import {
+  assembleExecutionContract,
+  type ContractDeclaration,
+} from "../runtime/execution-contract.js";
+import {
   makeSecretKey,
   REDACT,
   type SecretDeclaration,
@@ -253,6 +257,14 @@ export interface RegisteredAgent {
   readonly plugins: readonly {
     readonly provider: string;
   }[];
+
+  /**
+   * Parsed `contract:` block from `role.md` frontmatter (ADR-0047, ADR-0048,
+   * Phase 4 PR 1+2). Undefined when the role does not declare a contract —
+   * `assembleExecutionContract()` still produces a usable contract from
+   * runtime context in that case.
+   */
+  readonly contract?: ContractDeclaration;
 }
 
 /**
@@ -382,6 +394,7 @@ export const registeredAgentFromLoadedIdentity = (
     secrets,
     tools,
     plugins,
+    ...(frontmatter.contract !== undefined ? { contract: frontmatter.contract } : {}),
   };
 };
 
@@ -1374,13 +1387,30 @@ const buildSpawnContext = async (
     };
   }
 
+  const wakeMode = "individual" as const;
+  const wakeReason = event.wakeReason;
+
+  // Phase 4 PR 2: assemble the full ExecutionContract for this wake.
+  // Empty when the role lacks a `contract:` block — assembleExecutionContract
+  // handles the missing-declaration case and still returns a usable contract
+  // populated from runtime context (objective derived from wake reason,
+  // allowedSideEffects derived from write scopes).
+  const contract = assembleExecutionContract({
+    wakeReason,
+    wakeMode,
+    declaration: agent.contract,
+    signals,
+    budget,
+    githubWriteScopes: agent.githubWriteScopes,
+  });
+
   return {
     wakeId: event.wakeId,
     agentId,
     identity,
     signals,
-    wakeReason: event.wakeReason,
-    wakeMode: "individual" as const,
+    wakeReason,
+    wakeMode,
     budget,
     currentSchedule: formatTrigger(agent.trigger),
     capabilities: {
@@ -1397,6 +1427,7 @@ const buildSpawnContext = async (
     },
     mcpServerConfigs: agent.tools.mcp,
     environment: resolveAgentEnvironment(agent, secretsProvider),
+    contract,
   };
 };
 

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -1,5 +1,6 @@
 import type { WakeCostRecord } from "../cost/record.js";
 import { SOURCE_DIRECTIVE_LABEL, buildAgentRoutingLabels } from "../labels/index.js";
+import type { ExecutionContract } from "../runtime/execution-contract.js";
 
 /**
  * Agent execution — the pluggable boundary between the harness daemon and
@@ -628,18 +629,23 @@ export interface AgentSpawnContext {
    */
   readonly promptRef?: string;
   /**
-   * Minimal execution contract scaffold (Near-Term #9, Proposal 07).
+   * Full execution contract for this wake (Phase 4 PR 2, ADR-0047, ADR-0048).
    *
-   * In Phase 0/1, only `objective`, `doneWhen`, and `allowedSideEffects`
-   * are populated. Phase 4 expands this to the full `ExecutionContract`.
-   * Optional so pre-Phase-1 callers (tests, examples) do not need to
-   * populate it.
+   * Assembled by `assembleExecutionContract()` from the role's
+   * `contract:` block + runtime context (signals, budget, write scopes).
+   * Optional so test fixtures and pre-Phase-4 callers do not need to
+   * populate it; production daemon wakes always populate it from PR 2
+   * onward.
+   *
+   * Consumers (Phase 4 PR 3/4/6a):
+   *   - PromptAssembler renders `requiredOutputs` + `actionItems` into
+   *     the system prompt.
+   *   - `validateOutcomes` (PR 4) scores the wake against the obligation
+   *     sub-contract.
+   *   - `validateBehavior` (PR 6a, warning-only) reads `allowedSideEffects`
+   *     to cross-check narrative vs. tool calls.
    */
-  readonly contract?: {
-    readonly objective: string;
-    readonly doneWhen: readonly string[];
-    readonly allowedSideEffects: readonly string[];
-  };
+  readonly contract?: ExecutionContract;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/runtime/execution-contract.test.ts
+++ b/packages/core/src/runtime/execution-contract.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for `assembleExecutionContract` — Phase 4 PR 2 (ADR-0047, ADR-0048).
+ *
+ * Covers:
+ *   - Missing-declaration path: contract still assembles from runtime context
+ *   - Full declaration: every contract field maps through
+ *   - actionItems mapping from SignalBundle to ActionItemRef (with/without sourceRef)
+ *   - allowedSideEffects derived from githubWriteScopes (read-only vs read+write)
+ *   - objective synthesis precedence: done_when[0] > wakeReason
+ *   - approval policy switches on `approval_required_for`
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { assembleExecutionContract, contractDeclarationSchema } from "./execution-contract.js";
+import type { Signal, SignalBundle } from "../execution/index.js";
+import { makeAgentId, makeWakeId } from "../execution/index.js";
+
+const wakeId = makeWakeId("wake-test");
+
+const emptySignals: SignalBundle = {
+  wakeId,
+  assembledAt: new Date("2026-05-11T10:00:00Z"),
+  signals: [],
+  actionItems: [],
+  warnings: [],
+};
+
+const baseBudget = {
+  maxInputTokens: 0,
+  maxOutputTokens: 0,
+  maxWallClockMs: 60000,
+  model: { tier: "balanced" as const, provider: "unknown", model: "unknown", maxTokens: 4096 },
+  maxCostMicros: 0,
+};
+
+const emptyScopes = {
+  issueComments: [],
+  branchCommits: [],
+  labels: [],
+  issues: [],
+};
+
+const writeScopes = {
+  issueComments: ["xeeban/emergent-praxis"],
+  branchCommits: [{ repo: "xeeban/emergent-praxis", paths: ["drafts/**"] }],
+  labels: ["xeeban/emergent-praxis"],
+  issues: ["xeeban/emergent-praxis"],
+};
+
+describe("assembleExecutionContract", () => {
+  it("returns a valid contract when no declaration is present", () => {
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+
+    expect(contract.objective).toBe("Scheduled wake (0 9 * * *)");
+    expect(contract.requiredOutputs).toEqual([]);
+    expect(contract.actionItems).toEqual([]);
+    expect(contract.completionConditions).toEqual([]);
+    expect(contract.verification).toEqual([]);
+    expect(contract.allowedSideEffects).toEqual(["read"]);
+    expect(contract.approval).toEqual({ mode: "none" });
+  });
+
+  it("maps a full contract declaration through all five sub-fields", () => {
+    const declaration = contractDeclarationSchema.parse({
+      done_when: [
+        "Commit at least one research artifact under drafts/",
+        "OR post a substantive comment on an open issue",
+      ],
+      committed_artifacts: ["drafts/**/*.md", "docs/research/**/*.md"],
+      runtime_artifacts: [".murmuration/runs/**/*.md"],
+      verification_required_for: ["github.create_pull_request"],
+      approval_required_for: ["admin"],
+    });
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "manual", invokedBy: "source" },
+      wakeMode: "individual",
+      declaration,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: writeScopes,
+    });
+
+    expect(contract.objective).toBe("Commit at least one research artifact under drafts/");
+    expect(contract.requiredOutputs).toHaveLength(3);
+    expect(contract.requiredOutputs[0]).toMatchObject({
+      kind: "committed-artifact",
+      path: "drafts/**/*.md",
+    });
+    expect(contract.requiredOutputs[2]).toMatchObject({
+      kind: "runtime-artifact",
+      path: ".murmuration/runs/**/*.md",
+    });
+    expect(contract.completionConditions).toHaveLength(2);
+    expect(contract.completionConditions[0]?.id).toBe("done-when-0");
+    expect(contract.verification).toHaveLength(1);
+    expect(contract.verification[0]?.required).toBe(true);
+    expect(contract.allowedSideEffects).toEqual(["read", "write"]);
+    expect(contract.approval).toEqual({
+      mode: "required",
+      reason: "Source approval required for: admin",
+    });
+  });
+
+  it("maps SignalBundle.actionItems to ActionItemRef with sourceRef for github-issue signals", () => {
+    const issueSignal: Signal = {
+      id: "github-issue:xeeban/emergent-praxis#861",
+      kind: "github-issue",
+      trust: "trusted",
+      fetchedAt: new Date(),
+      number: 861,
+      title: "Action item: intelligence-agent — add conformant contract: block",
+      url: "https://github.com/xeeban/emergent-praxis/issues/861",
+      labels: ["assigned:intelligence-agent"],
+      excerpt: "...",
+    };
+    const inboxSignal: Signal = {
+      id: "inbox:msg-42",
+      kind: "inbox-message",
+      trust: "trusted",
+      fetchedAt: new Date(),
+      fromAgent: makeAgentId("memory-agent"),
+      path: "agents/intelligence-agent/inbox/msg-42.md",
+      excerpt: "...",
+    };
+
+    const signals: SignalBundle = {
+      ...emptySignals,
+      actionItems: [issueSignal, inboxSignal],
+    };
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+
+    expect(contract.actionItems).toHaveLength(2);
+    expect(contract.actionItems[0]).toEqual({
+      signalId: "github-issue:xeeban/emergent-praxis#861",
+      sourceRef: "https://github.com/xeeban/emergent-praxis/issues/861",
+    });
+    // inbox-message has no url, so sourceRef is absent
+    expect(contract.actionItems[1]).toEqual({ signalId: "inbox:msg-42" });
+  });
+
+  it("derives allowedSideEffects from write scopes (read-only when all empty)", () => {
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "manual", invokedBy: "source" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(contract.allowedSideEffects).toEqual(["read"]);
+  });
+
+  it("synthesizes objective from wakeReason variant when no done_when present", () => {
+    const scheduled = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(scheduled.objective).toBe("Scheduled wake (0 9 * * *)");
+
+    const event = assembleExecutionContract({
+      wakeReason: { kind: "event", eventType: "github.issue.opened", eventId: "issue-42" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(event.objective).toBe("Event-triggered wake: github.issue.opened");
+
+    const manual = assembleExecutionContract({
+      wakeReason: { kind: "manual", invokedBy: "source" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(manual.objective).toBe("Manual wake invoked by source");
+  });
+
+  it("preserves wakeMode and wakeReason on the assembled contract", () => {
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 23 * * *" },
+      wakeMode: "group-facilitator",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(contract.wakeMode).toBe("group-facilitator");
+    expect(contract.wakeReason).toEqual({ kind: "scheduled", cronExpression: "0 23 * * *" });
+  });
+
+  it("approval policy stays 'none' when approval_required_for is empty", () => {
+    const declaration = contractDeclarationSchema.parse({
+      done_when: ["do the thing"],
+      approval_required_for: [],
+    });
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+    expect(contract.approval).toEqual({ mode: "none" });
+  });
+});

--- a/packages/core/src/runtime/execution-contract.ts
+++ b/packages/core/src/runtime/execution-contract.ts
@@ -26,7 +26,7 @@
 
 import { z } from "zod";
 
-import type { CostBudget, WakeMode, WakeReason } from "../execution/index.js";
+import type { CostBudget, Signal, SignalBundle, WakeMode, WakeReason } from "../execution/index.js";
 import type { ApprovalPolicy, ToolPermission } from "../tools/registry.js";
 
 // ---------------------------------------------------------------------------
@@ -139,3 +139,150 @@ export const contractDeclarationSchema = z
  *  the parent schema; this type is what consumers see when a role
  *  declares the block. */
 export type ContractDeclaration = z.infer<typeof contractDeclarationSchema>;
+
+// ---------------------------------------------------------------------------
+// assembleExecutionContract (Phase 4 PR 2)
+// ---------------------------------------------------------------------------
+
+/** GitHub write scope shape consumed by {@link assembleExecutionContract}.
+ *  Mirrors the subset of `RegisteredAgent.githubWriteScopes` the contract
+ *  cares about — pulled out so this module does not depend on `daemon/`. */
+export interface GithubWriteScopesView {
+  readonly issueComments: readonly string[];
+  readonly branchCommits: readonly { readonly repo: string; readonly paths: readonly string[] }[];
+  readonly labels: readonly string[];
+  readonly issues: readonly string[];
+}
+
+/** Inputs to {@link assembleExecutionContract}. */
+export interface AssembleExecutionContractArgs {
+  readonly wakeReason: WakeReason;
+  readonly wakeMode: WakeMode;
+  /** Parsed `contract:` block from `role.md`. Undefined when the role
+   *  does not declare a contract — the function still returns a valid
+   *  {@link ExecutionContract} populated only from runtime context. */
+  readonly declaration: ContractDeclaration | undefined;
+  readonly signals: SignalBundle;
+  readonly budget: CostBudget;
+  readonly githubWriteScopes: GithubWriteScopesView;
+}
+
+/** Maps a single action-item Signal to an {@link ActionItemRef}. */
+const toActionItemRef = (signal: Signal): ActionItemRef => {
+  const sourceRef =
+    signal.kind === "github-issue" || signal.kind === "governance-round" ? signal.url : undefined;
+  return {
+    signalId: signal.id,
+    ...(sourceRef !== undefined ? { sourceRef } : {}),
+  };
+};
+
+/**
+ * Build a full {@link ExecutionContract} for one wake.
+ *
+ * Combines the operator-authored `contract:` block from `role.md` with
+ * runtime context (signal bundle, budget, wake reason, GitHub write
+ * scopes). The result is the single source of truth used by:
+ *
+ *   - The prompt assembler (PR 3) to render `requiredOutputs` and
+ *     `actionItems` into the system prompt.
+ *   - `validateOutcomes` (PR 4) to score the wake against the
+ *     declared obligations.
+ *
+ * Phase 4 PR 2 keeps the assembly intentionally minimal:
+ *
+ *   - `objective` is the first `done_when` string when present, else
+ *     a synthesized one-line derived from `wakeReason`.
+ *   - `requiredOutputs` is the concatenation of `committed_artifacts`
+ *     and `runtime_artifacts` from the declaration; each entry becomes
+ *     a glob-style required-output descriptor.
+ *   - `actionItems` is the SignalBundle's action-item array mapped 1:1
+ *     to {@link ActionItemRef}.
+ *   - `completionConditions` is one entry per `done_when` string.
+ *   - `verification` is one required step per `verification_required_for`
+ *     entry.
+ *   - `allowedSideEffects` is derived from `githubWriteScopes`: `read`
+ *     is always granted; `write` is added when any write scope is
+ *     non-empty. Finer-grained tool permission grants land in a later
+ *     PR.
+ *   - `approval` requires Source approval when `approval_required_for`
+ *     is non-empty; the reason string lists the gated keys.
+ *
+ * Phase 5+ will replace this with full Tsinghua NLAH semantics
+ * (disjunction, exemption, partial-credit). The v1 form is brutally
+ * simple per ADR-0048 §Decision-drivers (1) and the
+ * "v1 DSLs brutally simple" project rule.
+ */
+export const assembleExecutionContract = (
+  args: AssembleExecutionContractArgs,
+): ExecutionContract => {
+  const declaration = args.declaration;
+
+  const committedOutputs = (declaration?.committed_artifacts ?? []).map((path) => ({
+    kind: "committed-artifact" as const,
+    path,
+    description: `Committed artifact matching: ${path}`,
+  }));
+  const runtimeOutputs = (declaration?.runtime_artifacts ?? []).map((path) => ({
+    kind: "runtime-artifact" as const,
+    path,
+    description: `Runtime artifact matching: ${path}`,
+  }));
+  const requiredOutputs = [...committedOutputs, ...runtimeOutputs];
+
+  const actionItems = args.signals.actionItems.map(toActionItemRef);
+
+  const completionConditions: readonly CompletionCondition[] = (declaration?.done_when ?? []).map(
+    (description, idx) => ({
+      id: `done-when-${String(idx)}`,
+      description,
+    }),
+  );
+
+  const verification: readonly VerificationStep[] = (
+    declaration?.verification_required_for ?? []
+  ).map((id, idx) => ({
+    id: `verification-${String(idx)}`,
+    description: `Verification required for: ${id}`,
+    required: true,
+  }));
+
+  const writeScopes = args.githubWriteScopes;
+  const hasAnyWrite =
+    writeScopes.issueComments.length > 0 ||
+    writeScopes.branchCommits.length > 0 ||
+    writeScopes.labels.length > 0 ||
+    writeScopes.issues.length > 0;
+  const allowedSideEffects: readonly ToolPermission[] = hasAnyWrite ? ["read", "write"] : ["read"];
+
+  const firstDoneWhen = declaration?.done_when[0];
+  const objective =
+    firstDoneWhen ??
+    (args.wakeReason.kind === "scheduled"
+      ? `Scheduled wake (${args.wakeReason.cronExpression})`
+      : args.wakeReason.kind === "event"
+        ? `Event-triggered wake: ${args.wakeReason.eventType}`
+        : `Manual wake invoked by ${args.wakeReason.invokedBy}`);
+
+  const approvalKeys = declaration?.approval_required_for ?? [];
+  const approval: ApprovalPolicy =
+    approvalKeys.length > 0
+      ? {
+          mode: "required",
+          reason: `Source approval required for: ${approvalKeys.join(", ")}`,
+        }
+      : { mode: "none" };
+
+  return {
+    wakeReason: args.wakeReason,
+    wakeMode: args.wakeMode,
+    objective,
+    requiredOutputs,
+    actionItems,
+    completionConditions,
+    verification,
+    allowedSideEffects,
+    budget: args.budget,
+    approval,
+  };
+};


### PR DESCRIPTION
## Summary

Wires the `role.md` `contract:` block (shipped in PR 1, commit e617289) through to `AgentSpawnContext`. The full `ExecutionContract` is now assembled per-wake from the parsed declaration + signal bundle + budget + write scopes, and attached to `AgentSpawnContext.contract` ready for PR 3 (prompt assembly) and PR 4 (`validateOutcomes`) to consume.

ADR references: [ADR-0047](./docs/adr/0047-execution-contracts.md) (Execution Contracts) defines the contract shape. [ADR-0048](./docs/adr/0048-phase-4-scope-lock-for-v0.8.0.md) (Accepted 2026-05-12) defines the v0.8.0 scope lock that compresses Phase 4 to ~8 days; this PR lands within the §6 calendar.

## Changes

**`packages/core/src/runtime/execution-contract.ts`** — new `assembleExecutionContract()` function:
- Input: optional `ContractDeclaration` (from role.md PR 1) + `SignalBundle` + `CostBudget` + `GithubWriteScopesView`.
- Output: full `ExecutionContract`.
- V1 mapping (brutally simple per ADR-0048 Decision-driver 1):
  - `done_when` → `completionConditions[]` + first entry → `objective`
  - `committed_artifacts` → `requiredOutputs[kind: committed-artifact]`
  - `runtime_artifacts` → `requiredOutputs[kind: runtime-artifact]`
  - `signals.actionItems` → `actionItems[]` (`ActionItemRef` with `sourceRef` for github-issue / governance-round)
  - `verification_required_for` → `verification[]` (required: true)
  - `approval_required_for` (non-empty) → `approval.mode: required` with reason
  - any write scope non-empty → `allowedSideEffects: [read, write]`; else `[read]`
- Missing-declaration path returns a usable contract from runtime context alone — `objective` synthesized per `WakeReason` variant.

**`packages/core/src/execution/index.ts`** — `AgentSpawnContext.contract` upgraded from the Phase 0 stub (`{objective, doneWhen, allowedSideEffects}`) to the full `ExecutionContract` type. Type-only import sidesteps a runtime cycle with `runtime/execution-contract.ts`.

**`packages/core/src/daemon/index.ts`**:
- `RegisteredAgent.contract: ContractDeclaration` populated from `frontmatter.contract` in `registeredAgentFromLoadedIdentity`.
- `buildSpawnContext()` calls `assembleExecutionContract()` and attaches the result to `AgentSpawnContext.contract`.

**`packages/core/src/runtime/execution-contract.test.ts`** — new test file with 7 tests covering:
- Missing declaration path
- Full declaration mapping all five sub-fields
- `actionItems` mapping with/without `sourceRef`
- `allowedSideEffects` derivation (read-only vs read+write)
- Objective synthesis from each `WakeReason` variant
- WakeMode + WakeReason preservation on the assembled contract
- Approval policy switching on `approval_required_for`

## Engineering Circle consent

ADR-0048 accepted on EP #864 with engineering-agent (Engineering Lead #22) full consent on all four open questions. Facilitator-agent posted clean S3 synthesis. Quality-agent had a routing-gap (no objection filed). Source close 2026-05-12 10:50 PDT.

## Test plan

- [x] `pnpm run build` ✅
- [x] `pnpm run typecheck` ✅
- [x] `pnpm run lint` ✅ (0 errors, 25 pre-existing warnings)
- [x] `pnpm run format:check` ✅
- [x] `pnpm run test` ✅ (1197 passed, 2 skipped — 7 new tests in execution-contract.test.ts)
- [x] PR 1's 24h soak cleared 2026-05-12 10:21 PDT
- [x] intelligence-agent contract block parsed cleanly across 1 daily wake (06:00 PDT 2026-05-12); 2 more daily wakes needed for ADR-0048 §4 acceptance criterion
- [ ] After merge: rebuild + restart EP and CW daemons to pick up PR 2 runtime
- [ ] After merge: 12h soak before PR 3 lands (ADR-0048 §3 compressed timing)

## v0.8.0 calendar (per ADR-0048 §6)

| Day | Date | Action |
|---|---|---|
| Tue | 5-12 | PR 2 (this PR) + PR 3 parallel |
| Wed | 5-13 | PR 4 + PR 5 parallel |
| Thu–Fri | 5-14/15 | 48h observation under full contract |
| Sat | 5-16 | PR 6a (validateBehavior warning-only) |
| Sun | 5-17 | CHANGELOG + README + version bump |
| Mon | 5-18 | Final 24h observation |
| Tue | 5-19 | Tag v0.8.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)