### PR TITLE
fix(validation): credit blob URLs as committed-artifact evidence (harness#364 Part C)

### DIFF
--- a/packages/core/src/execution/execution.test.ts
+++ b/packages/core/src/execution/execution.test.ts
@@ -903,6 +903,91 @@ describe("validateWake", () => {
     expect(v.obligationStatus).toBe("unmet");
   });
 
+  it("blob URL in wakeSummary satisfies a committed-artifact obligation", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "docs/research/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Filed research at https://github.com/xeeban/emergent-praxis/blob/main/docs/research/competitive-positioning-2026-05-14.md.",
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("satisfied");
+  });
+
+  it("blob URL with #L anchor strips to the path before matching", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "docs/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "See https://github.com/xeeban/emergent-praxis/blob/main/docs/research/foo.md#L42 for details.",
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("satisfied");
+  });
+
+  it("blob URL whose path falls outside the glob does not satisfy", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "drafts/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Committed https://github.com/xeeban/emergent-praxis/blob/main/docs/legal/refund.md.",
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("unmet");
+  });
+
+  it("multiple blob URLs — one matching the glob is enough", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "drafts/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: [
+        "Posted https://github.com/xeeban/emergent-praxis/blob/main/docs/legal/refund.md.",
+        "Then drafted https://github.com/xeeban/emergent-praxis/blob/main/drafts/2026-05/article.md.",
+      ].join(" "),
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("satisfied");
+  });
+
+  it("blob URL inside a governance event payload counts as evidence", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "docs/research/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Research complete.",
+      governanceEvents: [
+        {
+          kind: "report",
+          payload: {
+            url: "https://github.com/xeeban/emergent-praxis/blob/main/docs/research/foo.md",
+          },
+        },
+      ],
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("satisfied");
+  });
+
+  it("no receipt and no blob URL leaves a committed-artifact obligation unmet", () => {
+    const contract = mkContract([{ kind: "committed-artifact", path: "drafts/**/*.md" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary: "Drafted the article and was about to commit.",
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("unmet");
+  });
+
+  it("blob URL satisfies a committed-artifact obligation with no path declared", () => {
+    const contract = mkContract([{ kind: "committed-artifact" }]);
+    const result = {
+      ...emptyResult,
+      wakeSummary:
+        "Committed https://github.com/xeeban/emergent-praxis/blob/main/anywhere/file.md.",
+    };
+    const v = validateWake({ ...mkCtx(), contract }, result, []);
+    expect(v.obligationStatus).toBe("satisfied");
+  });
+
   it("runtime-artifact required output is always satisfied (digest writer runs on completion)", () => {
     const contract = mkContract([{ kind: "runtime-artifact", path: ".murmuration/runs/**/*.md" }]);
     const v = validateWake({ ...mkCtx(), contract }, emptyResult, []);

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -860,6 +860,25 @@ const buildGithubIssueUrlMatcher = (issueNum: number): RegExp => {
 };
 
 /**
+ * Extract the `<path>` portion from every
+ * `github.com/<owner>/<repo>/blob/<branch>/<path>` URL in `text`.
+ * Trailing `#Lxxx` line anchors are stripped.
+ */
+const extractGithubBlobPaths = (text: string): readonly string[] => {
+  const re = /github\.com\/[^/\s]+\/[^/\s]+\/blob\/[^/\s]+\/([^\s)\]>`"']+)/gi;
+  const paths: string[] = [];
+  for (const match of text.matchAll(re)) {
+    const path = match[1];
+    if (path === undefined || path.length === 0) continue;
+    const beforeAnchor = path.split("#")[0] ?? path;
+    const cleanPath = beforeAnchor.replace(/[.,;:!?]+$/, "");
+    if (cleanPath.length === 0) continue;
+    paths.push(cleanPath);
+  }
+  return paths;
+};
+
+/**
  * Brutally-simple glob matcher (Phase 4 PR 4 v1).
  *
  * Supports prefix + suffix matching only:
@@ -920,14 +939,34 @@ const isOutputSatisfied = (
       // is being called, the wake completed, so a runtime artifact exists.
       return true;
     case "committed-artifact":
-    case "commit":
-      return receipts.some((r) => {
+    case "commit": {
+      const receiptHit = receipts.some((r) => {
         if (!r.success || r.action.kind !== "commit-file") return false;
         if (req.path === undefined) return true;
         const filePath = r.action.filePath;
         if (filePath === undefined) return false;
         return pathMatchesGlob(filePath, req.path);
       });
+      if (receiptHit) return true;
+
+      // Fallback evidence: a blob URL referenced in the wake summary or a
+      // governance event. Agents that commit via subprocess (e.g. `gh api`)
+      // leave no commit-file receipt but typically surface the resulting URL.
+      const blobPaths = [
+        ...extractGithubBlobPaths(result.wakeSummary),
+        ...result.governanceEvents.flatMap((g) => {
+          try {
+            return extractGithubBlobPaths(JSON.stringify(g));
+          } catch {
+            return [];
+          }
+        }),
+      ];
+      if (blobPaths.length === 0) return false;
+      const reqPath = req.path;
+      if (reqPath === undefined) return true;
+      return blobPaths.some((p) => pathMatchesGlob(p, reqPath));
+    }
     case "comment":
       return successfulReceiptOfKind("comment-issue");
     case "issue":


### PR DESCRIPTION
## Summary

Closes the receipt-vs-reality gap for agents that commit via subprocess (e.g. \`gh api\`): such commits land on the remote but produce no \`commit-file\` \`WakeActionReceipt\`, so the validator flagged the wake \`obligation-unmet\` even though the artifact existed.

Extend \`isOutputSatisfied\` so that, when no receipt matches, it falls back on \`github.com/<owner>/<repo>/blob/<branch>/<path>\` URLs found in \`wakeSummary\` or governance event payloads, matching the extracted path against the obligation's glob. Mirrors PR #369 (Part A, \`/issues/N\` URLs).

This is the v0.8.0 ship-quality companion to harness#364. Part B (opt-in \`verifiedActions\` field on \`AgentResult\`) remains deferred — tracked separately.

## Test plan

- [x] \`pnpm run build\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run lint\` — 0 errors (25 pre-existing warnings unchanged)
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm run test\` — 1247 passed, 2 skipped (7 new tests for blob-URL evidence)
- [ ] CI green on this PR
- [ ] Live verification: rerun an agent wake that previously triggered \`obligation-unmet\` despite a successful gh-CLI commit and confirm it now reports \`satisfied\`

Refs harness#364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)