### PR TITLE
chore: strip progress-note comments from Phase 4 surfaces

### DIFF
--- a/packages/cli/src/spirit/tools.test.ts
+++ b/packages/cli/src/spirit/tools.test.ts
@@ -81,7 +81,7 @@ describe("Spirit tools — read_file", () => {
   });
 });
 
-describe("Spirit tools — write_file (harness#366 trusted-surface protection)", () => {
+describe("Spirit tools — write_file (trusted-surface protection)", () => {
   let root = "";
 
   beforeEach(() => {
@@ -107,14 +107,14 @@ describe("Spirit tools — write_file (harness#366 trusted-surface protection)",
     return tool;
   };
 
-  it("refuses to overwrite agents/<id>/role.md (Phase 4 PR 3 trusted-segment surface)", async () => {
+  it("refuses to overwrite agents/<id>/role.md", async () => {
     const tool = getTool("write_file");
     const result = await tool.execute({
       path: "agents/alpha/role.md",
       content: "# rewritten\n",
     });
     expect(result).toMatch(/operator config/);
-    expect(result).toMatch(/harness#366/);
+    expect(result).toMatch(/trusted identity surface/);
   });
 
   it("refuses to overwrite agents/<id>/soul.md", async () => {
@@ -584,10 +584,10 @@ describe("Spirit tools — close_issue (K3)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// harness#318 — cost tool
+// cost tool
 // ---------------------------------------------------------------------------
 
-describe("Spirit tools — cost (harness#318)", () => {
+describe("Spirit tools — cost", () => {
   it("calls send('cost.summary') and returns formatted result", async () => {
     let calledMethod = "";
     const send: typeof noopSend = (method) => {
@@ -612,10 +612,10 @@ describe("Spirit tools — cost (harness#318)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// harness#319 — backlog tool
+// backlog tool
 // ---------------------------------------------------------------------------
 
-describe("Spirit tools — backlog (harness#319)", () => {
+describe("Spirit tools — backlog", () => {
   let root = "";
 
   beforeEach(() => {
@@ -697,10 +697,10 @@ describe("Spirit tools — backlog (harness#319)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// harness#320 — doctor tool
+// doctor tool
 // ---------------------------------------------------------------------------
 
-describe("Spirit tools — doctor (harness#320)", () => {
+describe("Spirit tools — doctor", () => {
   let root = "";
 
   beforeEach(() => {

--- a/packages/cli/src/spirit/tools.ts
+++ b/packages/cli/src/spirit/tools.ts
@@ -26,7 +26,7 @@ import { buildReport, type ReportScope } from "./reports.js";
 import { spiritSkillsDir } from "./system-prompt.js";
 
 // ---------------------------------------------------------------------------
-// Strict tool type for Spirit — ADR-0038 CF-D (harness#283)
+// Strict tool type for Spirit
 // ---------------------------------------------------------------------------
 //
 // Spirit's tools must use `z.object(...)` for `parameters` because the MCP
@@ -105,11 +105,11 @@ const safePath = (rootDir: string, path: string, mode: "read" | "write" = "read"
       );
     }
 
-    // Operator config files — identity + governance authority. ADR-0048 PR 3
-    // injects role.md content as a `trusted` system-prompt segment; if an
-    // agent could rewrite its own role.md it could escalate by editing
-    // `done_when`, clearing `approval_required_for`, or planting prompt
-    // injection in any frontmatter field. harness#366.
+    // Operator config files carry identity + governance authority and are
+    // rendered into agent prompts as `trusted` segments. Letting an agent
+    // rewrite its own role.md / soul.md / harness.yaml would let it edit
+    // `done_when`, clear `approval_required_for`, or inject prompts via
+    // any frontmatter field. Block writes to those paths.
     //
     // Normalize separators once so the regex catches Windows and POSIX paths.
     const relPosix = rel.replace(/\\/g, "/");
@@ -120,7 +120,7 @@ const safePath = (rootDir: string, path: string, mode: "read" | "write" = "read"
       relPosix === "harness.yaml"
     ) {
       throw new PathSafetyError(
-        `writing operator config "${path}" is not allowed — role.md, soul.md, and harness.yaml are the trusted identity surface (harness#366)`,
+        `writing operator config "${path}" is not allowed — role.md, soul.md, and harness.yaml are the trusted identity surface`,
       );
     }
   }
@@ -619,7 +619,6 @@ export const buildSpiritTools = (ctx: ToolContext): readonly SpiritTool[] => {
     },
   };
 
-  // harness#318 — cost tool
   const costTool: SpiritTool = {
     name: "cost",
     description:
@@ -628,7 +627,6 @@ export const buildSpiritTools = (ctx: ToolContext): readonly SpiritTool[] => {
     execute: async () => formatSocketResponse(await send("cost.summary")),
   };
 
-  // harness#319 — backlog tool
   const backlogTool: SpiritTool = {
     name: "backlog",
     description:
@@ -668,7 +666,6 @@ export const buildSpiritTools = (ctx: ToolContext): readonly SpiritTool[] => {
     },
   };
 
-  // harness#320 — doctor tool
   const doctorTool: SpiritTool = {
     name: "doctor",
     description:

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -83,7 +83,7 @@ const CIRCUIT_BREAKER_THRESHOLD = 3;
 const MAX_IDLE_SKIP_STREAK = 12;
 
 /**
- * Hash the wake context's stable shape for idle-wake skip (harness#297).
+ * Hash the wake context's stable shape for idle-wake skip.
  * Captures everything that should cause the LLM to behave differently
  * across wakes:
  *   - all signal fields except `fetchedAt` (which is just Date.now()
@@ -193,8 +193,7 @@ export interface RegisteredAgent {
 
   /**
    * Least-privilege GitHub write surface. Empty arrays mean read-only.
-   * Enforced at the github client layer by harness#16 (P5) —
-   * declaration surfaces here.
+   * Enforced at the github client layer — this is the declaration surface.
    */
   readonly githubWriteScopes: {
     readonly issueComments: readonly string[];
@@ -259,10 +258,9 @@ export interface RegisteredAgent {
   }[];
 
   /**
-   * Parsed `contract:` block from `role.md` frontmatter (ADR-0047, ADR-0048,
-   * Phase 4 PR 1+2). Undefined when the role does not declare a contract —
-   * `assembleExecutionContract()` still produces a usable contract from
-   * runtime context in that case.
+   * Parsed `contract:` block from `role.md` frontmatter. Undefined when
+   * the role does not declare a contract — `assembleExecutionContract()`
+   * still produces a usable contract from runtime context in that case.
    */
   readonly contract?: ContractDeclaration;
 }
@@ -300,11 +298,9 @@ export const registeredAgentFromLoadedIdentity = (
       }
     : undefined;
 
-  // Auto-derive the membership-aware OR-set of routing labels (harness#331
-  // fix, with derivation moved here from boot.ts per Engineering Standard
-  // #8 — keep the composition root thin). The aggregator listens for any
-  // of these to deliver assigned items, scoped directives, group
-  // directives, and broadcast directives.
+  // Auto-derive the membership-aware OR-set of routing labels. The
+  // aggregator listens for any of these to deliver assigned items,
+  // scoped directives, group directives, and broadcast directives.
   //
   // Operator precedence: if `signals.github_scopes[].filter.any_label` is
   // explicitly set in role.md, that wins; otherwise the daemon's
@@ -807,9 +803,9 @@ export class Daemon {
     // injection needed. Agents see directives as github-issue signals
     // with the "source-directive" label and respond in their wake output.
 
-    // Idle-wake skip (harness#297): if the bound context hashes equal
-    // to what we fired last time AND the last wake succeeded AND we
-    // haven't been skipping for too long, drop the LLM call entirely.
+    // Idle-wake skip: if the bound context hashes equal to what we fired
+    // last time AND the last wake succeeded AND we haven't been skipping
+    // for too long, drop the LLM call entirely.
     // The hash captures signal IDs + their updatedAt + action items +
     // identity frontmatter, so any meaningful change forces a fire.
     // Manual triggers (`--now`, scheduler kind === "manual") always
@@ -891,8 +887,8 @@ export class Daemon {
               signals: context.signals.signals,
               agentId: agent.agentId,
               groupIds: agent.groupMemberships,
-              // Phase 4 PR 4: pass the assembled contract so obligation
-              // validation runs alongside the legacy heuristic.
+              // Pass the assembled contract so obligation validation runs
+              // alongside the legacy heuristic.
               ...(context.contract !== undefined ? { contract: context.contract } : {}),
             },
             result,
@@ -961,15 +957,12 @@ export class Daemon {
         });
       }
 
-      // Phase 5 measurability hook (engineering-agent's harness#363 recommendation,
-      // 2026-05-14). Emit a distinct event whenever a completed wake fell back
-      // to the legacy heuristic — either because no contract was supplied
-      // (`obligationStatus === undefined`) or because the contract declared
-      // no `requiredOutputs` (`obligationStatus === "not-applicable"`).
-      //
-      // v0.9.0 retires the legacy heuristic; the promotion gate is "zero
-      // `daemon.validate.legacy-fallback` events during a 14-day soak". This
-      // event makes that gate measurable from v0.8.0 onward.
+      // Emit a distinct event whenever a completed wake fell back to the
+      // legacy heuristic — either because no contract was supplied
+      // (`obligationStatus === undefined`) or because the contract
+      // declared no `requiredOutputs` (`obligationStatus === "not-applicable"`).
+      // Operators can count these events to measure how many wakes still
+      // skip the obligation sub-contract.
       if (
         isCompleted(result) &&
         (validation.obligationStatus === undefined ||
@@ -1011,9 +1004,9 @@ export class Daemon {
                 wakeSummary: amendWakeSummaryWithValidation(result.wakeSummary, validation),
               }
             : result;
-        // Phase 4 PR 5: pass the validation result so the index entry
-        // can record validationStatus, obligationStatus, and the
-        // unmet-required-output count for dashboard surfacing.
+        // Pass the validation result so the index entry can record
+        // validationStatus, obligationStatus, and the unmet-required-output
+        // count for dashboard surfacing.
         await this.#runArtifactWriter.record(
           recordedResult,
           result.costRecord,
@@ -1434,11 +1427,10 @@ const buildSpawnContext = async (
   const wakeMode = "individual" as const;
   const wakeReason = event.wakeReason;
 
-  // Phase 4 PR 2: assemble the full ExecutionContract for this wake.
-  // Empty when the role lacks a `contract:` block — assembleExecutionContract
-  // handles the missing-declaration case and still returns a usable contract
-  // populated from runtime context (objective derived from wake reason,
-  // allowedSideEffects derived from write scopes).
+  // Assemble the full ExecutionContract for this wake. When the role
+  // lacks a `contract:` block, `assembleExecutionContract` still returns
+  // a usable contract populated from runtime context (objective derived
+  // from wake reason, allowedSideEffects derived from write scopes).
   const contract = assembleExecutionContract({
     wakeReason,
     wakeMode,

--- a/packages/core/src/execution/execution.test.ts
+++ b/packages/core/src/execution/execution.test.ts
@@ -418,14 +418,10 @@ describe("validateWake", () => {
   });
 
   // -------------------------------------------------------------------------
-  // harness#364 Part A — GitHub issue URL counts as structural evidence
+  // GitHub issue URL counts as structural evidence
   // -------------------------------------------------------------------------
 
-  it("treats a full GitHub issue URL in wakeSummary as structural evidence (harness#364)", () => {
-    // Reproduces engineering-agent's 2026-05-11 wake on EP #845: comment
-    // posted via subscription-CLI subprocess; URL lands in wakeSummary
-    // but no receipt exists. Before this fix, the wake was flagged
-    // narrative-only-claim → idle.
+  it("treats a full GitHub issue URL in wakeSummary as structural evidence", () => {
     const directive = makeIssueSignal(845, ["source-directive", "assigned:engineering-agent"]);
     const result = {
       ...emptyResult,
@@ -738,7 +734,7 @@ describe("validateWake", () => {
     expect(() => validateWake(mkCtx({ signals: [directive] }), result, [])).not.toThrow();
   });
 
-  // Routing filter tests (harness#354 regression coverage)
+  // Routing filter tests
 
   it("skips a directive scoped to a different agent — does not count as unaddressed", () => {
     const directive = makeIssueSignal(100, ["source-directive", "assigned:other-agent"]);
@@ -789,7 +785,7 @@ describe("validateWake", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Phase 4 PR 4 — contract obligation enforcement (ADR-0047, ADR-0048)
+  // Contract obligation enforcement
   // -------------------------------------------------------------------------
 
   const baseBudget = {
@@ -1259,7 +1255,7 @@ describe("renderSignalForPrompt", () => {
 });
 
 // ---------------------------------------------------------------------------
-// validateBehavior — Phase 4 PR 6a (warning-only)
+// validateBehavior (advisory warnings)
 // ---------------------------------------------------------------------------
 
 describe("validateBehavior", () => {

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -425,11 +425,7 @@ export interface SignalBundle {
    * dropped by a sub-query failure." Absent or empty array when every
    * query succeeded; populated alongside `warnings` (which carry the
    * same info as a human-readable string) for callers that want
-   * structured access. Added in v0.7.1 (QA review of harness#331).
-   *
-   * Optional so existing callers / fixtures aren't forced to update — the
-   * aggregator always populates it; manual SignalBundle construction
-   * (tests, daemon hello-world path) may omit it.
+   * structured access.
    */
   readonly partialFailures?: readonly SignalAggregationFailure[];
   /**
@@ -625,25 +621,21 @@ export interface AgentSpawnContext {
   /**
    * Stable reference string for the prompt source (e.g. a git sha or
    * content hash). Used for prompt-level deduplication in `PromptBundle.hash`.
-   * Near-Term #1 (Proposal 07).
    */
   readonly promptRef?: string;
   /**
-   * Full execution contract for this wake (Phase 4 PR 2, ADR-0047, ADR-0048).
+   * Full execution contract for this wake.
    *
    * Assembled by `assembleExecutionContract()` from the role's
    * `contract:` block + runtime context (signals, budget, write scopes).
-   * Optional so test fixtures and pre-Phase-4 callers do not need to
-   * populate it; production daemon wakes always populate it from PR 2
-   * onward.
    *
-   * Consumers (Phase 4 PR 3/4/6a):
+   * Consumers:
    *   - PromptAssembler renders `requiredOutputs` + `actionItems` into
    *     the system prompt.
-   *   - `validateOutcomes` (PR 4) scores the wake against the obligation
+   *   - `validateOutcomes` scores the wake against the obligation
    *     sub-contract.
-   *   - `validateBehavior` (PR 6a, warning-only) reads `allowedSideEffects`
-   *     to cross-check narrative vs. tool calls.
+   *   - `validateBehavior` reads `allowedSideEffects` to cross-check
+   *     narrative vs. tool calls.
    */
   readonly contract?: ExecutionContract;
 }
@@ -719,8 +711,7 @@ export interface WakeActionReceipt {
 /**
  * A directive from the wake's signal bundle that lacked structured
  * evidence of action. Surfaced by `validateWake` so operators can
- * detect narrative-only "I have posted CONSENT" hallucinations
- * (Boundary 5 — see docs/plans/v0.5.2-boundary-5-phase-1-directive-validation.md).
+ * detect narrative-only "I have posted CONSENT" hallucinations.
  */
 export interface UnaddressedDirective {
   readonly issueNumber: number;
@@ -745,8 +736,7 @@ export interface WakeValidationResult {
    */
   readonly directivesUnaddressed: readonly UnaddressedDirective[];
   /**
-   * Contract obligation status (Phase 4 PR 4, ADR-0047 §2 obligation sub-contract,
-   * ADR-0048 §1).
+   * Contract obligation status.
    *
    *   `satisfied`     — every `requiredOutput` has matching successful evidence.
    *   `unmet`         — at least one `requiredOutput` is missing — wake is
@@ -755,8 +745,7 @@ export interface WakeValidationResult {
    *   `not-applicable` — no contract supplied, or `requiredOutputs` is empty;
    *                     the legacy heuristic is the sole gate.
    *
-   * Absent when `validateWake` was called without a contract (pre-Phase-4
-   * test paths and legacy harness consumers).
+   * Absent when `validateWake` was called without a contract.
    */
   readonly obligationStatus?: "satisfied" | "unmet" | "not-applicable";
   /**
@@ -765,14 +754,12 @@ export interface WakeValidationResult {
    */
   readonly unmetRequiredOutputs?: readonly { readonly kind: string; readonly path?: string }[];
   /**
-   * Behavior warnings from `validateBehavior` (Phase 4 PR 6a, ADR-0047 §2,
-   * ADR-0048 §1). Each warning describes a narrative claim in `wakeSummary`
-   * that lacks structured evidence (successful action receipt or URL).
+   * Behavior warnings from `validateBehavior`. Each warning describes a
+   * narrative claim in `wakeSummary` that lacks structured evidence
+   * (successful action receipt or URL).
    *
-   * **Warning-only in v0.8.0** — these do NOT affect `productive`,
-   * `idleWakes`, or `successfulWakes`. They surface on the dashboard so
-   * operators can calibrate before behavior validation is promoted to
-   * hard-fail in v0.8.1 (per ADR-0048 §Decision 2).
+   * These are advisory — they do NOT affect `productive`, `idleWakes`,
+   * or `successfulWakes`.
    */
   readonly behaviorWarnings?: readonly BehaviorWarning[];
   /** If not productive, why. */
@@ -780,11 +767,10 @@ export interface WakeValidationResult {
 }
 
 /**
- * One behavior warning from `validateBehavior` (Phase 4 PR 6a, ADR-0048 §1).
+ * One behavior warning from `validateBehavior`.
  *
- * Warning-only in v0.8.0: the wake's `productive` flag is not affected.
- * Surfaced on the dashboard for operator calibration before v0.8.1
- * promotes behavior validation to hard-fail.
+ * Advisory: the wake's `productive` flag is not affected. Surfaced on the
+ * dashboard for operator review.
  */
 export interface BehaviorWarning {
   /** Pattern that fired. v1 has a single kind; future kinds extend the
@@ -832,30 +818,17 @@ const buildIssueReferenceMatchers = (issueNum: number): readonly RegExp[] => {
 };
 
 /**
- * URL-form matcher for resolving "does this text reference a real GitHub
- * issue by URL". Used as structural evidence (Part A of harness#364):
- * subscription-CLI agents post comments via their subprocess tool layer
- * — these never reach `result.actions`/`actionReceipts`, but the URL
- * typically lands in `wakeSummary` or a governance event payload (e.g.
- * `https://github.com/xeeban/emergent-praxis/issues/845` or
- * `.../issues/845#issuecomment-NNN`).
+ * Match a fully-qualified `github.com/<owner>/<repo>/issues/<n>` URL,
+ * with word boundary on the trailing digit so `/issues/845` does not
+ * match `/issues/8450`. Comment anchors (`/issues/<n>#issuecomment-...`)
+ * are also accepted.
  *
- * Rationale: a fully-qualified GitHub URL is much harder to hallucinate
- * than a plain `#N` reference, and an agent emitting it has typically
- * received it from a real tool call's response payload. Treating these
- * as structural evidence eliminates the false-positive
- * `narrative-only-claim` that fires on every consent-round response from
- * subscription-CLI agents in EP (engineering-agent's 2026-05-12 audit).
- *
- * Full-fidelity fix (Part B) is an opt-in `verifiedActions` field on
- * `AgentResult` populated by subscription-CLI executors from confirmed
- * subprocess operations — deferred to v0.8.1 per ADR-0048.
+ * Used as structural evidence when an agent's commit/comment was made
+ * via subprocess and produced no WakeActionReceipt but left the URL in
+ * the wake summary or a governance event payload.
  */
 const buildGithubIssueUrlMatcher = (issueNum: number): RegExp => {
   const n = String(issueNum);
-  // github.com/<owner>/<repo>/issues/<n> with word boundary on the
-  // trailing digit so `/issues/845` does not match `/issues/8450`.
-  // Also handles the comment-anchor form `/issues/<n>#issuecomment-...`.
   return new RegExp(`github\\.com/[^/]+/[^/]+/issues/${n}(?!\\d)`, "i");
 };
 
@@ -879,22 +852,17 @@ const extractGithubBlobPaths = (text: string): readonly string[] => {
 };
 
 /**
- * Brutally-simple glob matcher (Phase 4 PR 4 v1).
+ * Prefix + suffix glob matcher.
  *
- * Supports prefix + suffix matching only:
- *   - The literal text before the first `*` becomes the required prefix.
- *   - The literal text after the last `*` becomes the required suffix.
- *   - Anything between is treated as "any path".
+ *   - The literal text before the first `*` is the required prefix.
+ *   - The literal text after the last `*` is the required suffix.
+ *   - Anything between matches arbitrary path content.
+ *   - A glob with no `*` matches only via exact equality.
  *
  * Examples:
  *   `drafts/**\/*.md` → prefix `drafts/`, suffix `.md`  → matches `drafts/foo/bar.md`
  *   `agents/*\/role.md` → prefix `agents/`, suffix `/role.md` → matches `agents/x/role.md`
  *   `*.md` → prefix ``, suffix `.md` → matches `foo.md`
- *
- * Tightening to full glob semantics (per-segment `*`, character classes,
- * `?` single-char) is deferred to v0.8.1 per ADR-0048 / "v1 DSLs brutally
- * simple". Operators who need exact path matching can spell out the full
- * path with no wildcards — that takes the exact-match fast path.
  */
 const pathMatchesGlob = (actual: string, glob: string): boolean => {
   if (glob === actual) return true;
@@ -908,14 +876,14 @@ const pathMatchesGlob = (actual: string, glob: string): boolean => {
 };
 
 /**
- * Check one required output against the wake's actual evidence (Phase 4 PR 4).
+ * Check one required output against the wake's actual evidence.
  *
- * The mapping from `RequiredOutput.kind` to evidence is intentionally lax for
- * v1: any successful receipt of the matching action kind satisfies the
- * obligation, plus path-glob checks where a `path` is declared. The contract
- * narrative remains the agent's authoritative guide on _what_ to produce; the
- * validator's job is to refuse "I claim I did it" wakes that have no
- * structured evidence at all (Boundary 5 generalized).
+ * The mapping from `RequiredOutput.kind` to evidence is intentionally lax:
+ * any successful receipt of the matching action kind satisfies the
+ * obligation, plus path-glob checks where a `path` is declared. The
+ * contract narrative remains the agent's authoritative guide on _what_ to
+ * produce; the validator's job is to refuse "I claim I did it" wakes that
+ * have no structured evidence at all.
  */
 const isOutputSatisfied = (
   req: { readonly kind: string; readonly path?: string },
@@ -981,25 +949,18 @@ const isOutputSatisfied = (
 };
 
 /**
- * Behavior validation (Phase 4 PR 6a, ADR-0047 §2, ADR-0048 §1).
+ * Behavior validation.
  *
  * Scans `wakeSummary` for action-verb patterns that reference issue numbers
- * ("posted to #123", "closed issue #456", "committed to drafts/foo.md") and
- * checks each against structural evidence:
+ * ("posted to #123", "closed issue #456", "labeled #789") and checks each
+ * against structural evidence:
  *
  *   - successful WakeActionReceipt of the matching kind + issueNumber
- *   - GitHub issue URL for the same issue number (per harness#364 Part A)
+ *   - a GitHub issue URL for the same issue number
  *
- * Unmatched claims produce a `BehaviorWarning`. **Warning-only in v0.8.0**:
- * results are surfaced on dashboards and recorded on the wake but do not
- * affect `productive`/`idleWakes`/`successfulWakes`. v0.8.1 will promote
- * to hard-fail after 14d composite-permission soak per the original
- * ADR-0048 calendar (deferred from v0.8.0).
- *
- * Brutally simple v1 per the project rule: regex patterns over wake
- * summary, no NLP. False-positive rate is calibrated against real wake
- * data during the warning-only window. Operators can scrub their
- * narrative phrasing if a specific pattern is over-firing.
+ * Unmatched claims produce a `BehaviorWarning`. Warnings are advisory:
+ * they surface on dashboards and the wake record but do NOT affect
+ * `productive`, `idleWakes`, or `successfulWakes`.
  */
 export const validateBehavior = (
   result: {
@@ -1034,12 +995,11 @@ export const validateBehavior = (
       (r) => r.success && r.action.kind === actionKind && r.action.issueNumber === issueNum,
     );
 
-  // Pattern: "(posted|commented|replied|left a comment|added a comment) (on|to|at)? (issue)? #N"
-  // Allow up to ~80 chars between the verb and the #N to catch reasonable
-  // phrasing like "posted my consent position on issue #864". Non-greedy
-  // (`{0,80}?`) so a sentence with multiple `#N` references attributes the
-  // FIRST one to this verb, not the last. Word-boundary on the trailing
-  // digit so `#5` does not match `#54`.
+  // Up to ~80 chars between the verb and the #N catches phrasing like
+  // "posted my consent position on issue #864". The `{0,80}?` quantifier
+  // is non-greedy so a sentence with multiple `#N` references attributes
+  // the FIRST one to this verb, not the last. The trailing `(?!\d)` is a
+  // word boundary on the digit so `#5` does not match `#54`.
   const commentClaimRegex =
     /\b(posted|commented|replied|left a comment|added a comment)\b(?:[^.\n]{0,80}?)#(\d+)(?!\d)/gi;
   const closeClaimRegex = /\b(closed|resolved)\b(?:[^.\n]{0,80}?)#(\d+)(?!\d)/gi;
@@ -1096,14 +1056,13 @@ export const validateBehavior = (
  * structured-evidence backing for any source-directive items in signals.
  * Used when no custom validator is configured.
  *
- * Phase 4 PR 4: when `contract.requiredOutputs` is non-empty, each required
- * output is checked against successful action receipts. An unmet required
- * output marks the wake non-productive even if the legacy heuristic
+ * When `contract.requiredOutputs` is non-empty, each required output is
+ * also checked against successful action receipts. An unmet required
+ * output marks the wake non-productive even if the heuristic
  * (artifactCount > 0, no unaddressed directives) would have passed.
  *
- * Phase 4 PR 6a: additionally runs `validateBehavior` and attaches any
- * warnings to the result. Warnings are **warning-only**: they do not
- * affect `productive` or the legacy heuristic.
+ * `validateBehavior` runs alongside and attaches its warnings to the
+ * result. Behavior warnings are advisory and do not affect `productive`.
  */
 export const validateWake = (
   context: {
@@ -1114,16 +1073,15 @@ export const validateWake = (
      * don't intersect this agent's routing set (assigned:<id>,
      * scope:agent:<id>, scope:group:<gid>, scope:all) are treated as
      * signal, not accountability, and do not count as unaddressed.
-     * Harness #354 (effectiveness scoring scope bug).
      *
      * Pass empty groupIds when the agent has no group memberships.
      */
     agentId: string;
     groupIds: readonly string[];
     /**
-     * Optional ExecutionContract (Phase 4 PR 4, ADR-0047, ADR-0048). When
-     * supplied and `requiredOutputs` is non-empty, obligation validation
-     * runs and may override the heuristic productive flag.
+     * Optional ExecutionContract. When supplied and `requiredOutputs` is
+     * non-empty, obligation validation runs and may override the
+     * heuristic productive flag.
      */
     contract?: ExecutionContract;
   },
@@ -1157,9 +1115,8 @@ export const validateWake = (
     }
   }
 
-  // Directive validation (Boundary 5 Phase 1):
-  // every source-directive in the bundle (signals + actionItems) must
-  // be backed by a successful receipt OR a governance event whose
+  // Every source-directive in the bundle (signals + actionItems) must be
+  // backed by a successful receipt OR a governance event whose
   // payload-as-string references the issue number with a word boundary.
   // The word boundary blocks `#5` from matching `#50` / `#592`. We also
   // serialize each governance event once (outside the per-directive loop)
@@ -1182,7 +1139,7 @@ export const validateWake = (
 
   // Routing set for this agent — directives whose labels don't intersect
   // this set are visible signal (facilitator cross-visibility) but not
-  // this agent's accountability. Harness #354.
+  // this agent's accountability.
   const agentRoutingSet = new Set(buildAgentRoutingLabels(context.agentId, context.groupIds));
 
   const allBundle: readonly Signal[] = [...context.signals, ...context.actionItems];
@@ -1228,11 +1185,11 @@ export const validateWake = (
       continue;
     }
 
-    // harness#364 Part A: a fully-qualified GitHub issue URL in the wake
-    // summary or any governance event counts as structural evidence. This
-    // covers subscription-CLI agents whose subprocess-internal comment
-    // posts never land in `result.actions` but typically leave a URL in
-    // the wake summary (the tool-call response includes the issue URL).
+    // A fully-qualified GitHub issue URL in the wake summary or any
+    // governance event counts as structural evidence. This covers
+    // subscription-CLI agents whose subprocess-internal comment posts
+    // never land in `result.actions` but typically leave a URL in the
+    // wake summary (the tool-call response includes the issue URL).
     const urlMatcher = buildGithubIssueUrlMatcher(issueNum);
     if (urlMatcher.test(result.wakeSummary)) {
       continue;
@@ -1249,7 +1206,6 @@ export const validateWake = (
     directivesUnaddressed.push({ issueNumber: issueNum, reason: "no-structured-action" });
   }
 
-  // Phase 4 PR 4: contract obligation check.
   let obligationStatus: "satisfied" | "unmet" | "not-applicable" | undefined;
   let unmetRequiredOutputs: { readonly kind: string; readonly path?: string }[] | undefined;
   if (context.contract !== undefined) {
@@ -1288,10 +1244,9 @@ export const validateWake = (
           ? `${String(actionItemsAssigned)} action items assigned but none addressed`
           : "wake completed but produced no artifacts";
 
-  // Phase 4 PR 6a: behavior validation runs alongside outcome validation
-  // but is warning-only — its findings do NOT affect `productive` or
-  // any other counter. They surface on the dashboard for operator
-  // calibration before v0.8.1 promotes to hard-fail.
+  // Behavior validation runs alongside outcome validation but its
+  // findings are advisory — they do NOT affect `productive` or any other
+  // counter. They surface on the dashboard for operator review.
   const behaviorWarnings = validateBehavior(result, actionReceipts);
 
   const baseResult: WakeValidationResult = {
@@ -1326,8 +1281,6 @@ export const validateWake = (
  * affected line — the directives_unaddressed line still appends at the
  * end as a fallback, but the effectiveness downgrade is lost. Tests in
  * `execution.test.ts` lock the current format.
- *
- * Boundary 5 Phase 1.
  */
 export const amendWakeSummaryWithValidation = (
   summary: string,


### PR DESCRIPTION
## Summary

Comments are now what-this-code-does explanations only. Progress markers that belonged in PR descriptions or issue history have been removed across the Phase 4 surfaces:

- \`(Phase 4 PR N)\` scope tags
- \`(harness#NNN)\` / \`(ADR-NNNN)\` cross-references inside otherwise load-bearing comments and docstrings
- Dated incident notes (e.g. \"engineering-agent's 2026-05-11 wake on EP #845\")
- Forward-plan notes (\"deferred to v0.8.1\", \"v0.9.0 retires ...\")

Affected files:

- \`packages/core/src/execution/index.ts\`
- \`packages/core/src/daemon/index.ts\`
- \`packages/cli/src/spirit/tools.ts\` (plus matching test)
- \`packages/core/src/execution/execution.test.ts\` (section headers + test names)

The semantic content of each comment is preserved. Net diff: −62 lines (181 changed lines on \`execution/index.ts\` alone, almost entirely comment removal).

## Test plan

- [x] \`pnpm run build\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run lint\` — 0 errors (25 pre-existing warnings unchanged)
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm run test\` — 1247 passed (one updated assertion in \`tools.test.ts\` for the new user-facing message)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)