### PR TITLE
feat(daemon): emit daemon.validate.legacy-fallback event (harness#363)

### DIFF
--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -961,6 +961,30 @@ export class Daemon {
         });
       }
 
+      // Phase 5 measurability hook (engineering-agent's harness#363 recommendation,
+      // 2026-05-14). Emit a distinct event whenever a completed wake fell back
+      // to the legacy heuristic — either because no contract was supplied
+      // (`obligationStatus === undefined`) or because the contract declared
+      // no `requiredOutputs` (`obligationStatus === "not-applicable"`).
+      //
+      // v0.9.0 retires the legacy heuristic; the promotion gate is "zero
+      // `daemon.validate.legacy-fallback` events during a 14-day soak". This
+      // event makes that gate measurable from v0.8.0 onward.
+      if (
+        isCompleted(result) &&
+        (validation.obligationStatus === undefined ||
+          validation.obligationStatus === "not-applicable")
+      ) {
+        this.#logger.info("daemon.validate.legacy-fallback", {
+          agentId: agent.agentId,
+          wakeId: event.wakeId.value,
+          reason:
+            validation.obligationStatus === undefined
+              ? "no-contract-context"
+              : "no-required-outputs-declared",
+        });
+      }
+
       // Record outcome in state store
       const outcome = isCompleted(result)
         ? ("success" as const)


### PR DESCRIPTION
## Summary

Adds a distinct \`daemon.validate.legacy-fallback\` log event whenever a completed wake falls back to the legacy heuristic. Makes the v0.9.0 promotion gate measurable from v0.8.0 onward.

Engineering-agent identified this as a pre-v0.8.0 must-have in their 2026-05-14 audit:

> \"Identified immediate action item: add \`daemon.validate.legacy-fallback\` log event to the current shallow heuristic branch so condition 3 [zero legacy-fallback log events during a 14-day soak] is measurable from day one.\"

Filed at [harness#363](https://github.com/murmurations-ai/murmurations-harness/issues/363#issuecomment-4448986165).

## Fires when

A completed wake has either:

- \`obligationStatus === undefined\` → \`reason: \"no-contract-context\"\` (daemon predates Phase 4 wiring OR caller didn't pass a contract — should be impossible in production after v0.8.0)
- \`obligationStatus === \"not-applicable\"\` → \`reason: \"no-required-outputs-declared\"\` (operator authored a \`contract:\` block but left output arrays empty)

## Why it matters

v0.9.0 retires the legacy heuristic. The promotion gate is \"zero \`daemon.validate.legacy-fallback\` events during a 14-day soak.\" This PR makes that gate measurable from day one of v0.8.0 — no waiting until v0.8.1 to start the count.

## Test plan

- [x] \`pnpm run build\` ✅
- [x] \`pnpm run typecheck\` ✅
- [x] \`pnpm run lint\` ✅ (0 errors)
- [x] \`pnpm run format:check\` ✅
- [x] \`pnpm run test\` ✅ (1240 passed — existing wake-validation tests unaffected; logger calls are info-level side effects)

## References

- harness#363 (engineering-agent position)
- ADR-0048 §Decision 2 (v0.8.1+ behavioral hard-fail promotion path; this paves the way for the parallel v0.9.0 obligation-only promotion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)