### PR TITLE
docs: v0.8.0 CHANGELOG + README — execution contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,71 @@
 All notable changes to the Murmuration Harness are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.0] - 2026-05-19
+
+**Execution contracts — agents declare what completion looks like in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces it.**
+
+The harness shipped through v0.7.2 with the wake loop measuring whether agents _produced artifacts_, not whether they _satisfied an obligation_. v0.8.0 closes that gap by introducing the `contract:` block in `role.md`, an end-to-end pipeline that assembles a per-wake `ExecutionContract` from operator-authored declarations plus runtime context, injects the obligation into the system prompt as a `trusted` segment, and validates outcomes against the declared `requiredOutputs`. Behavioral validation (the narrative-vs-tool-call cross-check) ships in warning-only mode in v0.8.0 — operator calibration before promotion to hard-fail in v0.8.1.
+
+ADR-0047 ([Execution Contracts](docs/adr/0047-execution-contracts.md)) defines the contract shape; ADR-0048 ([Phase 4 scope lock](docs/adr/0048-phase-4-scope-lock-for-v0.8.0.md)) compresses the 22–28 day target to ~8 days by deferring `validateBehavior` hard-fail to v0.8.1.
+
+### Added
+
+- **`contract:` block in `role.md` frontmatter** (#367). Optional operator-facing declaration with five fields, all arrays defaulting to empty: `done_when`, `committed_artifacts`, `runtime_artifacts`, `verification_required_for`, `approval_required_for`. Parsed via Zod with `.strict()` so typos surface at boot. Roles without a `contract:` block continue to work — the harness synthesizes a minimal default from runtime context.
+- **`assembleExecutionContract()`** (#367). New core function that builds a full `ExecutionContract` per wake from the role's `contract:` block + signal bundle + budget + GitHub write scopes. Result lands on `AgentSpawnContext.contract` and threads through to prompt assembly + post-wake validation. Brutally-simple v1 mapping: `done_when` → `completionConditions`, `committed_artifacts` + `runtime_artifacts` → `requiredOutputs` by kind, signal action items → `ActionItemRef[]`, `verification_required_for` → required `VerificationStep[]`, `approval_required_for` → `ApprovalPolicy`.
+- **Contract-aware system prompt** (#370). `PromptAssembler` injects a `trusted` `contract` segment containing Objective, Completion conditions, Required outputs, Verification, Permitted side effects, and Source approval — so the agent reads what completion looks like before doing the wake. When no obligations are declared, the segment degrades to a short notice instead of empty sections.
+- **Obligation enforcement in `validateWake`** (#371). When the contract declares `requiredOutputs`, each one is checked against successful action receipts: `committed-artifact` / `commit` → matching `commit-file` receipt + path glob, `comment` → `comment-issue` receipt, `issue` → `create-issue` receipt, `runtime-artifact` → auto-satisfied on wake completion, `governance-event` → at least one event emitted, `summary` → non-empty `wakeSummary`. Unmet obligations override the legacy heuristic and mark the wake non-productive — counts toward `idleWakes`. New fields on `WakeValidationResult`: `obligationStatus` (`satisfied` | `unmet` | `not-applicable`) and `unmetRequiredOutputs[]`.
+- **`pathMatchesGlob` brutally-simple matcher** (#371). Prefix + suffix glob matcher supporting `drafts/**/*.md`, `agents/*/role.md`, `*.md`. Full glob semantics (per-segment `*`, character classes, `?`) deferred to v0.8.1.
+- **Dashboard surfaces `validationStatus` per wake** (#372). The TUI agents panel now shows obligation results: red `[obl-unmet:N]` badge when `requiredOutputs` go unmet, yellow `[dir-unaddr]` for unaddressed source directives (Boundary 5 carry-forward), dim `[idle-val]` for plain-idle wakes. Productive wakes show no badge. `index.jsonl` gains `validationStatus`, `obligationStatus`, `unmetRequiredOutputsCount`, and `productive` fields.
+- **`validateBehavior` in warning-only mode** (#373). Scans `wakeSummary` for action-verb patterns (`posted to #N`, `closed #N`, `labeled #N`) and cross-checks each against either a successful `WakeActionReceipt` of the matching kind + issue number OR a GitHub issue URL for the same issue number. Unmatched claims emit a `BehaviorWarning`. **Warning-only** — does NOT affect `productive`, `idleWakes`, or `successfulWakes`. Dashboard renders the count as a yellow `[beh:N]` badge.
+- **GitHub issue URLs as structural evidence** (#369). `validateWake` directive validation now treats a fully-qualified URL like `github.com/<owner>/<repo>/issues/<N>` in `wakeSummary` or any governance event payload as evidence the agent acted on that issue — eliminates the false-positive `narrative-only-claim` that fired on every consent-round response from subscription-CLI agents (whose subprocess-internal comment posts never land in `result.actions`).
+- **ADR-0047** (Execution Contracts) and **ADR-0048** (Phase 4 scope lock) accepted.
+
+### Changed
+
+- **`AgentSpawnContext.contract`** type upgraded from the Phase 0 stub (`{objective, doneWhen, allowedSideEffects}`) to the full `ExecutionContract` type. Test fixtures and pre-Phase-4 callers can still leave it `undefined`; production daemon wakes always populate it.
+- **`validateWake` signature** — context arg now accepts an optional `contract: ExecutionContract`. Legacy callers without a contract continue to use the heuristic path; `obligationStatus` is `undefined` on the result.
+- **`RunArtifactWriter.record()` and `DispatchRunArtifactWriter.record()`** accept an optional `WakeValidationResult` so `index.jsonl` entries can carry validation fields downstream to dashboards and eval queries.
+- **Spirit `write_file` blocks operator config paths** (#368). The `safePath` write guard now refuses overwrites to `agents/<id>/role.md`, `agents/<id>/soul.md`, `murmuration/soul.md`, and `harness.yaml`. Closes the trusted-segment injection path before contract content becomes prompt-trusted in #370. Read access is unaffected; subdirectory writes (`agents/<id>/prompts/wake.md`) remain allowed.
+
+### Fixed
+
+- **`validateWake` false-positive on subscription-CLI WakeAction comments** (#369, #364 Part A). Subscription-CLI agents post comments via subprocess tool calls that never reach `result.actions`. The validator now treats a `/issues/<N>` URL in `wakeSummary` or any governance event as structural evidence (with word-boundary lookahead so `/issues/845` does not satisfy `#84` or `#8450`). Part B (`verifiedActions` field on `AgentResult`) deferred to v0.8.1.
+
+### Known limitations (v0.8.1 follow-ups)
+
+- **`validateBehavior` ships warning-only**. Hallucinated tool-call claims are surfaced on the dashboard but do not mark the wake non-productive. Operators relying on `successfulWakes` as a correctness signal should be aware that behavioral hallucinations are flagged, not enforced. Hard-fail promotion lands in v0.8.1 after the 14-day composite-permission soak per ADR-0048 §Decision 2.
+- **Obligation validator only checks `requiredOutputs`** — it does NOT evaluate OR clauses in `done_when` strings. Agents whose contract has OR semantics across multiple output kinds (e.g. "commit OR comment OR governance event") may show `obligation-unmet` even when one OR branch was satisfied. Use `requiredOutputs` to express AND obligations and accept the v0.8.0 limitation, or wait for v0.8.1 DSL semantics.
+- **Glob matcher is prefix+suffix only**. `drafts/**/*.md` matches `drafts/foo/bar.md`; `agents/*/role.md` matches `agents/x/role.md` (and over-matches `agents/x/y/role.md`). Per-segment glob semantics arrive in v0.8.1. Operators needing exact path matching can spell out the full path with no wildcards.
+- **`validateWake` FP "narrative-only-claim" Part B** — the long-term clean fix is an opt-in `verifiedActions` field on `AgentResult` populated by subscription-CLI executors. Part A (URL evidence) covers most observed cases; Part B lands in v0.8.1.
+
+### Migration
+
+Operators with existing murmurations do **not** need to add a `contract:` block to their role.md files — agents continue to work unchanged with the legacy heuristic. To opt in:
+
+```yaml
+# role.md frontmatter
+contract:
+  done_when:
+    - "At least one research artifact committed under drafts/"
+    - "OR at least one substantive issue comment posted"
+  committed_artifacts:
+    - "drafts/**/*.md"
+  runtime_artifacts:
+    - ".murmuration/runs/<agent-id>/**/*.md"
+  verification_required_for: []
+  approval_required_for: []
+```
+
+See the **Execution contracts** section of [README.md](README.md#execution-contracts) for the full syntax.
+
+### Internals
+
+- 1240 tests passing across 72 test files (up from 1097 in v0.7.2; +143 new tests for the contract pipeline).
+- All Phase 4 PRs merged: #367 (PR 1+2), #368 (#366 gate), #369 (#364 gate), #370 (PR 3), #371 (PR 4), #372 (PR 5), #373 (PR 6a).
+- Cold-start cost gate measured (#365 closed): 138 ms boot phase, 0 GitHub API calls during cold-start — Phase 4 contract assembly is local file I/O.
+- Live runtime validation: intelligence-agent wake `116cd12b` (2026-05-13 15:46 UTC) fired the full pipeline end-to-end and produced the expected `obligationStatus: "unmet"` result for a wake that did its work via comments instead of commits.
+
 ## [0.7.2] - 2026-05-07
 
 **Signal routing correctness — agents now see their own directives, score only their own accountability, and read Source answers posted as comments.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ ADR-0047 ([Execution Contracts](docs/adr/0047-execution-contracts.md)) defines t
 - **Dashboard surfaces `validationStatus` per wake** (#372). The TUI agents panel now shows obligation results: red `[obl-unmet:N]` badge when `requiredOutputs` go unmet, yellow `[dir-unaddr]` for unaddressed source directives (Boundary 5 carry-forward), dim `[idle-val]` for plain-idle wakes. Productive wakes show no badge. `index.jsonl` gains `validationStatus`, `obligationStatus`, `unmetRequiredOutputsCount`, and `productive` fields.
 - **`validateBehavior` in warning-only mode** (#373). Scans `wakeSummary` for action-verb patterns (`posted to #N`, `closed #N`, `labeled #N`) and cross-checks each against either a successful `WakeActionReceipt` of the matching kind + issue number OR a GitHub issue URL for the same issue number. Unmatched claims emit a `BehaviorWarning`. **Warning-only** — does NOT affect `productive`, `idleWakes`, or `successfulWakes`. Dashboard renders the count as a yellow `[beh:N]` badge.
 - **GitHub issue URLs as structural evidence** (#369). `validateWake` directive validation now treats a fully-qualified URL like `github.com/<owner>/<repo>/issues/<N>` in `wakeSummary` or any governance event payload as evidence the agent acted on that issue — eliminates the false-positive `narrative-only-claim` that fired on every consent-round response from subscription-CLI agents (whose subprocess-internal comment posts never land in `result.actions`).
+- **GitHub blob URLs as `committed-artifact` evidence** (#377). The obligation validator now treats `github.com/<owner>/<repo>/blob/<branch>/<path>` URLs in `wakeSummary` or governance event payloads as evidence for `committed-artifact` / `commit` obligations when no `commit-file` receipt is present. Closes the same gap for subscription-CLI agents that commit via subprocess `gh api` calls.
+- **`daemon.validate.legacy-fallback` event** (#375). Emitted whenever a completed wake falls back to the legacy heuristic — either because no contract was supplied or because the contract declared no `requiredOutputs`. Operators can count these events to measure how many wakes still skip the obligation sub-contract.
 - **ADR-0047** (Execution Contracts) and **ADR-0048** (Phase 4 scope lock) accepted.
 
 ### Changed
@@ -33,6 +35,7 @@ ADR-0047 ([Execution Contracts](docs/adr/0047-execution-contracts.md)) defines t
 ### Fixed
 
 - **`validateWake` false-positive on subscription-CLI WakeAction comments** (#369, #364 Part A). Subscription-CLI agents post comments via subprocess tool calls that never reach `result.actions`. The validator now treats a `/issues/<N>` URL in `wakeSummary` or any governance event as structural evidence (with word-boundary lookahead so `/issues/845` does not satisfy `#84` or `#8450`). Part B (`verifiedActions` field on `AgentResult`) deferred to v0.8.1.
+- **`validateWake` false-positive on subprocess `gh api` commits** (#377, #364 Part C). Same class of bug for `committed-artifact` obligations: agents committing via `gh api` produce no `commit-file` receipt but leave a blob URL in the wake summary. Blob URLs are now accepted as evidence (with trailing sentence-punctuation stripped so `…/foo.md.` extracts `…/foo.md`).
 
 ### Known limitations (v0.8.1 follow-ups)
 

--- a/README.md
+++ b/README.md
@@ -346,11 +346,11 @@ Select at boot: `murmuration start --governance examples/governance-s3/index.mjs
 
 ```bash
 pnpm install              # install dependencies
-pnpm build                # build all 8 packages
+pnpm build                # build all 9 packages
 pnpm typecheck            # tsc --noEmit across all packages
 pnpm lint                 # eslint (strict-type-checked)
 pnpm format:check         # prettier check
-pnpm test                 # vitest (486 tests, 40 files)
+pnpm test                 # vitest (1240 tests, 72 files)
 pnpm check                # all of the above (CI locally)
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 The Murmuration Harness is an open-source TypeScript runtime that lets a single human — the **Source** — coordinate a murmuration of AI agents to do real work. It is not an autonomous agent framework. It is a tool that amplifies human agency.
 
-> **v0.7.2** (current) — Spirit-as-operator-execution-environment, subscription-CLI providers (Claude/Codex/Gemini Pro/Max), prompt boundary with trust classification, Phase 3 governance plugin extraction complete. 9 packages, 1178 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
+> **v0.8.0** (current) — Execution contracts: agents declare `done_when` / `committed_artifacts` / `verification_required_for` in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces `[obl-unmet:N]` when output paths go unmet. `validateBehavior` ships warning-only — calibration before hard-fail in v0.8.1. 9 packages, 1240 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
 >
-> **In flight (v0.8+):** ADR-0047 "Execution Contracts" (proposed) gates Phase 4 contract-backed completion — see [`docs/plans/proposal-07-phase4-implementation.md`](./docs/plans/proposal-07-phase4-implementation.md).
+> **In flight (v0.8.1+):** Promote `validateBehavior` to hard-fail after 14d composite-permission soak; per-segment glob matcher; `verifiedActions` field on `AgentResult` for the long-term subscription-CLI evidence fix.
 
 ## Quickstart (5 minutes, 6 commands)
 
@@ -144,6 +144,56 @@ tools:
 ```
 
 At wake time, the runner connects to declared MCP servers, discovers tools, and passes them to the LLM. The LLM can call tools in a multi-step loop (up to 5 rounds). Connections are cleaned up after each wake.
+
+### Execution contracts
+
+Agents can declare what completion looks like via an optional `contract:` block in `role.md` frontmatter. The harness assembles a per-wake `ExecutionContract` from the declaration plus runtime context (signals, budget, write scopes), injects it as a trusted prompt segment, and validates the wake's outcome against the obligation. Wakes that fail to produce declared `requiredOutputs` are marked non-productive and count toward `idleWakes`.
+
+```yaml
+# role.md frontmatter
+contract:
+  # Plain-language conditions an operator can read at review time.
+  # Note: v0.8.0 displays these in the prompt but does NOT evaluate OR clauses —
+  # they are advisory. The validator only enforces `requiredOutputs` (below).
+  done_when:
+    - "At least one research artifact committed under drafts/"
+    - "OR at least one substantive issue comment posted"
+
+  # Glob paths the agent must produce a `commit-file` for to satisfy the obligation.
+  # Prefix+suffix matching (v0.8.0): `drafts/**/*.md` matches `drafts/foo/bar.md`.
+  committed_artifacts:
+    - "drafts/**/*.md"
+    - "docs/research/**/*.md"
+
+  # Glob paths the daemon writes automatically (digests). Auto-satisfied
+  # on wake completion — listed for operator clarity, not for enforcement.
+  runtime_artifacts:
+    - ".murmuration/runs/<agent-id>/**/*.md"
+
+  # Tool / action IDs that require post-wake verification before the wake counts.
+  # v0.8.0 emits a VerificationStep with `required: true` for each entry;
+  # Phase 5+ wires actual verification steps.
+  verification_required_for:
+    - "github.create_pull_request"
+
+  # Permission classes requiring Source approval. When non-empty, the contract's
+  # `approval.mode` becomes `required` and approval-gated actions pause the wake.
+  approval_required_for: []
+```
+
+**Dashboard surfacing.** The TUI agents panel shows the validation result of the last wake as a colored badge after the wake count:
+
+| Badge           | Meaning                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| _(none)_        | Wake productive — all obligations met, no warnings.                                                                   |
+| `[obl-unmet:N]` | **N** `requiredOutputs` had no matching successful evidence (red — load-bearing).                                     |
+| `[dir-unaddr]`  | One or more source directives in the signal bundle were not addressed (yellow).                                       |
+| `[idle-val]`    | Wake produced no artifacts and had no directives (dim).                                                               |
+| `[beh:N]`       | **N** behavior warnings from the narrative-vs-tool-call cross-check (yellow). Warning-only in v0.8.0 — see CHANGELOG. |
+
+**No `contract:` block?** Agents continue to work with the legacy heuristic: a wake is productive when it produces ≥1 artifact and addresses any source directives in its bundle. The `contract:` block is opt-in.
+
+**Spec references.** [ADR-0047](docs/adr/0047-execution-contracts.md) defines the contract shape and the obligation/permission split. [ADR-0048](docs/adr/0048-phase-4-scope-lock-for-v0.8.0.md) documents the v0.8.0 scope lock (warning-only behavioral validation, prefix+suffix glob matcher, deferred 14d soak — all promoted to hard-fail in v0.8.1).
 
 ### Agent skills (AgentSkills.io)
 


### PR DESCRIPTION
## Summary

Drafts the v0.8.0 release notes (CHANGELOG.md) and adds an \"Execution contracts\" section to README.md documenting the new \`contract:\` block in \`role.md\` frontmatter. Held until release week per ADR-0048 §6.

## CHANGELOG coverage

All 8 PRs that landed in the v0.8.0 ship train:

| PR | Description |
|---|---|
| PR 1 (#367 ancestor) | role.md \`contract:\` Zod schema |
| PR 2 (#367) | \`assembleExecutionContract\` + buildSpawnContext wiring |
| #366 gate (#368) | safePath blocks role.md/soul.md writes |
| #364 gate (#369) | URL-as-evidence |
| #365 gate | cold-start measurement (138ms, 0 API calls) |
| PR 3 (#370) | contract-aware system prompt |
| PR 4 (#371) | validateOutcomes obligation enforcement |
| PR 5 (#372) | dashboard surfaces validationStatus |
| PR 6a (#373) | validateBehavior warning-only |

## Known limitations documented for v0.8.1

- \`validateBehavior\` ships warning-only (hard-fail deferred per ADR-0048 §Decision 2 after 14d soak)
- Obligation validator only checks \`requiredOutputs\` — does NOT evaluate OR clauses in \`done_when\`
- Glob matcher is prefix+suffix only (full per-segment semantics in v0.8.1)
- \`validateWake\` FP Part B (\`verifiedActions\` field on \`AgentResult\`) deferred to v0.8.1

## README changes

- Banner updated from v0.7.2 → v0.8.0 with the test count (1240) and the one-line feature summary
- New **Execution contracts** section between Tool calling (MCP) and Agent skills
  - Full \`contract:\` block example with operator-facing comments
  - Dashboard badge table (\`[obl-unmet:N]\`, \`[dir-unaddr]\`, \`[idle-val]\`, \`[beh:N]\`)
  - Spec links to ADR-0047 + ADR-0048
- Migration guidance: roles without a \`contract:\` block continue to work unchanged

## Test plan

- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1240 passed, 2 skipped)
- [ ] Manual review of CHANGELOG narrative + tone
- [ ] Manual review of README execution-contracts example

## Sequencing

Holds in this PR until release week:
- 2026-05-15 (Fri): 48h soak clears
- 2026-05-17 (Sun): merge this PR + version bump
- 2026-05-18 (Mon): final 24h observation
- 2026-05-19 (Tue): tag v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)