### PR TITLE
fix(validation): treat GitHub issue URLs as structural evidence (harness#364 Part A)

### DIFF
--- a/packages/core/src/execution/execution.test.ts
+++ b/packages/core/src/execution/execution.test.ts
@@ -416,6 +416,113 @@ describe("validateWake", () => {
     expect(v.reason).toContain("not addressed by structured evidence");
   });
 
+  // -------------------------------------------------------------------------
+  // harness#364 Part A — GitHub issue URL counts as structural evidence
+  // -------------------------------------------------------------------------
+
+  it("treats a full GitHub issue URL in wakeSummary as structural evidence (harness#364)", () => {
+    // Reproduces engineering-agent's 2026-05-11 wake on EP #845: comment
+    // posted via subscription-CLI subprocess; URL lands in wakeSummary
+    // but no receipt exists. Before this fix, the wake was flagged
+    // narrative-only-claim → idle.
+    const directive = makeIssueSignal(845, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Posted consent at https://github.com/xeeban/emergent-praxis/issues/845#issuecomment-4438893756. Round complete.",
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([]);
+  });
+
+  it("treats a bare issue URL (no comment anchor) as structural evidence", () => {
+    const directive = makeIssueSignal(845, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Done — see https://github.com/xeeban/emergent-praxis/issues/845",
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([]);
+  });
+
+  it("URL evidence works in governance event payloads too", () => {
+    const directive = makeIssueSignal(845, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Round complete.",
+      governanceEvents: [
+        {
+          kind: "report",
+          payload: {
+            note: "Posted consent at https://github.com/xeeban/emergent-praxis/issues/845",
+          },
+        },
+      ],
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([]);
+  });
+
+  it("URL word boundary: /issues/845 in the wake does not satisfy a directive on #84", () => {
+    // Directive on #84, but wakeSummary mentions #84 narratively AND has a
+    // URL pointing at #845 — the URL must NOT count as evidence for #84,
+    // and the bare #84 mention should still be flagged narrative-only-claim.
+    const directive = makeIssueSignal(84, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Reviewed #84 narratively. Filed related URL: https://github.com/xeeban/emergent-praxis/issues/845",
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([{ issueNumber: 84, reason: "narrative-only-claim" }]);
+  });
+
+  it("URL word boundary: /issues/845 does not satisfy a directive on issue 8450", () => {
+    const directive = makeIssueSignal(8450, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted at https://github.com/xeeban/emergent-praxis/issues/845",
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([
+      { issueNumber: 8450, reason: "no-structured-action" },
+    ]);
+  });
+
+  it("bare #845 reference without URL is still narrative-only-claim (URLs are the load-bearing signal)", () => {
+    const directive = makeIssueSignal(845, ["source-directive", "assigned:engineering-agent"]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "I have posted my CONSENT to issue #845.",
+    };
+    const v = validateWake(
+      mkCtx({ signals: [directive], agentId: "engineering-agent" }),
+      result,
+      [],
+    );
+    expect(v.directivesUnaddressed).toEqual([{ issueNumber: 845, reason: "narrative-only-claim" }]);
+  });
+
   it("flags a directive as no-structured-action when the wake produced nothing referring to it", () => {
     const directive = makeIssueSignal(571, ["source-directive", "assigned:architecture-agent"]);
     const v = validateWake(

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -781,6 +781,34 @@ const buildIssueReferenceMatchers = (issueNum: number): readonly RegExp[] => {
 };
 
 /**
+ * URL-form matcher for resolving "does this text reference a real GitHub
+ * issue by URL". Used as structural evidence (Part A of harness#364):
+ * subscription-CLI agents post comments via their subprocess tool layer
+ * — these never reach `result.actions`/`actionReceipts`, but the URL
+ * typically lands in `wakeSummary` or a governance event payload (e.g.
+ * `https://github.com/xeeban/emergent-praxis/issues/845` or
+ * `.../issues/845#issuecomment-NNN`).
+ *
+ * Rationale: a fully-qualified GitHub URL is much harder to hallucinate
+ * than a plain `#N` reference, and an agent emitting it has typically
+ * received it from a real tool call's response payload. Treating these
+ * as structural evidence eliminates the false-positive
+ * `narrative-only-claim` that fires on every consent-round response from
+ * subscription-CLI agents in EP (engineering-agent's 2026-05-12 audit).
+ *
+ * Full-fidelity fix (Part B) is an opt-in `verifiedActions` field on
+ * `AgentResult` populated by subscription-CLI executors from confirmed
+ * subprocess operations — deferred to v0.8.1 per ADR-0048.
+ */
+const buildGithubIssueUrlMatcher = (issueNum: number): RegExp => {
+  const n = String(issueNum);
+  // github.com/<owner>/<repo>/issues/<n> with word boundary on the
+  // trailing digit so `/issues/845` does not match `/issues/8450`.
+  // Also handles the comment-anchor form `/issues/<n>#issuecomment-...`.
+  return new RegExp(`github\\.com/[^/]+/[^/]+/issues/${n}(?!\\d)`, "i");
+};
+
+/**
  * Default validation: checks artifact count, action item coverage, and
  * structured-evidence backing for any source-directive items in signals.
  * Used when no custom validator is configured.
@@ -899,6 +927,19 @@ export const validateWake = (
     const hasUnexecutedAction = result.actions.some((a) => a.issueNumber === issueNum);
     if (hasUnexecutedAction) {
       directivesUnaddressed.push({ issueNumber: issueNum, reason: "no-successful-receipt" });
+      continue;
+    }
+
+    // harness#364 Part A: a fully-qualified GitHub issue URL in the wake
+    // summary or any governance event counts as structural evidence. This
+    // covers subscription-CLI agents whose subprocess-internal comment
+    // posts never land in `result.actions` but typically leave a URL in
+    // the wake summary (the tool-call response includes the issue URL).
+    const urlMatcher = buildGithubIssueUrlMatcher(issueNum);
+    if (urlMatcher.test(result.wakeSummary)) {
+      continue;
+    }
+    if (govEventStrings.some((s) => s !== "" && urlMatcher.test(s))) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Closes #364 (Part A — near-term mitigation). Eliminates the false-positive \`narrative-only-claim\` that fires on every consent-round response from subscription-CLI agents (claude/codex/gemini CLI providers) — the dominant population in EP and the population we ship v0.8.0 with.

## Root cause

Engineering-agent's [2026-05-12 audit](https://github.com/murmurations-ai/murmurations-harness/issues/364#issuecomment-4438893756) traced this:

1. Subscription-CLI agents post comments via subprocess-internal tool calls.
2. The comment lands but the harness's \`onWakeActions\` executor never sees it (no entry in \`result.actions\`).
3. \`validateWake\` finds no receipt for the directive issue number.
4. Falls through to wake-summary check; flags the \`#N\` reference as \`narrative-only-claim\`.
5. The wake is marked idle despite the comment being real and landing successfully.

Verified by EP engineering-agent wake \`56915398\` (2026-05-12): comment landed on EP #845 at 16:17:22 UTC, but the wake was logged \`daemon.wake.directives.unaddressed\` with reason \`narrative-only-claim\`.

## Fix

\`buildGithubIssueUrlMatcher(issueNum)\` builds a word-boundary regex:

\`\`\`
github\\.com/[^/]+/[^/]+/issues/<N>(?!\\d)
\`\`\`

When this regex matches \`result.wakeSummary\` OR any governance event payload string, the directive is treated as satisfied. The trailing \`(?!\\d)\` lookahead prevents \`/issues/845\` from satisfying directives on \`#84\` or \`#8450\`.

A URL is a much higher-fidelity signal than a bare \`#N\` reference because:
- LLMs rarely hallucinate complete \`github.com/<owner>/<repo>/issues/<n>\` paths
- Agents typically receive the URL from a real tool-call response payload (e.g., the GitHub CLI \`gh issue view\` output)

## Part B (deferred to v0.8.1 per ADR-0048)

Engineering-agent's clean long-term fix: opt-in \`verifiedActions\` field on \`AgentResult\` populated by subscription-CLI executors from confirmed subprocess operations. Out of scope for v0.8.0.

## Test plan

- [x] 6 new tests in \`packages/core/src/execution/execution.test.ts\`:
  - Full URL with comment anchor → satisfied
  - Bare issue URL (no anchor) → satisfied
  - URL in governance event payload → satisfied
  - URL word boundary: \`/issues/845\` does NOT satisfy \`#84\`
  - URL word boundary: \`/issues/845\` does NOT satisfy \`#8450\`
  - Bare \`#845\` without URL → still \`narrative-only-claim\` (URLs are the load-bearing signal)
- [x] \`pnpm run build\` ✅
- [x] \`pnpm run typecheck\` ✅
- [x] \`pnpm run lint\` ✅ (0 errors)
- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1210 passed, 2 skipped — +6 new)

## Sequencing

Ships before Phase 4 PR 3 + PR 4 merge. Engineering-agent flagged this as a P1 blocker before Phase 4 ships. Together with #366 (merged in #368) and #365 (cold-start measurement, closed), this clears the three Phase 4 pre-merge gates.

## References

- harness#364 (this PR closes Part A)
- ADR-0047 (Execution Contracts)
- ADR-0048 (Phase 4 scope lock, Accepted 2026-05-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)