### PR TITLE
Phase 4 PR 6a: validateBehavior in warning-only mode

### DIFF
--- a/packages/core/src/daemon/runs.ts
+++ b/packages/core/src/daemon/runs.ts
@@ -196,6 +196,14 @@ export interface RunArtifactIndexEntry {
    */
   readonly unmetRequiredOutputsCount?: number;
   /**
+   * Count of behavior warnings emitted by `validateBehavior` (Phase 4
+   * PR 6a, ADR-0047 §2, ADR-0048 §1). Warning-only signal — does NOT
+   * affect `productive` or `successfulWakes`. Dashboards surface this
+   * as a yellow badge so operators can calibrate before v0.8.1 promotes
+   * behavior validation to hard-fail.
+   */
+  readonly behaviorWarningCount?: number;
+  /**
    * Subscription-CLI audit context (T-CLI-9 / harness#301).
    * Present on all subscription-CLI wakes; absent for API-provider wakes.
    */
@@ -356,6 +364,9 @@ const buildIndexEntry = (
             : {}),
           ...(validation.unmetRequiredOutputs !== undefined
             ? { unmetRequiredOutputsCount: validation.unmetRequiredOutputs.length }
+            : {}),
+          ...(validation.behaviorWarnings !== undefined
+            ? { behaviorWarningCount: validation.behaviorWarnings.length }
             : {}),
         }
       : {}),

--- a/packages/core/src/execution/execution.test.ts
+++ b/packages/core/src/execution/execution.test.ts
@@ -5,6 +5,7 @@ import {
   isFailed,
   parseSelfReflection,
   renderSignalForPrompt,
+  validateBehavior,
   validateWake,
   amendWakeSummaryWithValidation,
   isKilled,
@@ -1169,5 +1170,162 @@ describe("renderSignalForPrompt", () => {
     const result = renderSignalForPrompt({ ...baseSignal, trust: "semi-trusted" });
     expect(result).toContain("<semi-trusted-signal>");
     expect(result).toContain("</semi-trusted-signal>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBehavior — Phase 4 PR 6a (warning-only)
+// ---------------------------------------------------------------------------
+
+describe("validateBehavior", () => {
+  const emptyResult = { actions: [], governanceEvents: [], wakeSummary: "" };
+
+  it("returns no warnings when wake summary is empty", () => {
+    const warnings = validateBehavior(emptyResult, []);
+    expect(warnings).toEqual([]);
+  });
+
+  it("flags a 'posted to #N' narrative claim without a matching receipt", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted my consent position to #864. Round complete.",
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      kind: "narrative-action-without-evidence",
+      issueNumber: 864,
+      verb: "posted",
+    });
+  });
+
+  it("does NOT flag when a successful comment-issue receipt matches", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted my consent position to #864.",
+    };
+    const warnings = validateBehavior(result, [
+      {
+        action: { kind: "comment-issue" as const, issueNumber: 864, body: "consent" },
+        success: true,
+      },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("does NOT flag when a GitHub URL for the issue is in the wake summary", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Posted consent at https://github.com/xeeban/emergent-praxis/issues/864#issuecomment-1234",
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toEqual([]);
+  });
+
+  it("does NOT flag when a GitHub URL is in a governance event payload", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted consent on #864.",
+      governanceEvents: [
+        {
+          kind: "report",
+          payload: { url: "https://github.com/xeeban/emergent-praxis/issues/864" },
+        },
+      ],
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toEqual([]);
+  });
+
+  it("flags a 'closed #N' claim without a matching close-issue receipt", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Closed #100 after Source ratified the proposal.",
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.verb).toBe("closed");
+    expect(warnings[0]?.issueNumber).toBe(100);
+  });
+
+  it("flags a 'labeled #N' claim without a matching label-issue receipt", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Labeled #205 with priority:high.",
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.verb).toBe("labeled");
+  });
+
+  it("collects multiple warnings independently", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted on #100 and closed #200 and labeled #300 with done. None had receipts.",
+    };
+    const warnings = validateBehavior(result, []);
+    expect(warnings).toHaveLength(3);
+    expect(warnings.map((w) => w.issueNumber).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([
+      100, 200, 300,
+    ]);
+  });
+
+  it("word boundary: 'posted on #5' does NOT match a #50 receipt", () => {
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Posted on #5.",
+    };
+    const warnings = validateBehavior(result, [
+      {
+        action: { kind: "comment-issue" as const, issueNumber: 50, body: "x" },
+        success: true,
+      },
+    ]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.issueNumber).toBe(5);
+  });
+});
+
+describe("validateWake — behaviorWarnings integration (warning-only)", () => {
+  const ctx = { actionItems: [], signals: [], agentId: "test", groupIds: [] };
+
+  it("includes behaviorWarnings on the validation result when narrative claims have no evidence", () => {
+    const result = {
+      actions: [],
+      outputs: [],
+      governanceEvents: [],
+      wakeSummary: "Posted on #864 (no receipt, no URL).",
+    };
+    const v = validateWake(ctx, result, []);
+    expect(v.behaviorWarnings).toBeDefined();
+    expect(v.behaviorWarnings).toHaveLength(1);
+  });
+
+  it("does NOT mark wake non-productive when only behaviorWarnings fire (warning-only)", () => {
+    const result = {
+      actions: [],
+      outputs: [],
+      governanceEvents: [],
+      // Successful action + a hallucinated claim on a different issue.
+      wakeSummary: "Posted on #999 (hallucinated; no evidence).",
+    };
+    const receipts = [
+      { action: { kind: "label-issue" as const, issueNumber: 1, label: "x" }, success: true },
+    ];
+    const v = validateWake(ctx, result, receipts);
+    expect(v.productive).toBe(true);
+    expect(v.behaviorWarnings).toHaveLength(1);
+  });
+
+  it("omits behaviorWarnings field when no warnings fire", () => {
+    const result = {
+      actions: [],
+      outputs: [],
+      governanceEvents: [],
+      wakeSummary: "Routine wake, no issue references.",
+    };
+    const v = validateWake(ctx, result, []);
+    expect(v.behaviorWarnings).toBeUndefined();
   });
 });

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -764,8 +764,39 @@ export interface WakeValidationResult {
    * successful evidence. Populated only when `obligationStatus` is `"unmet"`.
    */
   readonly unmetRequiredOutputs?: readonly { readonly kind: string; readonly path?: string }[];
+  /**
+   * Behavior warnings from `validateBehavior` (Phase 4 PR 6a, ADR-0047 §2,
+   * ADR-0048 §1). Each warning describes a narrative claim in `wakeSummary`
+   * that lacks structured evidence (successful action receipt or URL).
+   *
+   * **Warning-only in v0.8.0** — these do NOT affect `productive`,
+   * `idleWakes`, or `successfulWakes`. They surface on the dashboard so
+   * operators can calibrate before behavior validation is promoted to
+   * hard-fail in v0.8.1 (per ADR-0048 §Decision 2).
+   */
+  readonly behaviorWarnings?: readonly BehaviorWarning[];
   /** If not productive, why. */
   readonly reason?: string;
+}
+
+/**
+ * One behavior warning from `validateBehavior` (Phase 4 PR 6a, ADR-0048 §1).
+ *
+ * Warning-only in v0.8.0: the wake's `productive` flag is not affected.
+ * Surfaced on the dashboard for operator calibration before v0.8.1
+ * promotes behavior validation to hard-fail.
+ */
+export interface BehaviorWarning {
+  /** Pattern that fired. v1 has a single kind; future kinds extend the
+   *  union as new patterns are added (always at minor version bumps to
+   *  let dashboards version-gate display). */
+  readonly kind: "narrative-action-without-evidence";
+  /** Human-readable description of the unmatched claim. */
+  readonly message: string;
+  /** Issue number the agent's narrative referenced, when detectable. */
+  readonly issueNumber?: number;
+  /** Detected narrative verb (e.g. "posted", "commented", "closed", "committed"). */
+  readonly verb?: string;
 }
 
 type GithubIssueSignal = Extract<Signal, { kind: "github-issue" }>;
@@ -911,6 +942,117 @@ const isOutputSatisfied = (
 };
 
 /**
+ * Behavior validation (Phase 4 PR 6a, ADR-0047 §2, ADR-0048 §1).
+ *
+ * Scans `wakeSummary` for action-verb patterns that reference issue numbers
+ * ("posted to #123", "closed issue #456", "committed to drafts/foo.md") and
+ * checks each against structural evidence:
+ *
+ *   - successful WakeActionReceipt of the matching kind + issueNumber
+ *   - GitHub issue URL for the same issue number (per harness#364 Part A)
+ *
+ * Unmatched claims produce a `BehaviorWarning`. **Warning-only in v0.8.0**:
+ * results are surfaced on dashboards and recorded on the wake but do not
+ * affect `productive`/`idleWakes`/`successfulWakes`. v0.8.1 will promote
+ * to hard-fail after 14d composite-permission soak per the original
+ * ADR-0048 calendar (deferred from v0.8.0).
+ *
+ * Brutally simple v1 per the project rule: regex patterns over wake
+ * summary, no NLP. False-positive rate is calibrated against real wake
+ * data during the warning-only window. Operators can scrub their
+ * narrative phrasing if a specific pattern is over-firing.
+ */
+export const validateBehavior = (
+  result: {
+    actions: readonly WakeAction[];
+    governanceEvents: readonly EmittedGovernanceEvent[];
+    wakeSummary: string;
+  },
+  actionReceipts: readonly WakeActionReceipt[],
+): readonly BehaviorWarning[] => {
+  const warnings: BehaviorWarning[] = [];
+  const summary = result.wakeSummary;
+  if (summary.length === 0) return warnings;
+
+  // Pre-compute governance event text for URL evidence checks.
+  const govStrings: string[] = [];
+  for (const g of result.governanceEvents) {
+    try {
+      govStrings.push(JSON.stringify(g));
+    } catch {
+      govStrings.push("");
+    }
+  }
+
+  const hasUrlEvidence = (issueNum: number): boolean => {
+    const re = new RegExp(`github\\.com/[^/]+/[^/]+/issues/${String(issueNum)}(?!\\d)`, "i");
+    if (re.test(summary)) return true;
+    return govStrings.some((s) => s !== "" && re.test(s));
+  };
+
+  const hasReceiptOfKind = (issueNum: number, actionKind: WakeAction["kind"]): boolean =>
+    actionReceipts.some(
+      (r) => r.success && r.action.kind === actionKind && r.action.issueNumber === issueNum,
+    );
+
+  // Pattern: "(posted|commented|replied|left a comment|added a comment) (on|to|at)? (issue)? #N"
+  // Allow up to ~80 chars between the verb and the #N to catch reasonable
+  // phrasing like "posted my consent position on issue #864". Non-greedy
+  // (`{0,80}?`) so a sentence with multiple `#N` references attributes the
+  // FIRST one to this verb, not the last. Word-boundary on the trailing
+  // digit so `#5` does not match `#54`.
+  const commentClaimRegex =
+    /\b(posted|commented|replied|left a comment|added a comment)\b(?:[^.\n]{0,80}?)#(\d+)(?!\d)/gi;
+  const closeClaimRegex = /\b(closed|resolved)\b(?:[^.\n]{0,80}?)#(\d+)(?!\d)/gi;
+  const labelClaimRegex =
+    /\b(labeled|labelled|tagged|added (?:the )?label)\b(?:[^.\n]{0,80}?)#(\d+)(?!\d)/gi;
+
+  for (const match of summary.matchAll(commentClaimRegex)) {
+    const verb = match[1]?.toLowerCase() ?? "posted";
+    const n = Number(match[2]);
+    if (!Number.isFinite(n)) continue;
+    if (hasReceiptOfKind(n, "comment-issue")) continue;
+    if (hasUrlEvidence(n)) continue;
+    warnings.push({
+      kind: "narrative-action-without-evidence",
+      message: `Narrative claims "${verb} … #${String(n)}" but no successful comment-issue receipt or issue URL`,
+      issueNumber: n,
+      verb,
+    });
+  }
+
+  for (const match of summary.matchAll(closeClaimRegex)) {
+    const verb = match[1]?.toLowerCase() ?? "closed";
+    const n = Number(match[2]);
+    if (!Number.isFinite(n)) continue;
+    if (hasReceiptOfKind(n, "close-issue")) continue;
+    if (hasUrlEvidence(n)) continue;
+    warnings.push({
+      kind: "narrative-action-without-evidence",
+      message: `Narrative claims "${verb} … #${String(n)}" but no successful close-issue receipt or issue URL`,
+      issueNumber: n,
+      verb,
+    });
+  }
+
+  for (const match of summary.matchAll(labelClaimRegex)) {
+    const verb = match[1]?.toLowerCase() ?? "labeled";
+    const n = Number(match[2]);
+    if (!Number.isFinite(n)) continue;
+    if (hasReceiptOfKind(n, "label-issue")) continue;
+    if (hasUrlEvidence(n)) continue;
+    warnings.push({
+      kind: "narrative-action-without-evidence",
+      message: `Narrative claims "${verb} … #${String(n)}" but no successful label-issue receipt or issue URL`,
+      issueNumber: n,
+      verb,
+    });
+  }
+
+  return warnings;
+};
+
+/**
  * Default validation: checks artifact count, action item coverage, and
  * structured-evidence backing for any source-directive items in signals.
  * Used when no custom validator is configured.
@@ -919,6 +1061,10 @@ const isOutputSatisfied = (
  * output is checked against successful action receipts. An unmet required
  * output marks the wake non-productive even if the legacy heuristic
  * (artifactCount > 0, no unaddressed directives) would have passed.
+ *
+ * Phase 4 PR 6a: additionally runs `validateBehavior` and attaches any
+ * warnings to the result. Warnings are **warning-only**: they do not
+ * affect `productive` or the legacy heuristic.
  */
 export const validateWake = (
   context: {
@@ -1103,6 +1249,12 @@ export const validateWake = (
           ? `${String(actionItemsAssigned)} action items assigned but none addressed`
           : "wake completed but produced no artifacts";
 
+  // Phase 4 PR 6a: behavior validation runs alongside outcome validation
+  // but is warning-only — its findings do NOT affect `productive` or
+  // any other counter. They surface on the dashboard for operator
+  // calibration before v0.8.1 promotes to hard-fail.
+  const behaviorWarnings = validateBehavior(result, actionReceipts);
+
   const baseResult: WakeValidationResult = {
     productive,
     artifactCount,
@@ -1111,6 +1263,7 @@ export const validateWake = (
     directivesUnaddressed,
     ...(obligationStatus !== undefined ? { obligationStatus } : {}),
     ...(unmetRequiredOutputs !== undefined ? { unmetRequiredOutputs } : {}),
+    ...(behaviorWarnings.length > 0 ? { behaviorWarnings } : {}),
     ...(reason !== undefined ? { reason } : {}),
   };
   return baseResult;

--- a/packages/dashboard-tui/src/dashboard.ts
+++ b/packages/dashboard-tui/src/dashboard.ts
@@ -138,6 +138,13 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
           : a.validationStatus === "idle"
             ? dim(" [idle-val]")
             : "";
+    // Phase 4 PR 6a: surface behavior warnings (warning-only, does NOT
+    // affect productive/successfulWakes). Yellow to distinguish from the
+    // load-bearing red `obl-unmet`. Elided when count is 0/null.
+    const behStr =
+      a.behaviorWarningCount !== null && a.behaviorWarningCount > 0
+        ? yellow(` [beh:${String(a.behaviorWarningCount)}]`)
+        : "";
 
     const time = a.lastWake!.toISOString().slice(11, 16);
     const next = a.nextWakeCountdown !== "--" ? a.nextWakeCountdown.padEnd(8) : dim("--".padEnd(8));
@@ -154,7 +161,7 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
         : dim("░".repeat(BAR_WIDTH));
 
     lines.push(
-      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}${validStr}`,
+      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}${validStr}${behStr}`,
     );
   }
 

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -57,6 +57,13 @@ export interface AgentStatus {
    * successful evidence (Phase 4 PR 4). Null when obligationStatus is not "unmet".
    */
   readonly unmetRequiredOutputsCount: number | null;
+  /**
+   * Count of behavior warnings (Phase 4 PR 6a). Null when validation
+   * data is unavailable. Warning-only signal — does NOT mark the wake
+   * non-productive; rendered as a yellow `[beh:N]` badge for operator
+   * calibration.
+   */
+  readonly behaviorWarningCount: number | null;
   readonly stale: boolean; // stalled or no wake in > 48h
   readonly consecutiveFailures: number;
   readonly totalWakes: number;
@@ -148,6 +155,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         validationStatus: null,
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
+        behaviorWarningCount: null,
         stale: false,
         consecutiveFailures: a.consecutiveFailures,
         totalWakes: a.totalWakes,
@@ -234,6 +242,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
       let validationStatus: AgentStatus["validationStatus"] = null;
       let obligationStatus: AgentStatus["obligationStatus"] = null;
       let unmetRequiredOutputsCount: AgentStatus["unmetRequiredOutputsCount"] = null;
+      let behaviorWarningCount: AgentStatus["behaviorWarningCount"] = null;
       try {
         const indexContent = await readFile(join(runsDir, agentId, "index.jsonl"), "utf8");
         const lines = indexContent
@@ -255,6 +264,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
             validationStatus?: string;
             obligationStatus?: string;
             unmetRequiredOutputsCount?: number;
+            behaviorWarningCount?: number;
           };
           costMicros = entry.llm?.costMicros ?? 0;
           costFormatted = `$${entry.llm?.costUsdFormatted ?? "0.0000"}`;
@@ -284,6 +294,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           if (typeof entry.unmetRequiredOutputsCount === "number") {
             unmetRequiredOutputsCount = entry.unmetRequiredOutputsCount;
           }
+          if (typeof entry.behaviorWarningCount === "number") {
+            behaviorWarningCount = entry.behaviorWarningCount;
+          }
         }
       } catch {
         /* no cost data */
@@ -302,6 +315,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         validationStatus,
         obligationStatus,
         unmetRequiredOutputsCount,
+        behaviorWarningCount,
         stale,
         consecutiveFailures: agentState.consecutiveFailures,
         totalWakes: agentState.totalWakes,
@@ -334,6 +348,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           validationStatus: null,
           obligationStatus: null,
           unmetRequiredOutputsCount: null,
+          behaviorWarningCount: null,
           stale: true,
           consecutiveFailures: 0,
           totalWakes: 0,
@@ -376,6 +391,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         validationStatus: null,
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
+        behaviorWarningCount: null,
         stale,
         consecutiveFailures: 0,
         totalWakes: 0,
@@ -396,6 +412,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         validationStatus: null,
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
+        behaviorWarningCount: null,
         stale: true,
         consecutiveFailures: 0,
         totalWakes: 0,


### PR DESCRIPTION
## Summary

Final Phase 4 PR for v0.8.0 — adds **behavior validation in warning-only mode**.

Scans wake summaries for action-verb patterns (\`posted to #N\`, \`closed #N\`, \`labeled #N\`) and cross-checks each against either:
- A successful \`WakeActionReceipt\` of the matching kind + issue number, OR
- A GitHub issue URL for the same issue number (per PR #369).

Unmatched claims emit a \`BehaviorWarning\` that the dashboard renders as a yellow \`[beh:N]\` badge.

## Warning-only semantics (ADR-0048 §1)

In v0.8.0, behavior warnings do **NOT** affect:
- \`productive\` flag
- \`idleWakes\` / \`successfulWakes\` counters
- Circuit breaker / consecutive-failure logic

They surface to operators so the threshold can be calibrated before v0.8.1 promotes to hard-fail (after the 14d composite-permission soak deferred from v0.8.0).

## Pattern coverage (v1)

Three verb families, intentionally narrow:

| Family | Verbs | Receipt evidence | URL evidence |
|---|---|---|---|
| Comment | \`posted\`, \`commented\`, \`replied\`, \`left/added a comment\` | \`comment-issue\` | \`/issues/N\` |
| Close | \`closed\`, \`resolved\` | \`close-issue\` | \`/issues/N\` |
| Label | \`labeled\`, \`labelled\`, \`tagged\`, \`added label\` | \`label-issue\` | \`/issues/N\` |

Non-greedy \`{0,80}?\` claim windows so a sentence like \"Posted on #100 and closed #200 and labeled #300\" attributes each \`#N\` to the correct verb (not all three to #300).

## Test plan

- [x] \`pnpm run build\` ✅
- [x] \`pnpm run typecheck\` ✅
- [x] \`pnpm run lint\` ✅ (0 errors)
- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1240 passed, +12 new)
  - 9 \`validateBehavior\` tests covering each pattern + URL/receipt evidence paths
  - 3 \`validateWake\` integration tests confirming warning-only semantics (productive unchanged)

## Phase 4 v0.8.0 status — all PRs shipped

| PR | Description | Status |
|---|---|---|
| PR 1 (#367 ancestor) | role.md \`contract:\` Zod schema | ✅ merged |
| PR 2 (#367) | \`assembleExecutionContract\` + buildSpawnContext | ✅ merged |
| #366 gate (#368) | safePath blocks role.md/soul.md/harness.yaml | ✅ merged |
| #364 gate (#369) | URL-as-evidence | ✅ merged |
| #365 gate | cold-start measurement (138ms, 0 API calls) | ✅ closed |
| PR 3 (#370) | contract-aware system prompt | ✅ merged |
| PR 4 (#371) | validateOutcomes obligation enforcement | ✅ merged |
| PR 5 (#372) | dashboard surfaces validationStatus | ✅ merged |
| **PR 6a (this)** | validateBehavior warning-only | ✅ in this PR |

After this merges + 48h observation, v0.8.0 can tag.

## References

- ADR-0047 §2 permission sub-contract
- ADR-0048 §1 Scope IN (PR 6a warning-only mode)
- ADR-0048 §Decision 2 (hard-fail deferred to v0.8.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)