### PR TITLE
fix(security): harden safePath against symlinks + case-fold, scrub orphan ps output

### DIFF
--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -24,6 +24,12 @@ type SessionRegistry = Record<string, SessionEntry>;
 const REGISTRY_DIR = join(homedir(), ".murmuration");
 const REGISTRY_PATH = join(REGISTRY_DIR, "sessions.json");
 
+// Anything outside printable ASCII + Unicode letters is a red flag in a
+// filesystem path read from another process's command line. The check is
+// intentionally narrow — controls, ESC, CR, LF, BEL, BS, and so on.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/;
+
 const loadRegistry = (): SessionRegistry => {
   if (!existsSync(REGISTRY_PATH)) return {};
   try {
@@ -141,30 +147,51 @@ export const listSessions = async (): Promise<void> => {
  * processes whose root isn't in `knownRoots`. Used to surface orphan
  * daemons in `murmuration list`. Best-effort — returns an empty list
  * if `ps` is unavailable or its output can't be parsed.
+ *
+ * Captured `--root` values are read from another process's command
+ * line, which any local user can populate with arbitrary bytes —
+ * including ANSI escape sequences that would inject controls into the
+ * operator's terminal when the row is printed. We reject any captured
+ * root that contains control characters and prefer `args=` (POSIX)
+ * over `command=` (BSD-only) when both are available.
  */
 const findOrphanDaemons = async (
   knownRoots: readonly string[],
 ): Promise<readonly { readonly pid: number; readonly root: string }[]> => {
   const { spawnSync } = await import("node:child_process");
-  // `ps -A -o pid=,command=` works on macOS and Linux. The `=` suffix
-  // suppresses headers so we don't have to skip a first line.
-  const result = spawnSync("ps", ["-A", "-o", "pid=,command="], { encoding: "utf8" });
+  // POSIX-portable selector. Some non-GNU `ps` implementations reject the
+  // `=`-suffix shorthand; we fall back to plain header output if needed.
+  const psArgs = ["-A", "-o", "pid=,args="];
+  let result = spawnSync("ps", psArgs, { encoding: "utf8" });
+  if (result.status !== 0) {
+    result = spawnSync("ps", ["-A", "-o", "pid,args"], { encoding: "utf8" });
+  }
   if (result.status !== 0) return [];
-  const stdout = typeof result.stdout === "string" ? result.stdout : "";
-  if (stdout.length === 0) return [];
+  const stdoutRaw = typeof result.stdout === "string" ? result.stdout : "";
+  if (stdoutRaw.length === 0) return [];
+
   const myPid = process.pid;
   const known = new Set(knownRoots.map((r) => resolve(r)));
   const orphans: { pid: number; root: string }[] = [];
-  for (const line of stdout.split("\n")) {
+  // First line of the fallback (`-o pid,args` without `=`) is the header.
+  // The `=`-suffix form has no header. Defensively treat any line whose
+  // first token isn't a digit as a header and skip it.
+  for (const line of stdoutRaw.split("\n")) {
     const m = /^\s*(\d+)\s+(.+)$/.exec(line);
     if (m === null) continue;
-    const pid = Number(m[1]);
+    const pidStr = m[1] ?? "";
     const cmd = m[2] ?? "";
+    const pid = Number(pidStr);
     if (Number.isNaN(pid) || pid === myPid) continue;
     if (!/\bmurmuration\b.*\bstart\b/.test(cmd)) continue;
     const rootMatch = /--root\s+(\S+)/.exec(cmd);
     if (rootMatch === null) continue;
-    const root = resolve(rootMatch[1] ?? "");
+    const captured = rootMatch[1];
+    if (captured === undefined || captured.length === 0) continue;
+    // Reject anything with control bytes (ANSI escape, CR, LF, etc.) so a
+    // malicious process can't terminal-inject via its --root argv.
+    if (CONTROL_CHAR_RE.test(captured)) continue;
+    const root = resolve(captured);
     if (known.has(root)) continue;
     orphans.push({ pid, root });
   }

--- a/packages/cli/src/spirit/tools.test.ts
+++ b/packages/cli/src/spirit/tools.test.ts
@@ -3,7 +3,7 @@
  * LLM: path-safety enforcement and skill loading.
  */
 
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -160,6 +160,44 @@ describe("Spirit tools — write_file (trusted-surface protection)", () => {
     const tool = getTool("read_file");
     const result = await tool.execute({ path: "agents/alpha/role.md" });
     expect(result).toBe("# original role\n");
+  });
+
+  it("refuses uppercase variants of protected paths (case-fold protection)", async () => {
+    const tool = getTool("write_file");
+    // macOS APFS is case-insensitive by default — Role.md and role.md are
+    // the same file. The guard must catch case-shifted variants.
+    const result = await tool.execute({
+      path: "agents/alpha/Role.md",
+      content: "# rewritten\n",
+    });
+    expect(result).toMatch(/operator config/);
+  });
+
+  it("refuses writes whose target is a symlink to a protected path", async () => {
+    // An attacker-controlled symlink `drafts/x.md → ../agents/alpha/role.md`
+    // must not bypass the regex check on the literal write path.
+    mkdirSync(join(root, "drafts"), { recursive: true });
+    symlinkSync(join(root, "agents", "alpha", "role.md"), join(root, "drafts", "trojan.md"));
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "drafts/trojan.md",
+      content: "# pwn\n",
+    });
+    expect(result).toMatch(/operator config/);
+  });
+
+  it("refuses writes whose containing directory is a symlink to a sibling agent", async () => {
+    // An attacker creates `agents/squatter → agents/alpha`, then writes
+    // to `agents/squatter/role.md`. The realpath resolution must catch
+    // this by walking the symlinked parent.
+    mkdirSync(join(root, "agents"), { recursive: true });
+    symlinkSync(join(root, "agents", "alpha"), join(root, "agents", "squatter"));
+    const tool = getTool("write_file");
+    const result = await tool.execute({
+      path: "agents/squatter/role.md",
+      content: "# stolen\n",
+    });
+    expect(result).toMatch(/operator config/);
   });
 });
 

--- a/packages/cli/src/spirit/tools.ts
+++ b/packages/cli/src/spirit/tools.ts
@@ -12,6 +12,7 @@
  * anyway. JSON is stringified; filesystem reads return raw bytes.
  */
 
+import { existsSync, realpathSync } from "node:fs";
 import { readFile, readdir, stat, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve, relative, basename, dirname } from "node:path";
 
@@ -79,52 +80,92 @@ class PathSafetyError extends Error {
  * `.env*` file in either direction. For writes, additionally refuses
  * anything under `.murmuration/` — that subtree is daemon-authored
  * runtime state; Spirit may read it but never write into it.
+ *
+ * Symlink resolution: every path comparison runs against the realpath
+ * of both `rootDir` and the target. An agent that creates a symlink
+ * `agents/foo/role.md → /etc/something` (or to a sibling agent's
+ * `role.md`) cannot use it to escape the root or reach a blocked path.
+ * When the target itself does not exist (the typical case for writes
+ * about to create a new file) the parent directory is realpath-resolved
+ * and the basename re-joined, so a symlinked containing directory is
+ * still caught.
+ *
+ * Case folding: the trusted-surface regex matches case-insensitively.
+ * macOS APFS is case-insensitive by default — `agents/foo/Role.md` and
+ * `agents/foo/role.md` write the same inode, and the guard must catch
+ * both. On case-sensitive filesystems this is mildly over-protective
+ * but never wrong.
  */
 const safePath = (rootDir: string, path: string, mode: "read" | "write" = "read"): string => {
-  const abs = resolve(rootDir, path);
-  const rel = relative(rootDir, abs);
+  const realRoot = realpathOrLexical(rootDir);
+  const lexicalAbs = resolve(rootDir, path);
+  const realAbs = realpathOfTargetOrParent(lexicalAbs);
+  const rel = relative(realRoot, realAbs);
   if (rel.startsWith("..") || rel === "..") {
     throw new PathSafetyError(`path "${path}" escapes the murmuration root`);
   }
-  const base = basename(abs);
+  const base = basename(realAbs);
   for (const pattern of BLOCKED_BASENAME_PATTERNS) {
     if (pattern.test(base)) {
       throw new PathSafetyError(`access to "${path}" is not allowed (contains secrets)`);
     }
   }
   if (mode === "write") {
-    // Use platform-correct separator handling: relative() on POSIX returns
-    // forward slashes; the leading-segment check works either way.
-    if (
-      rel === ".murmuration" ||
-      rel.startsWith(".murmuration/") ||
-      rel.startsWith(".murmuration\\")
-    ) {
+    const relPosixLower = rel.replace(/\\/g, "/").toLowerCase();
+    if (relPosixLower === ".murmuration" || relPosixLower.startsWith(".murmuration/")) {
       throw new PathSafetyError(
         `writing under ".murmuration/" is not allowed — that subtree is daemon-authored runtime state`,
       );
     }
-
-    // Operator config files carry identity + governance authority and are
-    // rendered into agent prompts as `trusted` segments. Letting an agent
-    // rewrite its own role.md / soul.md / harness.yaml would let it edit
-    // `done_when`, clear `approval_required_for`, or inject prompts via
-    // any frontmatter field. Block writes to those paths.
-    //
-    // Normalize separators once so the regex catches Windows and POSIX paths.
-    const relPosix = rel.replace(/\\/g, "/");
     if (
-      /^agents\/[^/]+\/role\.md$/.test(relPosix) ||
-      /^agents\/[^/]+\/soul\.md$/.test(relPosix) ||
-      relPosix === "murmuration/soul.md" ||
-      relPosix === "harness.yaml"
+      /^agents\/[^/]+\/role\.md$/.test(relPosixLower) ||
+      /^agents\/[^/]+\/soul\.md$/.test(relPosixLower) ||
+      relPosixLower === "murmuration/soul.md" ||
+      relPosixLower === "harness.yaml"
     ) {
       throw new PathSafetyError(
         `writing operator config "${path}" is not allowed — role.md, soul.md, and harness.yaml are the trusted identity surface`,
       );
     }
   }
-  return abs;
+  return realAbs;
+};
+
+/** Realpath the given path, falling back to lexical resolution on error. */
+const realpathOrLexical = (p: string): string => {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+};
+
+/**
+ * Realpath `target` if it exists; otherwise walk up until we find an
+ * existing ancestor, realpath that, and re-join the trailing path.
+ *
+ * Required for two cases:
+ *   1. Write to a path whose leaf does not exist yet (we still need to
+ *      realpath the containing directory to catch a symlinked parent).
+ *   2. Platforms where the root itself is a symlink (e.g. macOS `/tmp`
+ *      → `/private/tmp`). Without ancestor-walking, `realpath(rootDir)`
+ *      and the lexical `resolve()` of a non-existent target disagree
+ *      and `relative()` reports a false escape.
+ */
+const realpathOfTargetOrParent = (target: string): string => {
+  if (existsSync(target)) {
+    return realpathOrLexical(target);
+  }
+  let current = dirname(target);
+  let tail = basename(target);
+  while (current !== dirname(current)) {
+    if (existsSync(current)) {
+      return join(realpathOrLexical(current), tail);
+    }
+    tail = join(basename(current), tail);
+    current = dirname(current);
+  }
+  return target;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three P0 findings from the v0.8.0 multi-agent security review. Walked back the v0.8.0 tag (#384) to land these before re-tagging.

### P0.1 — `findOrphanDaemons` terminal-injection

\`murmuration list\` parsed \`--root <value>\` from another process's command line and echoed it unsanitized. Any local user could spawn \`sleep 1d --root $'\\e[2J\\e[H...'\` to spray ANSI controls into the operator's terminal. Now: reject captured roots containing control bytes; switched from BSD-only \`command=\` to POSIX \`args=\` with fallback.

### P0.2 — Spirit `safePath` symlink escape

The guard did lexical resolve only. An agent could pre-create \`agents/foo/role.md → /etc/something\` or \`drafts/x.md → ../agents/me/role.md\` and Spirit would follow the link despite the basename never matching the regex. Now: realpath both rootDir and target before checks. When the leaf doesn't exist yet (write case), walk up to the closest existing ancestor, realpath it, re-join the trailing path. Required both for new-file writes and to handle platforms where the root itself is a symlink (macOS \`/tmp → /private/tmp\`).

### P0.3 — Spirit `safePath` case sensitivity

The trusted-surface regex was case-sensitive. macOS APFS is case-insensitive by default — \`agents/foo/Role.md\` writes the same inode as \`role.md\` but bypassed the guard. Now: lowercase the relative path before comparison.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors (26 grandfathered warnings)
- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run test\` — 1260 passed (3 new tests covering case-fold, symlinked write target, symlinked containing directory)
- [ ] CI green

Closes the P0 row of the v0.8.0 review findings. Next PRs in sequence: type-tightening (`RequiredOutput` + `paths` collapse), boot extract, cleanup sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)