### PR TITLE
chore(release): walk back v0.8.0 tag — apply review fixes before re-tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Murmuration Harness are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.8.0] - 2026-05-19
+## [Unreleased]
 
 **Execution contracts — agents declare what completion looks like in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces it.**
 

--- a/docs/plans/v0.8.1-attach-tui-redesign.md
+++ b/docs/plans/v0.8.1-attach-tui-redesign.md
@@ -1,0 +1,181 @@
+# v0.8.1 — Attach REPL TUI Redesign
+
+**Status:** Design (2026-05-19) · **Target:** v0.8.1 · **Owner:** Source
+
+## Why
+
+The current `murmuration attach <name>` REPL is a single linear readline scroll. Three problems surfaced during the v0.8.0 release cycle:
+
+1. **Subprocess logs leak into the chat window.** `subprocess.spawn`, `subprocess.stderr.chunk`, and `subprocess.close` JSON lines are written to stderr by `packages/llm/src/providers/subprocess/base-client.ts` and appear interleaved with Spirit's response. They belong in a log file, not the conversation.
+2. **Per-turn token/cost line is noise.** `[N in / M out · ~$X]` after every Spirit reply clutters the conversational flow; operators rarely care per-turn.
+3. **No persistent identity context.** Source has to remember which murmuration they're attached to. Connection identity (name, harness version, agent count, daemon PID) should be visible at all times.
+
+Beyond cleanup, the right UX is a three-zone TUI: streaming scrollback on top, a dedicated Source input area, and a persistent footer pinned at the bottom — the same shape Source uses every day in Claude Code itself.
+
+## Goals
+
+- Replace the readline REPL with an `ink`-based three-zone TUI.
+- Subprocess logs route to `.murmuration/logs/spirit-debug.log` (or env-gated to stderr).
+- Per-turn cost line is removed from inline output; a `:cost` command and the footer surface the same data.
+- Footer renders `<name> · v<harness-version> · <N> agents · PID <pid>`, refreshed on a heartbeat.
+- Existing `:command` syntax (e.g. `:agents`, `:reset`, `:edit role`) continues to work — Source's muscle memory is preserved.
+- A new `/` palette opens a fuzzy-filterable command picker for discovery.
+
+## Non-goals
+
+- No mouse support. Keyboard-only.
+- No theming / color schemes beyond the existing palette.
+- No multi-pane split (split view, second agent, etc.) — single conversation surface.
+- No persistent scrollback across sessions (existing `repl-history-<name>` log stays as today).
+
+## Decisions (2026-05-19)
+
+| Question        | Decision                                                                      |
+| --------------- | ----------------------------------------------------------------------------- |
+| TUI library     | **ink** (React-based; same stack as GitHub CLI, Vercel, Gatsby)               |
+| Command model   | Keep `:command` for muscle memory **+** add `/` command palette for discovery |
+| Backward compat | Replace the readline REPL outright — no `--no-tui` fallback                   |
+| Scope           | All in v0.8.1 (TUI rebuild + log suppression + footer + cost-line removal)    |
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                      │
+│  [09:12] You: hi                                                     │
+│                                                                      │
+│  [09:12] Spirit: Hi Nori. It's been about two weeks since the        │
+│  kickoff wakes. Want a status check — what the agents have been      │
+│  up to, whether the LLM stub issue got resolved?                     │
+│                                                                      │
+│  …                                                                   │
+│                                                                      │
+│  ── streaming scrollback (grows upward; auto-scrolls on new turns) ──│
+│                                                                      │
+├──────────────────────────────────────────────────────────────────────┤
+│ > _                                                                  │
+│   (Spirit thinking · 4s)                                             │
+├──────────────────────────────────────────────────────────────────────┤
+│ chinook-wind · v0.8.0 · 6 agents · PID 22465 · ⏎ send  / palette  ?  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Zones
+
+1. **Scrollback** (flex-grow). Renders the conversation in chronological order. Each turn has a timestamp prefix and role label. Auto-scrolls to bottom on new turns; up/down arrow scrolls back through history when input is empty.
+2. **Input** (2 lines). Single-line input that expands to multi-line on `Shift+Enter` (or `\` continuation, TBD). Spirit-thinking spinner renders on the second line of the input zone while a turn is in flight.
+3. **Footer** (1 line). `<name> · v<harness-version> · <N> agents · PID <pid> · <hint>`. The hint area cycles through `⏎ send`, `/ palette`, `?` for help.
+
+## Component breakdown (ink)
+
+- `<AttachApp>` — root. Manages session state, command dispatch, and zone layout.
+- `<Scrollback>` — virtualized list of turns. Each turn is a `<Turn role="you|spirit|system" text="…" />`.
+- `<InputArea>` — controlled textarea + thinking-indicator. Owns the cursor and submit logic.
+- `<Footer>` — pure renderer of identity props.
+- `<CommandPalette>` — modal overlay when `/` is typed at the start of input. Fuzzy filter against the command list, arrow-navigate, `Enter` to run.
+- `<HelpModal>` — shown on `?` keypress. Lists `:commands`, leader chords, and palette shortcut.
+
+## Subprocess log routing
+
+Current behavior: `base-client.ts` writes JSON to `process.stderr` directly (3 events per subprocess invocation: spawn, stderr-chunk, close).
+
+New behavior:
+
+- Default: write to `<root>/.murmuration/logs/spirit-debug.log` (rotating, append-only).
+- Env-gated: when `MURMURATION_SUBPROCESS_TRACE=1` is set, ALSO write to stderr (preserves current daemon-debug workflow).
+- Daemon mode keeps both (operator wants stderr trail in the daemon log).
+- Attach REPL: leaves the env unset, so logs go to file only — chat window stays clean.
+
+API change: `BaseSubprocessClient` config grows `logSink?: { kind: "stderr" | "file"; path?: string } | "off"`. Default `"stderr"` for backward compat. Spirit attach passes `{ kind: "file", path: ".murmuration/logs/spirit-debug.log" }`.
+
+## Command model
+
+### `:command` (muscle memory)
+
+Typed at the start of input. Captured before submission. Examples:
+
+- `:agents`, `:groups`, `:events`, `:cost`, `:status`
+- `:reset`, `:reset memory`, `:reset conversation`
+- `:edit role`, `:edit soul`, `:edit harness`
+- `:detach`, `:quit`
+
+Behavior: input is treated as a command rather than a Spirit message. Output renders as a `system` turn in the scrollback.
+
+### `/` palette (discovery)
+
+Typed at the start of input. Triggers `<CommandPalette>` modal. Source can:
+
+- Arrow-navigate the filtered list.
+- Type to fuzzy-filter (`/age` matches `:agents`, `/res` matches `:reset`, `:reset memory`, etc.).
+- `Enter` runs the selected command.
+- `Esc` dismisses.
+
+The palette is the discoverable surface; `:command` is the keyboard-only shortcut for power users.
+
+### Leader-key chords
+
+Existing leader-key chords (currently `Ctrl+B` followed by a letter, per `attach.ts` config) stay. They're independent of the input zone and fire from anywhere in the TUI.
+
+## Streaming
+
+Spirit's current subprocess invocation returns a single final JSON blob on close — there's no incremental stream. For v0.8.1, the response renders as a single turn appended to scrollback when the subprocess closes. The Spirit-thinking spinner in the input zone provides liveness during the wait.
+
+Future (v0.9+) work for true streaming would require switching to the Anthropic SSE API, which is a separate effort and out of scope.
+
+## Footer refresh
+
+Footer data:
+
+- `name` — static (resolved at attach time).
+- `harness version` — static (`HARNESS_VERSION` constant).
+- `agent count` — refreshed every 5s from the daemon's `agents.list` RPC (cheap, idempotent).
+- `PID` — refreshed when agent-count poll runs (in case the daemon restarted under us).
+
+Agent-count polling lives in a single `useEffect` with a 5s interval; on daemon error, the footer renders `agents:?` and the operator can `:status` to investigate.
+
+## Migration of existing features
+
+Every feature in `packages/cli/src/attach.ts` needs a destination in the new TUI. Inventory:
+
+| Feature                                       | New home                                                                              |
+| --------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `readline` history (per-attach)               | ink + `useState` array; persisted to `.murmuration/repl-history-<name>` as today      |
+| Tab completion                                | Custom `useTabCompletion` hook driven by command list + agent list                    |
+| Leader-key chords                             | Top-level `<App>` `useInput` handler                                                  |
+| `:command` syntax                             | `parseInput()` returns either `{kind:"command",name,args}` or `{kind:"message",text}` |
+| Multi-line input                              | `Shift+Enter` inserts `\n`; `Enter` submits                                           |
+| Spirit-thinking spinner                       | `<ThinkingIndicator>` rendered conditionally in input zone                            |
+| `:edit role` / `:edit soul` / `:edit harness` | `useEditorEscape` hook that suspends ink, runs `$EDITOR`, resumes                     |
+| Confirm prompts (e.g. `:reset memory`)        | `<ConfirmModal>` overlay component                                                    |
+| `Ctrl+D` to detach                            | Top-level `useInput`                                                                  |
+| Stop spinner / cancel turn                    | `Ctrl+C` cancels the in-flight subprocess (existing `AbortController` path)           |
+
+## Implementation plan
+
+Single PR is the target per the scope decision, but staged commits for reviewability:
+
+1. **Commit 1 — Library + skeleton.** Add `ink`, `ink-text-input`, `ink-spinner` (or similar) to `packages/cli` deps. Create `packages/cli/src/attach/` directory with `<AttachApp>`, `<Scrollback>`, `<InputArea>`, `<Footer>` stubs. Wire `bin.ts attach` to render the new App in place of `runAttach`. No features yet — Spirit + commands TODO.
+2. **Commit 2 — Spirit integration.** Port `SpiritSession` lifecycle into the new App. Render turns into scrollback. Submit input → Spirit subprocess → append response turn.
+3. **Commit 3 — Command parser + `:commands`.** Add `parseInput`, port every `:command` from `attach.ts`. Render output as system turns.
+4. **Commit 4 — Command palette.** Add `<CommandPalette>` modal. Fuzzy filter, arrow-nav, run-on-Enter.
+5. **Commit 5 — Subprocess log routing.** Extend `BaseSubprocessClient` with `logSink` config. Default stays stderr (daemon). Spirit attach passes file sink.
+6. **Commit 6 — Footer refresh + identity.** Wire the daemon poll. Add `<HelpModal>` on `?`. Polish whitespace.
+7. **Commit 7 — Remove old `attach.ts`.** Delete `runAttach`, `runUnattachedRepl` (or keep `runUnattachedRepl` for the `murmuration` no-args case if it still has a purpose).
+8. **Commit 8 — CHANGELOG + README.** v0.8.1 release notes.
+
+## Risks
+
+- **ink + Node version compatibility.** Ink targets modern Node (≥18). Repo currently runs Node 20+ (per CI matrix). Should be fine.
+- **Terminal capability quirks.** Some terminals (Windows Terminal old versions, tmux in pre-2.5 era) render ink oddly. Mitigation: test in iTerm2, Terminal.app, vanilla zsh, tmux 3.x before merging.
+- **Editor escape lifecycle.** Ink and child-process editors (`$EDITOR vi`) coexist via `ink.suspend()` but it's fiddly. Test `:edit role` carefully.
+- **Scrollback memory growth.** Long sessions accumulate turns in state. Cap at 1000 turns with a "(scrollback truncated)" marker.
+
+## Open questions for follow-up
+
+- Should `/` palette include agent-specific commands (e.g. `/wake <agent>`) that aren't currently in `:command`? Probably yes — palette is the right place to expose verbs that don't have terse aliases.
+- Should the footer show daemon health (last heartbeat age, in-flight wakes)? Useful but adds polling. Defer to v0.8.2 unless it's trivial.
+- Mouse-click on a scrollback turn — open the digest file? Out of scope for v0.8.1.
+
+---
+
+_Source approved decisions on 2026-05-19. Implementation can begin immediately after v0.8.0 tag lands (which happens in the same release cycle as this design doc)._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## Summary

The v0.8.0 tag was cut at 16:34Z today, then deleted from origin ~30 min later after a multi-agent code review (architecture / security / TypeScript / quality) surfaced 16 findings — 4 P0, 4 P1, 8 P2 — that we'd rather fold into v0.8.0 than ship as patch releases.

This PR reverts the release artifacts only:

- Package versions: \`0.8.0\` → \`0.7.2\` across root + 8 workspace packages.
- CHANGELOG \`## [0.8.0] - 2026-05-19\` heading → \`## [Unreleased]\`. The release notes content stays as-is and will be re-dated when fixes land and a fresh tag is cut.
- Adds \`docs/plans/v0.8.1-attach-tui-redesign.md\` (the REPL TUI design doc filed during the walk-back conversation; out of scope for the v0.8.0 release, tracked separately for v0.8.1).

Code changes shipped during the original v0.8.0 cycle (PRs #367, #368, #369, #370, #371, #372, #373, #374, #375, #377, #378, #382, #383) stay on main. They were merged via squash PRs and were never tied to the tag itself.

## Review findings to be addressed before re-tag

**P0 (security mediums + type keystone):**
1. \`murmuration list\` terminal-injection via attacker-controlled \`--root\` value in \`ps\` output.
2. Spirit \`safePath\` doesn't resolve symlinks before the prefix check.
3. Spirit \`safePath\` regex is case-sensitive on macOS APFS (case-insensitive by default).
4. \`RequiredOutput.kind\` discriminated union widened to bare \`string\` in 3 of 4 declaration sites — propagated by the OR-semantics fix in #382.

**P1:**
5. boot.ts at 2,264 lines; incomplete-agent block + 6 \`process.exit()\` calls violate Engineering Standards #6 and #8.
6. \`path\` vs \`paths\` exclusive in docs but coexist in the type; collapse to \`paths\`-only.
7. \`ps\` parsing fragile under BSD/Linux variants.
8. Inline URL regex in \`validateBehavior\` duplicates \`buildGithubIssueUrlMatcher\`.

**P2:** comment hygiene (~12 sites), residual S3 vocabulary in core docstrings, dead \`actionItems\` field on \`ExecutionContract\`, \`isOutputSatisfied\` default-true, \`renderContractForPrompt\` always-emits side effects, \`list[0]!\` non-null assertion, test brittleness on \`findIncompleteAgents\` order, \`legacy-fallback\` event not on \`WakeValidationResult\`.

TUI rebuild stays in v0.8.1.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors (26 grandfathered warnings)
- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run test\` — 1257 passed (same count as immediately pre-tag)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)