### PR TITLE
Phase 4 PR 3: contract-aware system prompt

### DIFF
--- a/packages/core/src/runtime/execution-contract.test.ts
+++ b/packages/core/src/runtime/execution-contract.test.ts
@@ -12,7 +12,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { assembleExecutionContract, contractDeclarationSchema } from "./execution-contract.js";
+import {
+  assembleExecutionContract,
+  contractDeclarationSchema,
+  renderContractForPrompt,
+} from "./execution-contract.js";
 import type { Signal, SignalBundle } from "../execution/index.js";
 import { makeAgentId, makeWakeId } from "../execution/index.js";
 
@@ -227,5 +231,120 @@ describe("assembleExecutionContract", () => {
       githubWriteScopes: emptyScopes,
     });
     expect(contract.approval).toEqual({ mode: "none" });
+  });
+});
+
+describe("renderContractForPrompt", () => {
+  it("renders the no-obligations notice when only runtime context is present", () => {
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+
+    const rendered = renderContractForPrompt(contract);
+    expect(rendered).toMatch(/^# Execution Contract\n/);
+    expect(rendered).toContain("**Objective:** Scheduled wake (0 9 * * *)");
+    expect(rendered).toContain("_No explicit obligations declared");
+    expect(rendered).toContain("Permitted side effects");
+    expect(rendered).toContain("`read`");
+    expect(rendered).not.toContain("## Completion conditions");
+    expect(rendered).not.toContain("## Required outputs");
+    expect(rendered).not.toContain("## Source approval");
+  });
+
+  it("renders all sections when the contract is fully populated", () => {
+    const declaration = contractDeclarationSchema.parse({
+      done_when: [
+        "Commit at least one research artifact under drafts/",
+        "OR post a substantive comment on an open issue",
+      ],
+      committed_artifacts: ["drafts/**/*.md", "docs/research/**/*.md"],
+      runtime_artifacts: [".murmuration/runs/**/*.md"],
+      verification_required_for: ["github.create_pull_request"],
+      approval_required_for: ["admin"],
+    });
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "manual", invokedBy: "source" },
+      wakeMode: "individual",
+      declaration,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: writeScopes,
+    });
+
+    const rendered = renderContractForPrompt(contract);
+    expect(rendered).toContain(
+      "**Objective:** Commit at least one research artifact under drafts/",
+    );
+    expect(rendered).toContain("## Completion conditions");
+    expect(rendered).toContain("- Commit at least one research artifact under drafts/");
+    expect(rendered).toContain("- OR post a substantive comment on an open issue");
+    expect(rendered).toContain("## Required outputs");
+    expect(rendered).toContain("**committed-artifact** `drafts/**/*.md`");
+    expect(rendered).toContain("**runtime-artifact** `.murmuration/runs/**/*.md`");
+    expect(rendered).toContain("## Verification required");
+    expect(rendered).toContain("Verification required for: github.create_pull_request (required)");
+    expect(rendered).toContain("## Permitted side effects");
+    expect(rendered).toContain("`read, write`");
+    expect(rendered).toContain("## Source approval");
+    expect(rendered).toContain("**required** — Source approval required for: admin");
+  });
+
+  it("omits the verification section when no verification steps are declared", () => {
+    const declaration = contractDeclarationSchema.parse({
+      done_when: ["produce a digest"],
+      committed_artifacts: ["digests/**/*.md"],
+    });
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+
+    const rendered = renderContractForPrompt(contract);
+    expect(rendered).toContain("## Completion conditions");
+    expect(rendered).toContain("## Required outputs");
+    expect(rendered).not.toContain("## Verification required");
+    expect(rendered).not.toContain("## Source approval");
+  });
+
+  it("omits the approval section when mode is 'none'", () => {
+    const declaration = contractDeclarationSchema.parse({
+      done_when: ["do the thing"],
+    });
+
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
+      wakeMode: "individual",
+      declaration,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: emptyScopes,
+    });
+
+    const rendered = renderContractForPrompt(contract);
+    expect(rendered).not.toContain("## Source approval");
+  });
+
+  it("shows read+write when write scopes are present", () => {
+    const contract = assembleExecutionContract({
+      wakeReason: { kind: "manual", invokedBy: "source" },
+      wakeMode: "individual",
+      declaration: undefined,
+      signals: emptySignals,
+      budget: baseBudget,
+      githubWriteScopes: writeScopes,
+    });
+    const rendered = renderContractForPrompt(contract);
+    expect(rendered).toContain("`read, write`");
   });
 });

--- a/packages/core/src/runtime/execution-contract.ts
+++ b/packages/core/src/runtime/execution-contract.ts
@@ -286,3 +286,109 @@ export const assembleExecutionContract = (
     approval,
   };
 };
+
+// ---------------------------------------------------------------------------
+// renderContractForPrompt (Phase 4 PR 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render an {@link ExecutionContract} as a prompt segment body.
+ *
+ * Used by `PromptAssembler` to inject the contract into the system prompt
+ * as a `trusted` segment (the operator authored the underlying `role.md`
+ * `contract:` block; the harness assembled the runtime fields). The agent
+ * reads this block to learn what completion looks like and what side
+ * effects it may exercise this wake.
+ *
+ * Format is brutally simple per ADR-0048 / "v1 DSLs brutally simple":
+ * markdown sections with one bullet per item, no nesting, no DSL. The
+ * agent's role narrative remains authoritative on *how* to do the work;
+ * this block clarifies *what counts as done*.
+ *
+ * Sections are omitted when their list is empty (with the exception of
+ * the objective line, which is always emitted). When the contract has
+ * no obligations declared, the block degrades to a short
+ * "no obligations declared" notice rather than a wall of empty sections.
+ */
+export const renderContractForPrompt = (contract: ExecutionContract): string => {
+  const lines: string[] = [];
+  lines.push("# Execution Contract");
+  lines.push("");
+  lines.push("You must satisfy this contract to mark this wake productive.");
+  lines.push("");
+  lines.push(`**Objective:** ${contract.objective}`);
+
+  const hasObligation =
+    contract.completionConditions.length > 0 ||
+    contract.requiredOutputs.length > 0 ||
+    contract.verification.length > 0;
+
+  if (!hasObligation) {
+    lines.push("");
+    lines.push(
+      "_No explicit obligations declared in `role.md` `contract:` block. " +
+        "Follow your role narrative; the validator will fall back to artifact-presence heuristics._",
+    );
+  }
+
+  if (contract.completionConditions.length > 0) {
+    lines.push("");
+    lines.push("## Completion conditions");
+    lines.push("");
+    lines.push("This wake is productive when ALL of these conditions hold:");
+    lines.push("");
+    for (const cond of contract.completionConditions) {
+      lines.push(`- ${cond.description}`);
+    }
+  }
+
+  if (contract.requiredOutputs.length > 0) {
+    lines.push("");
+    lines.push("## Required outputs");
+    lines.push("");
+    lines.push(
+      "Produce at least one artifact matching each path. Globs accepted (e.g. `drafts/**/*.md`):",
+    );
+    lines.push("");
+    for (const out of contract.requiredOutputs) {
+      const pathPart = out.path !== undefined ? ` \`${out.path}\`` : "";
+      lines.push(`- **${out.kind}**${pathPart} — ${out.description}`);
+    }
+  }
+
+  if (contract.verification.length > 0) {
+    lines.push("");
+    lines.push("## Verification required");
+    lines.push("");
+    lines.push("These steps must succeed before the wake counts as productive:");
+    lines.push("");
+    for (const step of contract.verification) {
+      const requiredTag = step.required ? " (required)" : " (advisory)";
+      lines.push(`- ${step.description}${requiredTag}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## Permitted side effects");
+  lines.push("");
+  const sideEffectList = contract.allowedSideEffects.join(", ");
+  lines.push(
+    `You may exercise tools whose permission is one of: \`${sideEffectList}\`. ` +
+      "Tools requiring permissions outside this set will be refused at the tool layer.",
+  );
+
+  if (contract.approval.mode !== "none") {
+    lines.push("");
+    lines.push("## Source approval");
+    lines.push("");
+    const reason = contract.approval.reason ?? "Source approval is required for this wake's scope.";
+    lines.push(`**${contract.approval.mode}** — ${reason}`);
+    lines.push("");
+    lines.push(
+      "If an action would invoke an approval-gated capability, file the request as a " +
+        "structured action item rather than executing it; the harness will pause for Source.",
+    );
+  }
+
+  return lines.join("\n");
+};

--- a/packages/core/src/runtime/prompt-assembler.ts
+++ b/packages/core/src/runtime/prompt-assembler.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import type { AgentSpawnContext } from "../execution/index.js";
 import { renderSignalForPrompt } from "../execution/index.js";
 import { runsDirForAgent } from "../daemon/runs-path.js";
+import { renderContractForPrompt } from "./execution-contract.js";
 import { scanSkills, formatSkillsPromptBlock } from "../skills/index.js";
 
 // ---------------------------------------------------------------------------
@@ -249,7 +250,27 @@ export class PromptAssembler {
       content: MEMORY_PASSIVE_DATA_INSTRUCTION,
     };
 
+    // 4. Execution contract — emitted when spawn carries a contract
+    //    (Phase 4 PR 3, ADR-0047, ADR-0048). The contract is trusted because
+    //    it is assembled from the operator-authored role.md contract: block
+    //    plus harness-controlled runtime fields (budget, write scopes, signal
+    //    action items). Tells the agent what completion looks like and which
+    //    side effects are permitted.
+    const contractSegment: PromptSegment | undefined =
+      spawn.contract !== undefined
+        ? {
+            id: "execution-contract",
+            kind: "contract",
+            trust: "trusted",
+            content: renderContractForPrompt(spawn.contract),
+            sourceRef: `agents/${agentDir}/role.md#contract`,
+          }
+        : undefined;
+
     const system: PromptSegment[] = [identitySegment, skillsSegment, memoryInstructionSegment];
+    if (contractSegment !== undefined) {
+      system.push(contractSegment);
+    }
     // All system segments are stable — volatile content (signals, digests) is
     // in the user message. cacheAnchorIndex = system.length signals that
     // the full system array is cache-stable.


### PR DESCRIPTION
## Summary

Injects the assembled \`ExecutionContract\` (PR 2) into the system prompt as a \`trusted\` segment so the agent reads what completion looks like and which side effects are permitted before doing the wake.

Unblocked by:
- PR #368 (harness#366) — \`safePath\` now blocks agent self-edits of role.md/soul.md/harness.yaml, so injecting role.md-derived content as \`trusted\` is safe.
- PR #369 (harness#364 Part A) — validateWake now treats GitHub issue URLs as structural evidence.
- harness#365 cold-start gate cleared (138ms, 0 API calls — measured against the production daemon).

## Changes

**\`packages/core/src/runtime/execution-contract.ts\`**
- New \`renderContractForPrompt(contract)\` function. Brutally-simple v1 markdown:
  - **Objective** (always)
  - **Completion conditions** (when present)
  - **Required outputs** (when present)
  - **Verification required** (when present)
  - **Permitted side effects** (always)
  - **Source approval** (when mode !== \"none\")
- When the role has no \`contract:\` block, degrades to a short \"no obligations declared\" notice.

**\`packages/core/src/runtime/prompt-assembler.ts\`**
- \`PromptAssembler.assemble\` builds an \`execution-contract\` \`PromptSegment\` from \`spawn.contract\` and appends it to the system segments.
- Trust: \`trusted\` (operator-authored role.md + harness-assembled runtime fields).
- \`sourceRef\`: \`agents/<id>/role.md#contract\` for provenance.
- Optional: omitted when \`spawn.contract\` is undefined (test fixtures / pre-Phase-4 callers).

**\`packages/core/src/runtime/execution-contract.test.ts\`**
- 5 new render tests covering: no-obligations notice, full-section render, omitted verification section, omitted approval section, read+write side effects line.

## Test plan

- [x] \`pnpm run build\` ✅
- [x] \`pnpm run typecheck\` ✅
- [x] \`pnpm run lint\` ✅ (0 errors)
- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1215 passed, +5 new)

## Security note

PR #368 (harness#366) is a hard prerequisite for this PR — it closes the path where a compromised agent could edit its own role.md to inject malicious content into the now-\`trusted\` system-prompt segment. Both write_file and the trusted-injection sides of the boundary are in place before this lands.

## References

- ADR-0047 §1 obligation sub-contract
- ADR-0048 §1 (Phase 4 scope lock, Accepted 2026-05-12)
- harness#366 (closed by #368) — the safePath gate that unblocked this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)