### PR TITLE
fix(boot): throw typed BootError instead of process.exit (Engineering Standard #6)

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -19,7 +19,7 @@ import { resolve } from "node:path";
 
 import { runAttach, runUnattachedRepl } from "./attach.js";
 import { runBacklog } from "./backlog.js";
-import { bootDaemon } from "./boot.js";
+import { bootDaemon, BootError } from "./boot.js";
 import { runGroupWakeCommand } from "./group-wake.js";
 import { runDirective } from "./directive.js";
 import { runInit } from "./init.js";
@@ -623,6 +623,12 @@ main()
     if (command !== "start" && command !== "attach") process.exit(0);
   })
   .catch((error: unknown) => {
+    // BootError carries its own message + sysexits code. The message
+    // is already operator-formatted (no "fatal:" prefix needed).
+    if (error instanceof BootError) {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(error.exitCode);
+    }
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`murmuration: fatal: ${message}\n`);
     process.exit(1);

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -26,6 +26,30 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+/**
+ * Typed boot-time error. Thrown instead of `process.exit` so the
+ * composition root stays library-like — `bin.ts` is the only place
+ * that turns errors into exit codes (Engineering Standard #6).
+ *
+ * `kind` is a stable discriminator for testing and structured logging.
+ * `exitCode` is the conventional sysexits value the bin entrypoint
+ * should propagate (78 = configuration error per `sysexits.h`).
+ */
+export class BootError extends Error {
+  public readonly kind:
+    | "incomplete-agent-single"
+    | "no-agents-found"
+    | "governance-plugin-invalid"
+    | "secrets-load-failed";
+  public readonly exitCode: number;
+  public constructor(kind: BootError["kind"], message: string, exitCode = 78) {
+    super(message);
+    this.name = "BootError";
+    this.kind = kind;
+    this.exitCode = exitCode;
+  }
+}
+
 import {
   AgentStateStore,
   Daemon,
@@ -877,10 +901,10 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       typeof (candidate as { name?: unknown }).name !== "string" ||
       typeof (candidate as { onEventsEmitted?: unknown }).onEventsEmitted !== "function"
     ) {
-      process.stderr.write(
-        `murmuration: governance module at ${governancePath} must export a GovernancePlugin as default\n`,
+      throw new BootError(
+        "governance-plugin-invalid",
+        `murmuration: governance module at ${governancePath} must export a GovernancePlugin as default`,
       );
-      process.exit(78);
     }
     governancePlugin = candidate as import("@murmurations-ai/core").GovernancePlugin;
     const range = governancePlugin.compatibleCoreVersionRange;
@@ -946,11 +970,11 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     const incompleteAgents = await loader.findIncompleteAgents();
     const incompleteSingle = incompleteAgents.find((i) => i.dir === options.agentDir);
     if (incompleteSingle !== undefined) {
-      process.stderr.write(
+      throw new BootError(
+        "incomplete-agent-single",
         `murmuration: agent "${options.agentDir}" is incomplete — missing ${incompleteSingle.missing.join(", ")}. ` +
-          `Add the missing file before booting this agent.\n`,
+          `Add the missing file before booting this agent.`,
       );
-      process.exit(78);
     }
     agentDirs = [options.agentDir];
   } else if (options.rootDir !== undefined) {
@@ -982,10 +1006,10 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         incompleteAgents.length > 0
           ? ` — ${String(incompleteAgents.length)} directory(s) skipped as incomplete (see warnings above)`
           : "";
-      process.stderr.write(
-        `murmuration: no agents found in ${resolve(exampleRoot, "agents")}/*/ (looking for role.md + soul.md)${hint}\n`,
+      throw new BootError(
+        "no-agents-found",
+        `murmuration: no agents found in ${resolve(exampleRoot, "agents")}/*/ (looking for role.md + soul.md)${hint}`,
       );
-      process.exit(78);
     }
   } else {
     // No --root, no --agent → default hello-world example.
@@ -1170,7 +1194,7 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
           reason: "secrets load failed",
         })}\n`,
       );
-      process.exit(78);
+      throw new BootError("secrets-load-failed", "murmuration: secrets load failed");
     }
     if (provider.has(GITHUB_TOKEN)) {
       // Resolve the target repo once, so the shared githubClient has


### PR DESCRIPTION
## Summary

Architecture review of v0.8.0 flagged \`boot.ts\` as violating Engineering Standard #6 ("only \`bin.ts\` may exit the process"). The v0.8.0 work added three new \`process.exit(78)\` calls in the composition root; this PR converts those and the pre-existing governance-plugin path to a typed \`BootError\`.

### Changes

- New \`BootError\` class in \`boot.ts\`, exported. Discriminated by \`kind\`: \`incomplete-agent-single\`, \`no-agents-found\`, \`governance-plugin-invalid\`, \`secrets-load-failed\`. Carries its own \`exitCode\` (default 78 = sysexits configuration error).
- 4 \`process.exit\` + \`stderr.write\` sites in \`boot.ts\` converted to \`throw new BootError(...)\`.
- \`bin.ts\` catch handler recognizes \`BootError\` and prints \`error.message\` directly (no \`fatal:\` prefix since the message is already operator-formatted), then exits with the carried code.

### Not in scope

The architecture review also called out that \`boot.ts\` is 2,264 lines and the incomplete-agent block (plus other roster-validation logic) should move into a dedicated \`AgentRosterValidator\` class. That's a larger refactor tracked for v0.9.0. This PR closes only the immediate Standard #6 violation that landed during v0.8.0.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors
- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run test\` — 1260 passed (no test changes; behaviour identical for operators)
- [ ] CI green

Sibling of #385 (security) and #386 (type tightening). Next: #387ish (cleanup sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)