### PR TITLE
chore(v0.8.0): cleanup sweep — comment hygiene + dead actionItems + side-effects emit-when-needed

### DIFF
--- a/packages/core/src/daemon/runs.ts
+++ b/packages/core/src/daemon/runs.ts
@@ -41,7 +41,7 @@ import type { WakeCostRecord } from "../cost/record.js";
 import type { AgentResult, WakeValidationResult } from "../execution/index.js";
 
 /**
- * Audit record for subscription-CLI wakes (T-CLI-9 / harness#301).
+ * Audit record for subscription-CLI wakes.
  *
  * Recorded before the subprocess is spawned so the record reflects
  * what was **configured**, not what the subprocess reported. A
@@ -67,7 +67,7 @@ export interface SubscriptionCliAuditContext {
    * restricted by the CLI's own defaults — see ADR-0036).
    */
   readonly allowedTools: readonly string[];
-  /** Always `true` — harness#300 (env allowlist) landed before this field. */
+  /** Always `true` — env allowlist is applied unconditionally. */
   readonly envAllowlistApplied: true;
 }
 
@@ -92,7 +92,7 @@ export interface RunArtifactWriterConfig {
    */
   readonly now?: () => Date;
   /**
-   * Subscription-CLI audit context for T-CLI-9 / harness#301.
+   * Subscription-CLI audit context.
    * When set, every index.jsonl entry written by this writer will
    * include a `subscriptionCli` block. Absent for API-provider agents.
    */
@@ -166,10 +166,8 @@ export interface RunArtifactIndexEntry {
    * `unaddressed-directives` — one or more source-directives were not
    *   backed by structured evidence.
    * `obligation-unmet` — the role.md `contract.requiredOutputs` had at
-   *   least one entry without matching successful evidence (Phase 4 PR 4,
-   *   ADR-0047 §2 obligation sub-contract).
+   *   least one entry without matching successful evidence.
    * `unknown` — validation data unavailable (legacy entry or failed wake).
-   * Near-Term #4 (Proposal 07 Phase 1), extended in Phase 4 PR 5.
    */
   readonly validationStatus?:
     | "productive"
@@ -184,28 +182,24 @@ export interface RunArtifactIndexEntry {
    */
   readonly directivesUnaddressed?: number;
   /**
-   * Contract obligation status (Phase 4 PR 4, ADR-0047 §2).
-   * Absent when no contract was supplied (e.g. roles without a
-   * `contract:` block when the daemon predates Phase 4 wiring).
+   * Contract obligation status. Absent when no contract was supplied
+   * (e.g. roles without a `contract:` block).
    */
   readonly obligationStatus?: "satisfied" | "unmet" | "not-applicable";
   /**
    * Number of `requiredOutputs` from the contract that had no matching
-   * successful evidence (Phase 4 PR 4). Populated only when
-   * `obligationStatus === "unmet"`.
+   * successful evidence. Populated only when `obligationStatus === "unmet"`.
    */
   readonly unmetRequiredOutputsCount?: number;
   /**
-   * Count of behavior warnings emitted by `validateBehavior` (Phase 4
-   * PR 6a, ADR-0047 §2, ADR-0048 §1). Warning-only signal — does NOT
-   * affect `productive` or `successfulWakes`. Dashboards surface this
-   * as a yellow badge so operators can calibrate before v0.8.1 promotes
-   * behavior validation to hard-fail.
+   * Count of behavior warnings emitted by `validateBehavior`. Advisory
+   * signal — does NOT affect `productive` or `successfulWakes`.
+   * Dashboards surface this as a yellow badge for operator review.
    */
   readonly behaviorWarningCount?: number;
   /**
-   * Subscription-CLI audit context (T-CLI-9 / harness#301).
-   * Present on all subscription-CLI wakes; absent for API-provider wakes.
+   * Subscription-CLI audit context. Present on all subscription-CLI
+   * wakes; absent for API-provider wakes.
    */
   readonly subscriptionCli?: SubscriptionCliAuditContext;
 }
@@ -227,7 +221,7 @@ export class RunArtifactWriter {
    * loop is never blocked by a failed write.
    *
    * `validation` is optional so test fixtures and legacy callers
-   * continue to work; production daemon wakes always pass it (Phase 4 PR 5).
+   * continue to work; production daemon wakes always pass it.
    */
   public async record(
     result: AgentResult,

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -460,11 +460,11 @@ export const roleFrontmatterSchema = z.object({
   // EFFECTIVENESS reflection without machine-checked done conditions.
   accountabilities: accountabilitiesSchema,
 
-  // ADR-0047: execution contract declaration (Phase 4 PR 1). Optional —
-  // roles without a `contract:` block fall back to the synthesized
-  // minimal default at spawn time (ADR-0047 §4 fallback). Unknown keys
-  // are rejected via `.strict()` so typos in `done_when` / etc. surface
-  // at boot rather than silently degrading validation.
+  // Execution contract declaration (ADR-0047). Optional — roles without
+  // a `contract:` block fall back to the synthesized minimal default at
+  // spawn time. Unknown keys are rejected via `.strict()` so typos in
+  // `done_when` / etc. surface at boot rather than silently degrading
+  // validation.
   contract: contractDeclarationSchema.optional(),
 });
 

--- a/packages/core/src/runtime/execution-contract.test.ts
+++ b/packages/core/src/runtime/execution-contract.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  *   - Missing-declaration path: contract still assembles from runtime context
  *   - Full declaration: every contract field maps through
- *   - actionItems mapping from SignalBundle to ActionItemRef (with/without sourceRef)
+ *   - requiredOutputs mapping from committed/runtime artifacts
  *   - allowedSideEffects derived from githubWriteScopes (read-only vs read+write)
  *   - objective synthesis precedence: done_when[0] > wakeReason
  *   - approval policy switches on `approval_required_for`
@@ -17,8 +17,8 @@ import {
   contractDeclarationSchema,
   renderContractForPrompt,
 } from "./execution-contract.js";
-import type { Signal, SignalBundle } from "../execution/index.js";
-import { makeAgentId, makeWakeId } from "../execution/index.js";
+import type { SignalBundle } from "../execution/index.js";
+import { makeWakeId } from "../execution/index.js";
 
 const wakeId = makeWakeId("wake-test");
 
@@ -65,7 +65,6 @@ describe("assembleExecutionContract", () => {
 
     expect(contract.objective).toBe("Scheduled wake (0 9 * * *)");
     expect(contract.requiredOutputs).toEqual([]);
-    expect(contract.actionItems).toEqual([]);
     expect(contract.completionConditions).toEqual([]);
     expect(contract.verification).toEqual([]);
     expect(contract.allowedSideEffects).toEqual(["read"]);
@@ -115,51 +114,6 @@ describe("assembleExecutionContract", () => {
       mode: "required",
       reason: "Source approval required for: admin",
     });
-  });
-
-  it("maps SignalBundle.actionItems to ActionItemRef with sourceRef for github-issue signals", () => {
-    const issueSignal: Signal = {
-      id: "github-issue:xeeban/emergent-praxis#861",
-      kind: "github-issue",
-      trust: "trusted",
-      fetchedAt: new Date(),
-      number: 861,
-      title: "Action item: intelligence-agent — add conformant contract: block",
-      url: "https://github.com/xeeban/emergent-praxis/issues/861",
-      labels: ["assigned:intelligence-agent"],
-      excerpt: "...",
-    };
-    const inboxSignal: Signal = {
-      id: "inbox:msg-42",
-      kind: "inbox-message",
-      trust: "trusted",
-      fetchedAt: new Date(),
-      fromAgent: makeAgentId("memory-agent"),
-      path: "agents/intelligence-agent/inbox/msg-42.md",
-      excerpt: "...",
-    };
-
-    const signals: SignalBundle = {
-      ...emptySignals,
-      actionItems: [issueSignal, inboxSignal],
-    };
-
-    const contract = assembleExecutionContract({
-      wakeReason: { kind: "scheduled", cronExpression: "0 9 * * *" },
-      wakeMode: "individual",
-      declaration: undefined,
-      signals,
-      budget: baseBudget,
-      githubWriteScopes: emptyScopes,
-    });
-
-    expect(contract.actionItems).toHaveLength(2);
-    expect(contract.actionItems[0]).toEqual({
-      signalId: "github-issue:xeeban/emergent-praxis#861",
-      sourceRef: "https://github.com/xeeban/emergent-praxis/issues/861",
-    });
-    // inbox-message has no url, so sourceRef is absent
-    expect(contract.actionItems[1]).toEqual({ signalId: "inbox:msg-42" });
   });
 
   it("derives allowedSideEffects from write scopes (read-only when all empty)", () => {
@@ -252,8 +206,9 @@ describe("renderContractForPrompt", () => {
     expect(rendered).toMatch(/^# Execution Contract\n/);
     expect(rendered).toContain("**Objective:** Scheduled wake (0 9 * * *)");
     expect(rendered).toContain("_No explicit obligations declared");
-    expect(rendered).toContain("Permitted side effects");
-    expect(rendered).toContain("`read`");
+    // Read-only contracts no longer render the Permitted side effects
+    // section — the agent learns nothing actionable from "you may read".
+    expect(rendered).not.toContain("## Permitted side effects");
     expect(rendered).not.toContain("## Completion conditions");
     expect(rendered).not.toContain("## Required outputs");
     expect(rendered).not.toContain("## Source approval");

--- a/packages/core/src/runtime/execution-contract.ts
+++ b/packages/core/src/runtime/execution-contract.ts
@@ -26,20 +26,12 @@
 
 import { z } from "zod";
 
-import type { CostBudget, Signal, SignalBundle, WakeMode, WakeReason } from "../execution/index.js";
+import type { CostBudget, SignalBundle, WakeMode, WakeReason } from "../execution/index.js";
 import type { ApprovalPolicy, ToolPermission } from "../tools/registry.js";
 
 // ---------------------------------------------------------------------------
 // Sub-types
 // ---------------------------------------------------------------------------
-
-/** Machine-readable reference to an action item from the signal bundle. */
-export interface ActionItemRef {
-  /** Signal id of the action item issue (e.g. `"github-issue:xeeban/ep#842"`). */
-  readonly signalId: string;
-  /** Optional source ref for provenance (e.g. the issue URL). */
-  readonly sourceRef?: string;
-}
 
 /** One testable condition that must be true for the wake to be considered done. */
 export interface CompletionCondition {
@@ -108,11 +100,9 @@ export interface ExecutionContract {
 
   /** Artifacts the agent must produce to satisfy the contract. */
   readonly requiredOutputs: readonly RequiredOutput[];
-  /** Action items from the signal bundle mapped into the contract. */
-  readonly actionItems: readonly ActionItemRef[];
-  /** Testable completion conditions (Phase 4 validator checks these). */
+  /** Testable completion conditions checked post-wake by the validator. */
   readonly completionConditions: readonly CompletionCondition[];
-  /** Post-wake verification steps (Phase 4). */
+  /** Post-wake verification steps. */
   readonly verification: readonly VerificationStep[];
 
   // ── Permission sub-contract ───────────────────────────────────────────
@@ -130,21 +120,15 @@ export interface ExecutionContract {
 // ---------------------------------------------------------------------------
 
 /**
- * Zod schema for the optional `contract:` block in `role.md` frontmatter
- * (ADR-0047 §4, Phase 4 PR 1). All arrays default to empty so a partial
- * `contract: {}` block parses cleanly; unknown keys are rejected via
- * `.strict()` so typos surface at boot rather than silently degrading.
+ * Zod schema for the optional `contract:` block in `role.md` frontmatter.
+ * All arrays default to empty so a partial `contract: {}` block parses
+ * cleanly; unknown keys are rejected via `.strict()` so typos surface at
+ * boot rather than silently degrading.
  *
- * The schema is intentionally minimal per the "v1 brutally simple"
- * design principle in `docs/plans/proposal-07-phase4-implementation.md`:
- * no nesting, no expressions, no operators beyond single-level `OR` in
- * `done_when[]` strings (parsed downstream in `buildSpawnContext` —
- * PR 2). When operators demand more expressive grammar, file a
- * follow-up ADR rather than extending this schema.
- *
- * The downstream mapping into {@link ExecutionContract} happens at
- * spawn time in PR 2. Operators with no `contract:` block fall back
- * to the synthesized minimal default (ADR-0047 §4 fallback).
+ * The schema is intentionally minimal: no nesting, no expressions, no
+ * operators beyond single-level `OR` in `done_when[]` strings (parsed
+ * downstream in `assembleExecutionContract`). Operators with no
+ * `contract:` block fall back to a synthesized minimal default.
  */
 export const contractDeclarationSchema = z
   .object({
@@ -162,7 +146,7 @@ export const contractDeclarationSchema = z
 export type ContractDeclaration = z.infer<typeof contractDeclarationSchema>;
 
 // ---------------------------------------------------------------------------
-// assembleExecutionContract (Phase 4 PR 2)
+// assembleExecutionContract
 // ---------------------------------------------------------------------------
 
 /** GitHub write scope shape consumed by {@link assembleExecutionContract}.
@@ -188,51 +172,31 @@ export interface AssembleExecutionContractArgs {
   readonly githubWriteScopes: GithubWriteScopesView;
 }
 
-/** Maps a single action-item Signal to an {@link ActionItemRef}. */
-const toActionItemRef = (signal: Signal): ActionItemRef => {
-  const sourceRef =
-    signal.kind === "github-issue" || signal.kind === "governance-round" ? signal.url : undefined;
-  return {
-    signalId: signal.id,
-    ...(sourceRef !== undefined ? { sourceRef } : {}),
-  };
-};
-
 /**
  * Build a full {@link ExecutionContract} for one wake.
  *
  * Combines the operator-authored `contract:` block from `role.md` with
  * runtime context (signal bundle, budget, wake reason, GitHub write
- * scopes). The result is the single source of truth used by:
+ * scopes). The result is the single source of truth used by the prompt
+ * assembler (to render `requiredOutputs` into the system prompt) and
+ * `validateOutcomes` (to score the wake against the declared obligations).
  *
- *   - The prompt assembler (PR 3) to render `requiredOutputs` and
- *     `actionItems` into the system prompt.
- *   - `validateOutcomes` (PR 4) to score the wake against the
- *     declared obligations.
- *
- * Phase 4 PR 2 keeps the assembly intentionally minimal:
+ * Mapping:
  *
  *   - `objective` is the first `done_when` string when present, else
  *     a synthesized one-line derived from `wakeReason`.
  *   - `requiredOutputs` is the concatenation of `committed_artifacts`
- *     and `runtime_artifacts` from the declaration; each entry becomes
- *     a glob-style required-output descriptor.
- *   - `actionItems` is the SignalBundle's action-item array mapped 1:1
- *     to {@link ActionItemRef}.
+ *     and `runtime_artifacts` from the declaration; each declaration
+ *     becomes one obligation whose `paths` array OR-matches across
+ *     every declared glob.
  *   - `completionConditions` is one entry per `done_when` string.
  *   - `verification` is one required step per `verification_required_for`
  *     entry.
  *   - `allowedSideEffects` is derived from `githubWriteScopes`: `read`
  *     is always granted; `write` is added when any write scope is
- *     non-empty. Finer-grained tool permission grants land in a later
- *     PR.
+ *     non-empty.
  *   - `approval` requires Source approval when `approval_required_for`
  *     is non-empty; the reason string lists the gated keys.
- *
- * Phase 5+ will replace this with full Tsinghua NLAH semantics
- * (disjunction, exemption, partial-credit). The v1 form is brutally
- * simple per ADR-0048 §Decision-drivers (1) and the
- * "v1 DSLs brutally simple" project rule.
  */
 export const assembleExecutionContract = (
   args: AssembleExecutionContractArgs,
@@ -258,8 +222,6 @@ export const assembleExecutionContract = (
     ...buildPathObligation("committed-artifact", declaration?.committed_artifacts ?? []),
     ...buildPathObligation("runtime-artifact", declaration?.runtime_artifacts ?? []),
   ];
-
-  const actionItems = args.signals.actionItems.map(toActionItemRef);
 
   const completionConditions: readonly CompletionCondition[] = (declaration?.done_when ?? []).map(
     (description, idx) => ({
@@ -307,7 +269,6 @@ export const assembleExecutionContract = (
     wakeMode: args.wakeMode,
     objective,
     requiredOutputs,
-    actionItems,
     completionConditions,
     verification,
     allowedSideEffects,
@@ -317,7 +278,7 @@ export const assembleExecutionContract = (
 };
 
 // ---------------------------------------------------------------------------
-// renderContractForPrompt (Phase 4 PR 3)
+// renderContractForPrompt
 // ---------------------------------------------------------------------------
 
 /**
@@ -405,14 +366,21 @@ export const renderContractForPrompt = (contract: ExecutionContract): string => 
     }
   }
 
-  lines.push("");
-  lines.push("## Permitted side effects");
-  lines.push("");
-  const sideEffectList = contract.allowedSideEffects.join(", ");
-  lines.push(
-    `You may exercise tools whose permission is one of: \`${sideEffectList}\`. ` +
-      "Tools requiring permissions outside this set will be refused at the tool layer.",
-  );
+  // Only emit "Permitted side effects" when the contract grants anything
+  // beyond plain `read`. Read-only contracts are the common case; rendering
+  // the section every wake wastes prompt tokens without telling the agent
+  // anything new.
+  const writePermissions = contract.allowedSideEffects.filter((p) => p !== "read");
+  if (writePermissions.length > 0) {
+    lines.push("");
+    lines.push("## Permitted side effects");
+    lines.push("");
+    const sideEffectList = contract.allowedSideEffects.join(", ");
+    lines.push(
+      `You may exercise tools whose permission is one of: \`${sideEffectList}\`. ` +
+        "Tools requiring permissions outside this set will be refused at the tool layer.",
+    );
+  }
 
   if (contract.approval.mode !== "none") {
     lines.push("");

--- a/packages/core/src/runtime/runtime.test.ts
+++ b/packages/core/src/runtime/runtime.test.ts
@@ -14,7 +14,6 @@
 import { describe, expect, it } from "vitest";
 
 import type {
-  ActionItemRef,
   CompletionCondition,
   ExecutionContract,
   VerificationStep,
@@ -97,11 +96,6 @@ const minimalEnv: EnvironmentSpec = {
   publicEnv: { MURMURATION_ENV: "test" },
   secretGrants: [],
   network: "none",
-};
-
-const actionItemRef: ActionItemRef = {
-  signalId: "github-issue:xeeban/ep#1",
-  sourceRef: "https://github.com/xeeban/ep/issues/1",
 };
 
 const completionCondition: CompletionCondition = {
@@ -282,7 +276,6 @@ describe("Proposal 07 Phase 0 boundary types", () => {
         wakeMode: "individual",
         objective: "Review open action items and post one comment.",
         requiredOutputs: [{ kind: "comment", description: "At least one issue comment" }],
-        actionItems: [actionItemRef],
         completionConditions: [completionCondition],
         verification: [verificationStep],
         allowedSideEffects: ["read", "write"],
@@ -302,7 +295,6 @@ describe("Proposal 07 Phase 0 boundary types", () => {
       };
       expect(contract.wakeMode).toBe("individual");
       expect(contract.allowedSideEffects).toContain("write");
-      expect(contract.actionItems[0]?.signalId).toBe("github-issue:xeeban/ep#1");
     });
   });
 
@@ -344,7 +336,6 @@ describe("Proposal 07 Phase 0 boundary types", () => {
           wakeMode: "individual",
           objective: "Test wake.",
           requiredOutputs: [],
-          actionItems: [],
           completionConditions: [],
           verification: [],
           allowedSideEffects: [],


### PR DESCRIPTION
## Summary

Five v0.8.0 review findings, one mechanical sweep. Last of the four cleanup PRs (#385 security, #386 type tightening, #387 boot typed errors, this one).

### P2.1 — Comment hygiene regressed

The post-#378 rule was "no progress-note style comments — keep what explains the code, drop Phase/PR/incident markers." A subsequent wave of PRs re-introduced ~10 \`Phase 4 PR N\`, \`(harness#NNN)\`, "before v0.8.1 promotes...", "Phase 5+ will replace this with full Tsinghua NLAH semantics", and forward-plan markers across \`runtime/execution-contract.ts\`, \`daemon/runs.ts\`, \`identity/index.ts\`. Scrubbed.

### P2.3 — Dead `actionItems` field on `ExecutionContract`

Populated by the assembler but never read by the prompt renderer, validator, or any other consumer. The live read path goes through \`context.signals.actionItems\` / \`context.actionItems\` on \`validateWake\`. Removed the field, the \`toActionItemRef\` mapper, and the \`ActionItemRef\` interface. Tests that exercised the dead mapping are removed.

### P2.5 — `renderContractForPrompt` always-emitted "Permitted side effects" section

For the common read-only contract the section was prompt-token noise. Now only emitted when the contract grants anything beyond read.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` 0 errors (25 grandfathered warnings — same as post-#386 baseline)
- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run test\` — 1258 passed (2 fewer than pre-PR: dead \`ActionItemRef\` mapping test + obsolete side-effects positive-assertion)
- [ ] CI green

## Not in this PR (deferred to v0.8.1)

- L3: incomplete-agent stderr writes raw readdir dir names
- P1.4: dedup of inline URL regex in \`validateBehavior\`
- P2.7: \`findIncompleteAgents\` tests over-assert order
- P2.8: daemon legacy-fallback event not on \`WakeValidationResult\`

Once #387 and this PR merge, we re-tag v0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)