### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## Summary

Bumps root + 8 package versions from \`0.7.2\` → \`0.8.0\` for the Phase 4 execution contracts release. CHANGELOG and README landed in #374. Tag \`v0.8.0\` is cut on \`main\` after this merges.

## Test plan

- [x] \`pnpm run build\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run lint\` — 0 errors (25 pre-existing warnings)
- [x] \`pnpm run format:check\` — clean
- [x] \`pnpm run test\` — 1247 passed, 2 skipped
- [ ] CI green
- [ ] Soak signal clean (zero \`daemon.validate.legacy-fallback\` events through 2026-05-19 morning — confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)