### PR TITLE
fix(types): extract RequiredOutput, collapse path→paths, exhaustive switch

### DIFF
--- a/packages/core/src/daemon/runs.test.ts
+++ b/packages/core/src/daemon/runs.test.ts
@@ -414,8 +414,12 @@ describe("RunArtifactWriter", () => {
         directivesUnaddressed: [],
         obligationStatus: "unmet",
         unmetRequiredOutputs: [
-          { kind: "committed-artifact", path: "drafts/**/*.md" },
-          { kind: "comment" },
+          {
+            kind: "committed-artifact",
+            paths: ["drafts/**/*.md"],
+            description: "test",
+          },
+          { kind: "comment", description: "test" },
         ],
         reason: "contract obligation unmet: 2 required output(s) without matching evidence",
       });
@@ -441,7 +445,7 @@ describe("RunArtifactWriter", () => {
         actionItemsAssigned: 0,
         directivesUnaddressed: [{ issueNumber: 1, reason: "narrative-only-claim" }],
         obligationStatus: "unmet",
-        unmetRequiredOutputs: [{ kind: "committed-artifact" }],
+        unmetRequiredOutputs: [{ kind: "committed-artifact", description: "test" }],
       });
 
       const entry = JSON.parse(

--- a/packages/core/src/execution/execution.test.ts
+++ b/packages/core/src/execution/execution.test.ts
@@ -796,6 +796,9 @@ describe("validateWake", () => {
     maxCostMicros: 0,
   };
 
+  // `path` is a test-helper convenience that maps to `paths: [path]` so
+  // existing single-path test inputs stay terse. The contract type itself
+  // only carries `paths`.
   const mkContract = (
     requiredOutputs: readonly {
       readonly kind:
@@ -814,12 +817,14 @@ describe("validateWake", () => {
     wakeReason: { kind: "scheduled" as const, cronExpression: "0 9 * * *" },
     wakeMode: "individual" as const,
     objective: "test objective",
-    requiredOutputs: requiredOutputs.map((r) => ({
-      kind: r.kind,
-      ...(r.path !== undefined ? { path: r.path } : {}),
-      ...(r.paths !== undefined ? { paths: r.paths } : {}),
-      description: r.description ?? "test required output",
-    })),
+    requiredOutputs: requiredOutputs.map((r) => {
+      const paths = r.paths ?? (r.path !== undefined ? [r.path] : undefined);
+      return {
+        kind: r.kind,
+        ...(paths !== undefined ? { paths } : {}),
+        description: r.description ?? "test required output",
+      };
+    }),
     actionItems: [],
     completionConditions: [],
     verification: [],
@@ -878,9 +883,9 @@ describe("validateWake", () => {
     expect(v.obligationStatus).toBe("unmet");
     expect(v.productive).toBe(false);
     expect(v.unmetRequiredOutputs).toHaveLength(1);
-    expect(v.unmetRequiredOutputs?.[0]).toEqual({
+    expect(v.unmetRequiredOutputs?.[0]).toMatchObject({
       kind: "committed-artifact",
-      path: "drafts/**/*.md",
+      paths: ["drafts/**/*.md"],
     });
     expect(v.reason).toContain("contract obligation unmet");
   });
@@ -1047,29 +1052,6 @@ describe("validateWake", () => {
       kind: "committed-artifact",
       paths: ["drafts/**/*.md", "docs/research/**/*.md", "pipeline/**/*.md"],
     });
-  });
-
-  it("paths wins over path when both are set on an obligation", () => {
-    const contract = mkContract([
-      {
-        kind: "committed-artifact",
-        path: "drafts/**/*.md",
-        paths: ["docs/research/**/*.md"],
-      },
-    ]);
-    // Receipt matches `paths[0]` but NOT `path` — should still satisfy (paths wins).
-    const receipts = [
-      {
-        action: {
-          kind: "commit-file" as const,
-          filePath: "docs/research/foo.md",
-          fileContent: "x",
-        },
-        success: true,
-      },
-    ];
-    const v = validateWake({ ...mkCtx(), contract }, emptyResult, receipts);
-    expect(v.obligationStatus).toBe("satisfied");
   });
 
   it("runtime-artifact required output is always satisfied (digest writer runs on completion)", () => {

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -1,6 +1,6 @@
 import type { WakeCostRecord } from "../cost/record.js";
 import { SOURCE_DIRECTIVE_LABEL, buildAgentRoutingLabels } from "../labels/index.js";
-import type { ExecutionContract } from "../runtime/execution-contract.js";
+import type { ExecutionContract, RequiredOutput } from "../runtime/execution-contract.js";
 
 /**
  * Agent execution — the pluggable boundary between the harness daemon and
@@ -752,11 +752,7 @@ export interface WakeValidationResult {
    * The specific `requiredOutputs` from the contract that have no matching
    * successful evidence. Populated only when `obligationStatus` is `"unmet"`.
    */
-  readonly unmetRequiredOutputs?: readonly {
-    readonly kind: string;
-    readonly path?: string;
-    readonly paths?: readonly string[];
-  }[];
+  readonly unmetRequiredOutputs?: readonly RequiredOutput[];
   /**
    * Behavior warnings from `validateBehavior`. Each warning describes a
    * narrative claim in `wakeSummary` that lacks structured evidence
@@ -884,17 +880,13 @@ const pathMatchesGlob = (actual: string, glob: string): boolean => {
  *
  * The mapping from `RequiredOutput.kind` to evidence is intentionally lax:
  * any successful receipt of the matching action kind satisfies the
- * obligation, plus path-glob checks where a `path` is declared. The
+ * obligation, plus path-glob OR-match for path-bearing kinds. The
  * contract narrative remains the agent's authoritative guide on _what_ to
  * produce; the validator's job is to refuse "I claim I did it" wakes that
  * have no structured evidence at all.
  */
 const isOutputSatisfied = (
-  req: {
-    readonly kind: string;
-    readonly path?: string;
-    readonly paths?: readonly string[];
-  },
+  req: RequiredOutput,
   result: {
     readonly actions: readonly WakeAction[];
     readonly outputs: readonly AgentOutputArtifact[];
@@ -916,16 +908,9 @@ const isOutputSatisfied = (
       return true;
     case "committed-artifact":
     case "commit": {
-      // Build the set of acceptable globs. `paths` (OR semantics) wins over
-      // `path` (single glob) when both are set. An obligation with neither
-      // matches any commit-file receipt or any blob URL — a "did the agent
-      // commit anything" check.
-      const globs: readonly string[] | undefined =
-        req.paths !== undefined && req.paths.length > 0
-          ? req.paths
-          : req.path !== undefined
-            ? [req.path]
-            : undefined;
+      // An obligation with no `paths` matches any commit-file receipt or
+      // any blob URL — the "did the agent commit anything" case.
+      const globs = req.paths !== undefined && req.paths.length > 0 ? req.paths : undefined;
 
       const receiptHit = receipts.some((r) => {
         if (!r.success || r.action.kind !== "commit-file") return false;
@@ -959,10 +944,15 @@ const isOutputSatisfied = (
       return successfulReceiptOfKind("create-issue");
     case "governance-event":
       return result.governanceEvents.length > 0;
-    default:
-      // Unknown kinds default to "satisfied" — forward-compat with future
-      // contract extensions. The validator is a safety net, not a gatekeeper.
-      return true;
+    default: {
+      // Exhaustiveness check: if `RequiredOutputKind` grows a new member
+      // without a matching case branch, this assignment fails to compile.
+      // The validator is the load-bearing gate for obligation-status, so
+      // a new kind must be handled deliberately rather than defaulting.
+      const _exhaustive: never = req.kind;
+      void _exhaustive;
+      return false;
+    }
   }
 };
 
@@ -1225,9 +1215,7 @@ export const validateWake = (
   }
 
   let obligationStatus: "satisfied" | "unmet" | "not-applicable" | undefined;
-  let unmetRequiredOutputs:
-    | { readonly kind: string; readonly path?: string; readonly paths?: readonly string[] }[]
-    | undefined;
+  let unmetRequiredOutputs: readonly RequiredOutput[] | undefined;
   if (context.contract !== undefined) {
     if (context.contract.requiredOutputs.length === 0) {
       obligationStatus = "not-applicable";
@@ -1239,11 +1227,7 @@ export const validateWake = (
         obligationStatus = "satisfied";
       } else {
         obligationStatus = "unmet";
-        unmetRequiredOutputs = unmet.map((req) => ({
-          kind: req.kind,
-          ...(req.path !== undefined ? { path: req.path } : {}),
-          ...(req.paths !== undefined ? { paths: req.paths } : {}),
-        }));
+        unmetRequiredOutputs = unmet;
       }
     }
   }

--- a/packages/core/src/runtime/execution-contract.test.ts
+++ b/packages/core/src/runtime/execution-contract.test.ts
@@ -94,8 +94,9 @@ describe("assembleExecutionContract", () => {
     });
 
     expect(contract.objective).toBe("Commit at least one research artifact under drafts/");
-    // Multi-path committed_artifacts folds into ONE obligation with `paths`;
-    // single-entry runtime_artifacts stays as a single-path obligation.
+    // Every path-bearing obligation uses the same `paths` shape — single-path
+    // declarations carry `paths.length === 1`, multi-path declarations OR-fold
+    // into one obligation whose `paths` is the full list.
     expect(contract.requiredOutputs).toHaveLength(2);
     expect(contract.requiredOutputs[0]).toMatchObject({
       kind: "committed-artifact",
@@ -103,7 +104,7 @@ describe("assembleExecutionContract", () => {
     });
     expect(contract.requiredOutputs[1]).toMatchObject({
       kind: "runtime-artifact",
-      path: ".murmuration/runs/**/*.md",
+      paths: [".murmuration/runs/**/*.md"],
     });
     expect(contract.completionConditions).toHaveLength(2);
     expect(contract.completionConditions[0]?.id).toBe("done-when-0");

--- a/packages/core/src/runtime/execution-contract.ts
+++ b/packages/core/src/runtime/execution-contract.ts
@@ -57,6 +57,38 @@ export interface VerificationStep {
   readonly required: boolean;
 }
 
+/**
+ * The closed set of obligation kinds the validator recognizes. The literal
+ * union is load-bearing — every consumer of {@link RequiredOutput} switches
+ * on this field, and `default: never` exhaustiveness checks catch new kinds
+ * at compile time.
+ */
+export type RequiredOutputKind =
+  | "summary"
+  | "runtime-artifact"
+  | "committed-artifact"
+  | "comment"
+  | "issue"
+  | "commit"
+  | "governance-event";
+
+/**
+ * One obligation an agent must satisfy this wake.
+ *
+ * `paths` is OR semantics: any one matching glob satisfies the obligation.
+ * The assembler folds a multi-entry `committed_artifacts:` list into a
+ * single `RequiredOutput` whose `paths` array carries every declared glob;
+ * a single-entry declaration is the same shape with `paths.length === 1`.
+ *
+ * `paths` is omitted entirely for non-path obligation kinds
+ * (`summary`, `comment`, `issue`, `governance-event`).
+ */
+export interface RequiredOutput {
+  readonly kind: RequiredOutputKind;
+  readonly paths?: readonly string[];
+  readonly description: string;
+}
+
 // ---------------------------------------------------------------------------
 // ExecutionContract
 // ---------------------------------------------------------------------------
@@ -74,29 +106,8 @@ export interface ExecutionContract {
   // Injected as a `trusted` prompt segment at spawn time.
   // Checked by WakeValidator POST-WAKE against actuals (Phase 4).
 
-  /**
-   * Artifacts the agent must produce to satisfy the contract.
-   *
-   * Each obligation accepts either a single `path` glob OR a list of `paths`.
-   * When `paths` is set, any one of the listed globs satisfies the obligation
-   * (OR semantics) — this is how the assembler folds a multi-entry
-   * `committed_artifacts:` list into a single obligation. `path` and `paths`
-   * are exclusive; a caller setting both is using the older (single-path)
-   * shape and `paths` is ignored.
-   */
-  readonly requiredOutputs: readonly {
-    readonly kind:
-      | "summary"
-      | "runtime-artifact"
-      | "committed-artifact"
-      | "comment"
-      | "issue"
-      | "commit"
-      | "governance-event";
-    readonly path?: string;
-    readonly paths?: readonly string[];
-    readonly description: string;
-  }[];
+  /** Artifacts the agent must produce to satisfy the contract. */
+  readonly requiredOutputs: readonly RequiredOutput[];
   /** Action items from the signal bundle mapped into the contract. */
   readonly actionItems: readonly ActionItemRef[];
   /** Testable completion conditions (Phase 4 validator checks these). */
@@ -228,41 +239,25 @@ export const assembleExecutionContract = (
 ): ExecutionContract => {
   const declaration = args.declaration;
 
-  // Fold a multi-entry path list into ONE obligation with OR semantics
-  // across the listed globs. A single-entry list becomes a single-path
-  // obligation (no `paths` field) for backwards-compatible output shape.
-  const foldPaths = <K extends "committed-artifact" | "runtime-artifact">(
-    kind: K,
+  // Multi-path declarations fold into ONE obligation whose `paths` carries
+  // every declared glob — the validator OR-matches across them. Single-path
+  // declarations are the same shape with `paths.length === 1`.
+  const buildPathObligation = (
+    kind: "committed-artifact" | "runtime-artifact",
     list: readonly string[],
-    describe: (p: string) => string,
-    describeMany: (n: number) => string,
-  ): readonly {
-    kind: K;
-    path?: string;
-    paths?: readonly string[];
-    description: string;
-  }[] => {
+  ): readonly RequiredOutput[] => {
     if (list.length === 0) return [];
-    if (list.length === 1) {
-      const path = list[0]!;
-      return [{ kind, path, description: describe(path) }];
-    }
-    return [{ kind, paths: list, description: describeMany(list.length) }];
+    const description =
+      list.length === 1
+        ? `${kind === "committed-artifact" ? "Committed" : "Runtime"} artifact matching: ${list[0] ?? ""}`
+        : `${kind === "committed-artifact" ? "Committed" : "Runtime"} artifact matching any of ${String(list.length)} declared paths`;
+    return [{ kind, paths: list, description }];
   };
 
-  const committedOutputs = foldPaths(
-    "committed-artifact",
-    declaration?.committed_artifacts ?? [],
-    (p) => `Committed artifact matching: ${p}`,
-    (n) => `Committed artifact matching any of ${String(n)} declared paths`,
-  );
-  const runtimeOutputs = foldPaths(
-    "runtime-artifact",
-    declaration?.runtime_artifacts ?? [],
-    (p) => `Runtime artifact matching: ${p}`,
-    (n) => `Runtime artifact matching any of ${String(n)} declared paths`,
-  );
-  const requiredOutputs = [...committedOutputs, ...runtimeOutputs];
+  const requiredOutputs: readonly RequiredOutput[] = [
+    ...buildPathObligation("committed-artifact", declaration?.committed_artifacts ?? []),
+    ...buildPathObligation("runtime-artifact", declaration?.runtime_artifacts ?? []),
+  ];
 
   const actionItems = args.signals.actionItems.map(toActionItemRef);
 
@@ -389,9 +384,10 @@ export const renderContractForPrompt = (contract: ExecutionContract): string => 
     for (const out of contract.requiredOutputs) {
       let pathPart = "";
       if (out.paths !== undefined && out.paths.length > 0) {
-        pathPart = ` (any of: ${out.paths.map((p) => `\`${p}\``).join(", ")})`;
-      } else if (out.path !== undefined) {
-        pathPart = ` \`${out.path}\``;
+        pathPart =
+          out.paths.length === 1
+            ? ` \`${out.paths[0] ?? ""}\``
+            : ` (any of: ${out.paths.map((p) => `\`${p}\``).join(", ")})`;
       }
       lines.push(`- **${out.kind}**${pathPart} — ${out.description}`);
     }


### PR DESCRIPTION
## Summary

Three v0.8.0 review findings, one keystone refactor. Sibling of #385 (security).

### P0.4 — `RequiredOutput.kind` discriminated union widened to `string`

The OR-semantics fix shipped earlier in the v0.8.0 cycle introduced three inline re-declarations of the obligation shape, each with `kind: string` instead of the 7-member literal union. The TS reviewer called this the keystone:

> _Each declaration widens \`kind\` differently. That throws away the discriminated-union narrowing the rest of the codebase relies on. Once \`RequiredOutput\` is a single named exported type, the exhaustive-switch fix falls out for free._

Fix: extract \`RequiredOutputKind\` and \`RequiredOutput\` as named exports in \`runtime/execution-contract.ts\`. Import at every consumer. \`isOutputSatisfied\` now takes \`req: RequiredOutput\`; its default branch is a \`never\` exhaustiveness check.

### P1.2 — `path` and `paths` as exclusive-but-coexisting fields

Previously the shape carried both, with a runtime tie-breaker documented one way and implemented the other (jsdoc said "path wins"; code said "paths wins"; tests locked the code's behaviour). Both reviewers (quality + TS) flagged this.

Fix: collapse to \`paths\` always. Single-path declarations are \`paths.length === 1\`. The prompt renderer special-cases length-1 for terser output (\`\`role.md\`\` instead of \`(any of: \`role.md\`)\`).

### P2.4 — `isOutputSatisfied` default-`true`

Speculative "forward-compat" against the closed Zod kind enum. Replaced with exhaustive \`never\` so a new kind forces a deliberate decision rather than silently satisfying.

## Breaking changes to the public surface

- \`WakeValidationResult.unmetRequiredOutputs\` items now have \`paths: string[]\` instead of \`path?: string\` + \`paths?: string[]\`. Index.jsonl consumers that read this field will need to update. (No v0.8.0 tag was published, so the only consumers are this repo's tests, which are updated in this PR.)

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors (25 grandfathered warnings — one fewer than pre-PR since collapsed-fields path removed one)
- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run test\` — 1256 passed (2 fewer than pre-PR: removed the obsolete "paths wins over path" test + absorbed a single-path assertion as paths-length-1)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)