### PR TITLE
fix(spirit): block write_file on role.md/soul.md/harness.yaml (harness#366)

### DIFF
--- a/packages/cli/src/spirit/tools.test.ts
+++ b/packages/cli/src/spirit/tools.test.ts
@@ -81,6 +81,88 @@ describe("Spirit tools — read_file", () => {
   });
 });
 
+describe("Spirit tools — write_file (harness#366 trusted-surface protection)", () => {
+  let root = "";
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), `spirit-test-${randomUUID().slice(0, 8)}-`));
+    mkdirSync(join(root, "agents", "alpha"), { recursive: true });
+    writeFileSync(join(root, "agents", "alpha", "role.md"), "# original role\n", "utf8");
+    writeFileSync(join(root, "agents", "alpha", "soul.md"), "# original soul\n", "utf8");
+    mkdirSync(join(root, "agents", "alpha", "prompts"), { recursive: true });
+    writeFileSync(join(root, "agents", "alpha", "prompts", "wake.md"), "wake task\n", "utf8");
+    mkdirSync(join(root, "murmuration"), { recursive: true });
+    writeFileSync(join(root, "murmuration", "soul.md"), "# original mur soul\n", "utf8");
+    writeFileSync(join(root, "harness.yaml"), "version: 0\n", "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const getTool = (name: string) => {
+    const tools = buildSpiritTools({ rootDir: root, send: noopSend });
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not found`);
+    return tool;
+  };
+
+  it("refuses to overwrite agents/<id>/role.md (Phase 4 PR 3 trusted-segment surface)", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "agents/alpha/role.md",
+      content: "# rewritten\n",
+    });
+    expect(result).toMatch(/operator config/);
+    expect(result).toMatch(/harness#366/);
+  });
+
+  it("refuses to overwrite agents/<id>/soul.md", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "agents/alpha/soul.md",
+      content: "# rewritten\n",
+    });
+    expect(result).toMatch(/operator config/);
+  });
+
+  it("refuses to overwrite murmuration/soul.md", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "murmuration/soul.md",
+      content: "# rewritten\n",
+    });
+    expect(result).toMatch(/operator config/);
+  });
+
+  it("refuses to overwrite harness.yaml", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({ path: "harness.yaml", content: "version: 999\n" });
+    expect(result).toMatch(/operator config/);
+  });
+
+  it("allows writes to agents/<id>/prompts/wake.md (only role.md and soul.md are blocked)", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "agents/alpha/prompts/wake.md",
+      content: "new wake\n",
+    });
+    expect(result).toMatch(/wrote/);
+  });
+
+  it("allows writes to a normal artifact path", async () => {
+    const tool = getTool("write_file");
+    const result = await tool.execute({ path: "drafts/article.md", content: "# draft\n" });
+    expect(result).toMatch(/wrote/);
+  });
+
+  it("read_file still works on the protected files (only writes are blocked)", async () => {
+    const tool = getTool("read_file");
+    const result = await tool.execute({ path: "agents/alpha/role.md" });
+    expect(result).toBe("# original role\n");
+  });
+});
+
 describe("Spirit tools — list_dir", () => {
   let root = "";
 

--- a/packages/cli/src/spirit/tools.ts
+++ b/packages/cli/src/spirit/tools.ts
@@ -104,6 +104,25 @@ const safePath = (rootDir: string, path: string, mode: "read" | "write" = "read"
         `writing under ".murmuration/" is not allowed — that subtree is daemon-authored runtime state`,
       );
     }
+
+    // Operator config files — identity + governance authority. ADR-0048 PR 3
+    // injects role.md content as a `trusted` system-prompt segment; if an
+    // agent could rewrite its own role.md it could escalate by editing
+    // `done_when`, clearing `approval_required_for`, or planting prompt
+    // injection in any frontmatter field. harness#366.
+    //
+    // Normalize separators once so the regex catches Windows and POSIX paths.
+    const relPosix = rel.replace(/\\/g, "/");
+    if (
+      /^agents\/[^/]+\/role\.md$/.test(relPosix) ||
+      /^agents\/[^/]+\/soul\.md$/.test(relPosix) ||
+      relPosix === "murmuration/soul.md" ||
+      relPosix === "harness.yaml"
+    ) {
+      throw new PathSafetyError(
+        `writing operator config "${path}" is not allowed — role.md, soul.md, and harness.yaml are the trusted identity surface (harness#366)`,
+      );
+    }
   }
   return abs;
 };


### PR DESCRIPTION
## Summary

Closes #366. Extends Spirit's `safePath` write guard to reject overwrites of the four operator-authored identity-trust paths:

- `agents/<id>/role.md`
- `agents/<id>/soul.md`
- `murmuration/soul.md`
- `harness.yaml`

## Why

Phase 4 PR 3 (`renderContractForPrompt` + system-prompt segment, on branch `feat/phase-4-pr-3-contract-aware-prompt`) injects `role.md`-derived contract content as a **`trusted`** prompt segment per ADR-0045 trust classification.

The existing safePath write guard blocked writes under `.murmuration/` only. A compromised or hallucinating agent with Spirit `write_file` access could overwrite its own `role.md` to inject malicious `done_when` strings into the trusted prompt segment, clear `approval_required_for` to bypass Source approval gates, or plant arbitrary content in any frontmatter field.

Engineering-agent identified this as a pre-PR-3 gate during an unprompted Phase 4 audit on 2026-05-13 (EP wake digest at `/runs/engineering-agent/2026-05-13/digest-2026-05-13T08-26-30Z-5980aaaa.md`).

## Severity

Medium. Requires Spirit write access + an already-compromised agent session. Not a remote attacker path.

## Test plan

- [x] 7 new tests in `packages/cli/src/spirit/tools.test.ts`:
  - role.md write blocked (message includes `harness#366`)
  - soul.md write blocked
  - murmuration/soul.md write blocked
  - harness.yaml write blocked
  - agents/<id>/prompts/wake.md write allowed (subdirectory pass-through)
  - normal artifact path write allowed
  - read_file on protected paths still works (read access unaffected)
- [x] `pnpm run build` ✅
- [x] `pnpm run typecheck` ✅
- [x] `pnpm run lint` ✅ (0 errors)
- [x] `pnpm run format:check` ✅
- [x] `pnpm run test` ✅ (1204 passed, +7 new)

## Cross-platform

`relative()` output is normalized to forward slashes via `replace(/\\\\/g, "/")` before regex matching so the check works on both POSIX (`agents/foo/role.md`) and Windows (`agents\\foo\\role.md`).

## Sequencing

Ships **before** Phase 4 PR 3 (contract-aware prompt) merges. Unblocks PR 3 push from local branch `feat/phase-4-pr-3-contract-aware-prompt` once this merges.

## References

- harness#366 (security medium, this PR closes it)
- ADR-0047 (Execution Contracts)
- ADR-0048 (Phase 4 scope lock for v0.8.0, Accepted 2026-05-12)
- ADR-0045 (Prompt Boundary trust classification — defines why role.md content becomes \`trusted\` in PR 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)