### PR TITLE
chore(ci): migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - "v*"
 
 permissions:
-  contents: write # for gh release create
+  contents: write # gh release create
+  id-token: write # npm Trusted Publishing (OIDC exchange at registry.npmjs.org)
 
 jobs:
   publish:
@@ -19,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
+        # Trusted Publishing requires pnpm >= 10.7. Pinned to a known-good
+        # release; bump when npm's OIDC contract changes.
         uses: pnpm/action-setup@v4
         with:
           version: 10.33.0
@@ -70,10 +73,16 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: Publish to npm
-        run: pnpm -r publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (Trusted Publishing via OIDC)
+        # No NODE_AUTH_TOKEN: pnpm exchanges the GitHub OIDC token for a
+        # short-lived npm publish token via the configured trusted publisher
+        # for each @murmurations-ai/* package. The trusted publisher
+        # binding lives in each package's npmjs.com Settings → Publishing
+        # access tab and must name this repo + this workflow + this branch.
+        # If npm errors with "no trusted publisher configured", finish the
+        # setup at https://www.npmjs.com/package/@murmurations-ai/<pkg>/access
+        # before re-running this workflow.
+        run: pnpm -r publish --access public --no-git-checks --provenance
 
       - name: Create GitHub release
         env:

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -42,6 +42,11 @@ Releases are **milestone-based**, not time-based. A release ships when its miles
 
 ### How to release
 
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which runs the
+full gate (build / typecheck / lint / format / test), publishes all 8
+packages to npm via Trusted Publishing (OIDC — no long-lived tokens), and
+creates the GitHub Release.
+
 ```bash
 # 1. Ensure clean main branch
 git checkout main && git pull
@@ -51,25 +56,53 @@ pnpm version --recursive <major|minor|patch>
 
 # 3. Update CHANGELOG.md with the release notes
 
-# 4. Commit and tag
+# 4. Commit, tag, push
 git add -A
 git commit -m "release: v0.2.0"
 git tag v0.2.0
-
-# 5. Push tag (triggers CI)
 git push origin main --tags
-
-# 6. Publish to npm
-pnpm build
-pnpm publish --recursive --access public --no-git-checks
-
-# 7. Create GitHub Release from the tag
-gh release create v0.2.0 --title "v0.2.0" --notes-file CHANGELOG-ENTRY.md
+# The Release workflow handles npm publish + GH release automatically.
 ```
 
-### Automated releases (future)
+### npm Trusted Publishing setup (one-time, per package)
 
-A GitHub Action will automate steps 6-7 when a version tag is pushed. Until then, releases are manual.
+The release workflow uses [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
+via GitHub OIDC. Each `@murmurations-ai/*` package must be configured on
+npmjs.com to trust this repository's `release.yml` workflow.
+
+Setup, once per package:
+
+1. Sign in to npmjs.com as a maintainer of `@murmurations-ai/*`.
+2. Go to the package page → **Settings** → **Publishing access**.
+3. Under **Trusted Publishers**, click **Add publisher**.
+4. Select **GitHub Actions** and fill:
+   - Repository: `murmurations-ai/murmurations-harness`
+   - Workflow filename: `release.yml`
+   - Environment: (leave blank unless we wire an env later)
+5. Save.
+
+Repeat for all 8 packages: `cli`, `core`, `dashboard-tui`, `github`, `llm`,
+`mcp`, `secrets-dotenv`, `signals`.
+
+Once configured, the workflow's `pnpm -r publish --provenance` step
+exchanges a GitHub OIDC token for a short-lived npm publish token per
+package — no `NPM_TOKEN` secret needed in the repo. The `--provenance`
+flag attaches a signed attestation linking the published tarball to the
+source commit and workflow run, visible on each package's npmjs.com page.
+
+### Manual publish (fallback)
+
+When Trusted Publishing isn't viable (e.g. tagging from a fork, or npm
+OIDC outage), publish manually from a clean local checkout of the tag:
+
+```bash
+git checkout v0.2.0
+pnpm install --frozen-lockfile
+pnpm build && pnpm check
+pnpm -r publish --access public --no-git-checks
+# This will prompt for npm 2FA. An automation token in ~/.npmrc bypasses
+# the prompt but is subject to npm's periodic security rotations.
+```
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

Replaces the \`NPM_TOKEN\`-based publish path with GitHub OIDC-based **npm Trusted Publishing**. The workflow no longer needs a long-lived npm token secret; each tag exchanges a short-lived GitHub OIDC token for a one-time-use npm publish token at registry.npmjs.org, scoped to this repo + this workflow file.

**Why now:** the 2026-05-20 npm email — they're rotating granular automation tokens with bypass-2FA in response to the "Mini Shai-Hulud" supply-chain pattern. Trusted Publishing is npm's recommended replacement: zero long-lived tokens, no rotation maintenance, no risk if a token leaks.

## Workflow changes

- \`permissions: id-token: write\` added (required for OIDC exchange).
- Removed \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` from the publish step.
- Added \`--provenance\` to \`pnpm -r publish\` so each tarball ships a signed attestation linking it to the source commit and workflow run, visible on each package's npmjs.com page.

## Operator setup required before next tag

Before merging this PR — or at least before the next \`v*\` tag — each of the 8 \`@murmurations-ai/*\` packages needs a Trusted Publisher binding on npmjs.com:

1. https://www.npmjs.com/package/@murmurations-ai/\`<pkg>\` → **Settings** → **Publishing access** → **Add publisher**
2. GitHub Actions, repo \`murmurations-ai/murmurations-harness\`, workflow \`release.yml\`, environment (blank).

Repeat for: \`cli\`, \`core\`, \`dashboard-tui\`, \`github\`, \`llm\`, \`mcp\`, \`secrets-dotenv\`, \`signals\`.

Until a package's binding is configured, publishing it will fail with "no trusted publisher configured". The remaining packages will publish fine — and the next tag can re-run the workflow once setup completes.

## Test plan

This change can't be fully exercised until the next tag fires the workflow. Verification before tag:
- [x] Workflow YAML is syntactically valid (visible in the GH Actions UI preview after push).
- [x] \`format:check\` passes.
- [ ] CI: this PR's checks (the workflow change has no runtime effect until a tag pushes).

Post-merge plan: complete the npmjs.com binding on each package, then verify by cutting a patch tag (v0.8.1 when ready) and watching the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)