### PR TITLE
Phase 4 PR 5: dashboard surfaces validationStatus

### DIFF
--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -987,7 +987,15 @@ export class Daemon {
                 wakeSummary: amendWakeSummaryWithValidation(result.wakeSummary, validation),
               }
             : result;
-        await this.#runArtifactWriter.record(recordedResult, result.costRecord, this.#logger);
+        // Phase 4 PR 5: pass the validation result so the index entry
+        // can record validationStatus, obligationStatus, and the
+        // unmet-required-output count for dashboard surfacing.
+        await this.#runArtifactWriter.record(
+          recordedResult,
+          result.costRecord,
+          this.#logger,
+          isCompleted(result) ? validation : undefined,
+        );
       }
 
       // Governance event routing — hand emitted events to the plugin,

--- a/packages/core/src/daemon/runs.test.ts
+++ b/packages/core/src/daemon/runs.test.ts
@@ -317,4 +317,138 @@ describe("RunArtifactWriter", () => {
       }
     });
   });
+
+  describe("validation propagation (Phase 4 PR 5, ADR-0048)", () => {
+    it("omits validation fields when no WakeValidationResult is passed", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord());
+
+      const indexPath = join(rootDir, "index.jsonl");
+      const entry = JSON.parse((await readFile(indexPath, "utf8")).trim()) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBeUndefined();
+      expect(entry.obligationStatus).toBeUndefined();
+      expect(entry.productive).toBeUndefined();
+      expect(entry.unmetRequiredOutputsCount).toBeUndefined();
+    });
+
+    it("records validationStatus=productive when validation passes", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, {
+        productive: true,
+        artifactCount: 2,
+        actionItemsAddressed: 0,
+        actionItemsAssigned: 0,
+        directivesUnaddressed: [],
+      });
+
+      const entry = JSON.parse(
+        (await readFile(join(rootDir, "index.jsonl"), "utf8")).trim(),
+      ) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBe("productive");
+      expect(entry.productive).toBe(true);
+      expect(entry.artifactCount).toBe(2);
+      expect(entry.directivesUnaddressed).toBe(0);
+    });
+
+    it("records validationStatus=idle when not productive and no directives unaddressed", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, {
+        productive: false,
+        artifactCount: 0,
+        actionItemsAddressed: 0,
+        actionItemsAssigned: 0,
+        directivesUnaddressed: [],
+        reason: "wake completed but produced no artifacts",
+      });
+
+      const entry = JSON.parse(
+        (await readFile(join(rootDir, "index.jsonl"), "utf8")).trim(),
+      ) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBe("idle");
+    });
+
+    it("records validationStatus=unaddressed-directives when boundary 5 fires", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, {
+        productive: false,
+        artifactCount: 0,
+        actionItemsAddressed: 0,
+        actionItemsAssigned: 0,
+        directivesUnaddressed: [{ issueNumber: 845, reason: "narrative-only-claim" }],
+        reason: "1 directive(s) in signals not addressed by structured evidence",
+      });
+
+      const entry = JSON.parse(
+        (await readFile(join(rootDir, "index.jsonl"), "utf8")).trim(),
+      ) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBe("unaddressed-directives");
+      expect(entry.directivesUnaddressed).toBe(1);
+    });
+
+    it("records validationStatus=obligation-unmet with unmetRequiredOutputsCount", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, {
+        productive: false,
+        artifactCount: 1,
+        actionItemsAddressed: 0,
+        actionItemsAssigned: 0,
+        directivesUnaddressed: [],
+        obligationStatus: "unmet",
+        unmetRequiredOutputs: [
+          { kind: "committed-artifact", path: "drafts/**/*.md" },
+          { kind: "comment" },
+        ],
+        reason: "contract obligation unmet: 2 required output(s) without matching evidence",
+      });
+
+      const entry = JSON.parse(
+        (await readFile(join(rootDir, "index.jsonl"), "utf8")).trim(),
+      ) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBe("obligation-unmet");
+      expect(entry.obligationStatus).toBe("unmet");
+      expect(entry.unmetRequiredOutputsCount).toBe(2);
+    });
+
+    it("obligation-unmet wins precedence over unaddressed-directives", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, {
+        productive: false,
+        artifactCount: 0,
+        actionItemsAddressed: 0,
+        actionItemsAssigned: 0,
+        directivesUnaddressed: [{ issueNumber: 1, reason: "narrative-only-claim" }],
+        obligationStatus: "unmet",
+        unmetRequiredOutputs: [{ kind: "committed-artifact" }],
+      });
+
+      const entry = JSON.parse(
+        (await readFile(join(rootDir, "index.jsonl"), "utf8")).trim(),
+      ) as RunArtifactIndexEntry;
+
+      expect(entry.validationStatus).toBe("obligation-unmet");
+    });
+  });
 });

--- a/packages/core/src/daemon/runs.ts
+++ b/packages/core/src/daemon/runs.ts
@@ -38,7 +38,7 @@ import { join } from "node:path";
 
 import { formatUSDMicros } from "../cost/usd.js";
 import type { WakeCostRecord } from "../cost/record.js";
-import type { AgentResult } from "../execution/index.js";
+import type { AgentResult, WakeValidationResult } from "../execution/index.js";
 
 /**
  * Audit record for subscription-CLI wakes (T-CLI-9 / harness#301).
@@ -165,16 +165,36 @@ export interface RunArtifactIndexEntry {
    * `idle` — wake ran but produced no artifacts.
    * `unaddressed-directives` — one or more source-directives were not
    *   backed by structured evidence.
+   * `obligation-unmet` — the role.md `contract.requiredOutputs` had at
+   *   least one entry without matching successful evidence (Phase 4 PR 4,
+   *   ADR-0047 §2 obligation sub-contract).
    * `unknown` — validation data unavailable (legacy entry or failed wake).
-   * Near-Term #4 (Proposal 07 Phase 1).
+   * Near-Term #4 (Proposal 07 Phase 1), extended in Phase 4 PR 5.
    */
-  readonly validationStatus?: "productive" | "idle" | "unaddressed-directives" | "unknown";
+  readonly validationStatus?:
+    | "productive"
+    | "idle"
+    | "unaddressed-directives"
+    | "obligation-unmet"
+    | "unknown";
   /**
    * Count of source-directives that were in the signal bundle but not
    * addressed with a successful action receipt (Boundary 5).
    * `0` means all directives were addressed. Absent when none present.
    */
   readonly directivesUnaddressed?: number;
+  /**
+   * Contract obligation status (Phase 4 PR 4, ADR-0047 §2).
+   * Absent when no contract was supplied (e.g. roles without a
+   * `contract:` block when the daemon predates Phase 4 wiring).
+   */
+  readonly obligationStatus?: "satisfied" | "unmet" | "not-applicable";
+  /**
+   * Number of `requiredOutputs` from the contract that had no matching
+   * successful evidence (Phase 4 PR 4). Populated only when
+   * `obligationStatus === "unmet"`.
+   */
+  readonly unmetRequiredOutputsCount?: number;
   /**
    * Subscription-CLI audit context (T-CLI-9 / harness#301).
    * Present on all subscription-CLI wakes; absent for API-provider wakes.
@@ -197,11 +217,15 @@ export class RunArtifactWriter {
    * Record one wake's artifacts. Catches all I/O errors internally
    * and reports them via the optional logger so the daemon's wake
    * loop is never blocked by a failed write.
+   *
+   * `validation` is optional so test fixtures and legacy callers
+   * continue to work; production daemon wakes always pass it (Phase 4 PR 5).
    */
   public async record(
     result: AgentResult,
     costRecord: WakeCostRecord | undefined,
     logger?: RunArtifactLogger,
+    validation?: WakeValidationResult,
   ): Promise<void> {
     try {
       const now = this.#now();
@@ -228,6 +252,7 @@ export class RunArtifactWriter {
         costRecord,
         digestRelativePath,
         this.#subscriptionCli,
+        validation,
       );
       // Newline-terminated so readers can stream line-by-line.
       await appendFile(indexAbsolutePath, `${JSON.stringify(entry)}\n`, "utf8");
@@ -259,16 +284,34 @@ const outcomeKindOf = (result: AgentResult): RunArtifactIndexEntry["outcome"] =>
   }
 };
 
+/**
+ * Compute the dashboard-facing validationStatus from a WakeValidationResult.
+ * Precedence: obligation-unmet > unaddressed-directives > idle > productive.
+ * Returns undefined when no validation result is supplied (legacy / test
+ * callers) — the dashboard treats absent as "unknown".
+ */
+const computeValidationStatus = (
+  validation: WakeValidationResult | undefined,
+): RunArtifactIndexEntry["validationStatus"] => {
+  if (validation === undefined) return undefined;
+  if (validation.obligationStatus === "unmet") return "obligation-unmet";
+  if (validation.directivesUnaddressed.length > 0) return "unaddressed-directives";
+  if (!validation.productive) return "idle";
+  return "productive";
+};
+
 const buildIndexEntry = (
   result: AgentResult,
   costRecord: WakeCostRecord | undefined,
   digestRelativePath: string,
   subscriptionCli?: SubscriptionCliAuditContext,
+  validation?: WakeValidationResult,
 ): RunArtifactIndexEntry => {
   const outcome = outcomeKindOf(result);
   const durationMs = result.finishedAt.getTime() - result.startedAt.getTime();
   const llm = costRecord?.llm;
   const github = costRecord?.github;
+  const validationStatus = computeValidationStatus(validation);
   return {
     schemaVersion: 1,
     wakeId: result.wakeId.value,
@@ -302,6 +345,20 @@ const buildIndexEntry = (
     },
     digestPath: digestRelativePath,
     ...(subscriptionCli !== undefined ? { subscriptionCli } : {}),
+    ...(validation !== undefined
+      ? {
+          productive: validation.productive,
+          artifactCount: validation.artifactCount,
+          ...(validationStatus !== undefined ? { validationStatus } : {}),
+          directivesUnaddressed: validation.directivesUnaddressed.length,
+          ...(validation.obligationStatus !== undefined
+            ? { obligationStatus: validation.obligationStatus }
+            : {}),
+          ...(validation.unmetRequiredOutputs !== undefined
+            ? { unmetRequiredOutputsCount: validation.unmetRequiredOutputs.length }
+            : {}),
+        }
+      : {}),
   };
 };
 
@@ -359,6 +416,7 @@ export class DispatchRunArtifactWriter {
     result: AgentResult,
     costRecord: WakeCostRecord | undefined,
     logger?: RunArtifactLogger,
+    validation?: WakeValidationResult,
   ): Promise<void> {
     const writer = this.#writers.get(result.agentId.value);
     if (!writer) {
@@ -369,6 +427,6 @@ export class DispatchRunArtifactWriter {
       });
       return;
     }
-    await writer.record(result, costRecord, logger);
+    await writer.record(result, costRecord, logger, validation);
   }
 }

--- a/packages/dashboard-tui/src/dashboard.ts
+++ b/packages/dashboard-tui/src/dashboard.ts
@@ -120,6 +120,24 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
         : a.subscriptionCliPermissionMode === "operator-approved"
           ? cyan(" [op-approved]")
           : "";
+    // Phase 4 PR 5: surface validationStatus from the last wake.
+    // Only show the badge when it carries operator-relevant signal.
+    // `productive` is the silent happy path; `unknown` and absent are
+    // both elided to keep the row terse.
+    const validStr =
+      a.validationStatus === "obligation-unmet"
+        ? red(
+            ` [obl-unmet${
+              a.unmetRequiredOutputsCount !== null && a.unmetRequiredOutputsCount > 0
+                ? `:${String(a.unmetRequiredOutputsCount)}`
+                : ""
+            }]`,
+          )
+        : a.validationStatus === "unaddressed-directives"
+          ? yellow(" [dir-unaddr]")
+          : a.validationStatus === "idle"
+            ? dim(" [idle-val]")
+            : "";
 
     const time = a.lastWake!.toISOString().slice(11, 16);
     const next = a.nextWakeCountdown !== "--" ? a.nextWakeCountdown.padEnd(8) : dim("--".padEnd(8));
@@ -136,7 +154,7 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
         : dim("░".repeat(BAR_WIDTH));
 
     lines.push(
-      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}`,
+      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}${validStr}`,
     );
   }
 

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -34,6 +34,29 @@ export interface AgentStatus {
    * agent has not yet completed a wake.
    */
   readonly subscriptionCliPermissionMode: "restricted" | "operator-approved" | "trusted" | null;
+  /**
+   * Validation status of the last wake (Phase 4 PR 5, ADR-0047, ADR-0048).
+   * Null when the agent has not yet completed a wake or the entry pre-dates
+   * Phase 4 wiring.
+   */
+  readonly validationStatus:
+    | "productive"
+    | "idle"
+    | "unaddressed-directives"
+    | "obligation-unmet"
+    | "unknown"
+    | null;
+  /**
+   * Contract obligation status of the last wake. Null when no contract
+   * was supplied (legacy entries or roles without a `contract:` block when
+   * the daemon predates Phase 4 wiring).
+   */
+  readonly obligationStatus: "satisfied" | "unmet" | "not-applicable" | null;
+  /**
+   * Number of `requiredOutputs` from the contract that had no matching
+   * successful evidence (Phase 4 PR 4). Null when obligationStatus is not "unmet".
+   */
+  readonly unmetRequiredOutputsCount: number | null;
   readonly stale: boolean; // stalled or no wake in > 48h
   readonly consecutiveFailures: number;
   readonly totalWakes: number;
@@ -122,6 +145,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         shadowCostMicros: null,
         shadowCostFormatted: null,
         subscriptionCliPermissionMode: null,
+        validationStatus: null,
+        obligationStatus: null,
+        unmetRequiredOutputsCount: null,
         stale: false,
         consecutiveFailures: a.consecutiveFailures,
         totalWakes: a.totalWakes,
@@ -205,6 +231,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
       let shadowCostMicros: number | null = null;
       let shadowCostFormatted: string | null = null;
       let subscriptionCliPermissionMode: AgentStatus["subscriptionCliPermissionMode"] = null;
+      let validationStatus: AgentStatus["validationStatus"] = null;
+      let obligationStatus: AgentStatus["obligationStatus"] = null;
+      let unmetRequiredOutputsCount: AgentStatus["unmetRequiredOutputsCount"] = null;
       try {
         const indexContent = await readFile(join(runsDir, agentId, "index.jsonl"), "utf8");
         const lines = indexContent
@@ -223,6 +252,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
             subscriptionCli?: {
               permissionMode?: string;
             };
+            validationStatus?: string;
+            obligationStatus?: string;
+            unmetRequiredOutputsCount?: number;
           };
           costMicros = entry.llm?.costMicros ?? 0;
           costFormatted = `$${entry.llm?.costUsdFormatted ?? "0.0000"}`;
@@ -234,6 +266,23 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           const pm = entry.subscriptionCli?.permissionMode;
           if (pm === "restricted" || pm === "operator-approved" || pm === "trusted") {
             subscriptionCliPermissionMode = pm;
+          }
+          const vs = entry.validationStatus;
+          if (
+            vs === "productive" ||
+            vs === "idle" ||
+            vs === "unaddressed-directives" ||
+            vs === "obligation-unmet" ||
+            vs === "unknown"
+          ) {
+            validationStatus = vs;
+          }
+          const os = entry.obligationStatus;
+          if (os === "satisfied" || os === "unmet" || os === "not-applicable") {
+            obligationStatus = os;
+          }
+          if (typeof entry.unmetRequiredOutputsCount === "number") {
+            unmetRequiredOutputsCount = entry.unmetRequiredOutputsCount;
           }
         }
       } catch {
@@ -250,6 +299,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         shadowCostMicros,
         shadowCostFormatted,
         subscriptionCliPermissionMode,
+        validationStatus,
+        obligationStatus,
+        unmetRequiredOutputsCount,
         stale,
         consecutiveFailures: agentState.consecutiveFailures,
         totalWakes: agentState.totalWakes,
@@ -279,6 +331,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           shadowCostMicros: null,
           shadowCostFormatted: null,
           subscriptionCliPermissionMode: null,
+          validationStatus: null,
+          obligationStatus: null,
+          unmetRequiredOutputsCount: null,
           stale: true,
           consecutiveFailures: 0,
           totalWakes: 0,
@@ -318,6 +373,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           fallbackPm === "trusted"
             ? fallbackPm
             : null,
+        validationStatus: null,
+        obligationStatus: null,
+        unmetRequiredOutputsCount: null,
         stale,
         consecutiveFailures: 0,
         totalWakes: 0,
@@ -335,6 +393,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         shadowCostMicros: null,
         shadowCostFormatted: null,
         subscriptionCliPermissionMode: null,
+        validationStatus: null,
+        obligationStatus: null,
+        unmetRequiredOutputsCount: null,
         stale: true,
         consecutiveFailures: 0,
         totalWakes: 0,


### PR DESCRIPTION
## Summary

Closes the loop on Phase 4: PR 1-4 wire the obligation pipeline; PR 5 makes the result visible to operators on the TUI dashboard.

Populates \`RunArtifactIndexEntry.validationStatus\` from \`WakeValidationResult\` (previously the field was declared but never set) and renders the status as a badge in the agents panel.

## Live-validated tonight

intelligence-agent wake \`116cd12b\` at 2026-05-13 15:46–15:54 UTC fired the new pipeline end-to-end and produced:

\`\`\`json
{
  \"obligationStatus\": \"unmet\",
  \"unmetRequiredOutputsCount\": 3,
  \"reason\": \"contract obligation unmet: 3 required output(s) without matching evidence\"
}
\`\`\`

The v1 brutally-simple obligation validator correctly flagged 3 unmet \`committed_artifacts\` paths — intelligence-agent did its work via governance event + comments rather than commits to drafts/. The dashboard now renders this as a red \`[obl-unmet:3]\` badge.

## Changes

**\`packages/core/src/daemon/runs.ts\`**
- \`RunArtifactIndexEntry.validationStatus\` extended with \`\"obligation-unmet\"\` variant.
- New optional fields: \`obligationStatus\`, \`unmetRequiredOutputsCount\`.
- \`computeValidationStatus\` helper with precedence: \`obligation-unmet\` > \`unaddressed-directives\` > \`idle\` > \`productive\`.
- \`record()\` and \`DispatchRunArtifactWriter.record()\` accept an optional \`WakeValidationResult\` and pass it to \`buildIndexEntry\`, which populates the validation fields.

**\`packages/core/src/daemon/index.ts\`**
- Pass the validation result to \`runArtifactWriter.record()\` (only for completed wakes; failures stay with the legacy heuristic).

**\`packages/dashboard-tui/src/data.ts\`**
- \`AgentStatus\` gains \`validationStatus\`, \`obligationStatus\`, \`unmetRequiredOutputsCount\`.
- State-store and index.jsonl fallback parse paths read these from index entries.

**\`packages/dashboard-tui/src/dashboard.ts\`**
- \`renderAgents\` adds a validation-status badge next to existing permission-mode / failure badges.
- Colors: **red** for \`obligation-unmet\` (load-bearing failure), **yellow** for \`unaddressed-directives\`, **dim** for plain \`idle\`. Productive wakes get no badge.

**\`packages/core/src/daemon/runs.test.ts\`**
- 6 new tests: omission without validation, productive/idle/unaddressed-directives/obligation-unmet status propagation, obligation-unmet precedence over directives-unaddressed.

## Test plan

- [x] \`pnpm run build\` ✅
- [x] \`pnpm run typecheck\` ✅
- [x] \`pnpm run lint\` ✅ (0 errors)
- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1228 passed, +6 new)
- [x] **Live runtime validation** — intelligence-agent wake \`116cd12b\` fired the full pipeline and produced the expected obligation-unmet result.

## Known limitation (v0.8.1 follow-up)

The v1 obligation validator only checks \`requiredOutputs\` (committed + runtime artifacts); it does NOT evaluate OR clauses in \`done_when\` strings. Agents whose contract has OR semantics across multiple output kinds (e.g. \"commit OR comment OR governance event\") may show \`obligation-unmet\` even when one OR branch was satisfied. Document in CHANGELOG; full DSL semantics land in v0.8.1 per ADR-0048 / \"v1 DSLs brutally simple\".

## References

- ADR-0047 §2 obligation sub-contract
- ADR-0048 §1 (Phase 4 scope lock, Accepted 2026-05-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)