### PR TITLE
feat(signals): comment cap default 5 + signal-bundle.large observability (#394 partial)

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1177,6 +1177,19 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     // aggregator too — non-github signals still benefit from the
     // tiered ordering.
     priorityBundle: true,
+    // harness#394: structured-log line when a wake's signal bundle exceeds
+    // count or byte thresholds — gives operators a way to see context-burn
+    // trends without parsing per-wake bundles by hand.
+    onBundleMetrics: (m) => {
+      logger.info("daemon.signal-bundle.large", {
+        agentId: m.agentId,
+        wakeId: m.wakeId,
+        issueCount: m.issueCount,
+        totalBytes: m.totalBytes,
+        issueThreshold: m.thresholds.issues,
+        byteThreshold: m.thresholds.bytes,
+      });
+    },
   });
 
   const firstPassDaemon = new Daemon({
@@ -1877,6 +1890,17 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
               // owns the integration; agent role.md doesn't need to
               // know.
               priorityBundle: true,
+              // harness#394: see comment on filesystemOnlyAggregator above.
+              onBundleMetrics: (m) => {
+                logger.info("daemon.signal-bundle.large", {
+                  agentId: m.agentId,
+                  wakeId: m.wakeId,
+                  issueCount: m.issueCount,
+                  totalBytes: m.totalBytes,
+                  issueThreshold: m.thresholds.issues,
+                  byteThreshold: m.thresholds.bytes,
+                });
+              },
             })
           : filesystemOnlyAggregator,
         runArtifactWriter,

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -80,6 +80,23 @@ export interface AggregatorCaps {
   readonly githubIssue: number;
   readonly privateNote: number;
   readonly inboxMessage: number;
+  /**
+   * Comments fetched per issue (harness#394, #350). Lowered from 20 → 5
+   * in v0.8.1 after field data showed comment pages dominate per-issue
+   * token cost on chatty threads. Operators with larger token budgets
+   * can raise this; the "+N more" tail names the omitted count so agents
+   * know to open the issue when they need the rest.
+   */
+  readonly commentsPerIssue: number;
+  /**
+   * Bundle observability (harness#394). The aggregator fires
+   * `onBundleMetrics` when issue count ≥ this threshold OR total github-issue
+   * excerpt bytes ≥ `largeBundleByteThreshold`. The daemon turns the metrics
+   * into a `daemon.signal-bundle.large` structured-log line so operators can
+   * spot context-burn growth before it dominates wake input.
+   */
+  readonly largeBundleIssueThreshold: number;
+  readonly largeBundleByteThreshold: number;
 }
 
 export const DEFAULT_AGGREGATOR_CAPS: AggregatorCaps = {
@@ -87,7 +104,26 @@ export const DEFAULT_AGGREGATOR_CAPS: AggregatorCaps = {
   githubIssue: 15,
   privateNote: 10,
   inboxMessage: 10,
+  commentsPerIssue: 5,
+  largeBundleIssueThreshold: 10,
+  largeBundleByteThreshold: 150_000,
 };
+
+/**
+ * Bundle-size telemetry for the `onBundleMetrics` hook. Emitted by
+ * {@link DefaultSignalAggregator} after bundle assembly when either
+ * threshold in {@link AggregatorCaps} is crossed.
+ */
+export interface BundleMetrics {
+  readonly agentId: string;
+  readonly wakeId: string;
+  readonly issueCount: number;
+  readonly totalBytes: number;
+  readonly thresholds: {
+    readonly issues: number;
+    readonly bytes: number;
+  };
+}
 
 /** Minimal CollaborationProvider interface for signal collection (ADR-0021). */
 export interface SignalCollaborationProvider {
@@ -136,6 +172,15 @@ export interface DefaultSignalAggregatorConfig {
    * remains sequential — this cap is only for the inner label fan-out.
    */
   readonly fanOutParallelism?: number;
+  /**
+   * Fires once per `aggregate()` call when the assembled bundle exceeds
+   * `largeBundleIssueThreshold` issues OR `largeBundleByteThreshold` bytes
+   * of github-issue excerpt content. The daemon wires this to a structured
+   * `daemon.signal-bundle.large` log line so operators can observe
+   * context-burn trends without parsing per-wake bundles by hand.
+   * No-op when undefined.
+   */
+  readonly onBundleMetrics?: (metrics: BundleMetrics) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -293,6 +338,31 @@ export class DefaultSignalAggregator implements SignalAggregator {
       const labels = (s as unknown as { labels: readonly string[] }).labels;
       return labels.includes(ACTION_ITEM_LABEL) && labels.includes(assignedLabel(agentIdValue));
     });
+
+    // harness#394: bundle-size observability. Sum github-issue excerpt bytes
+    // (the dominant per-wake input cost) and fire onBundleMetrics when either
+    // the issue count or byte threshold is crossed. The daemon turns this
+    // into a `daemon.signal-bundle.large` structured-log line.
+    if (this.#config.onBundleMetrics) {
+      let issueCount = 0;
+      let totalBytes = 0;
+      for (const s of finalSignals) {
+        if (s.kind !== "github-issue") continue;
+        issueCount++;
+        totalBytes += s.excerpt.length;
+      }
+      const issueThreshold = this.#caps.largeBundleIssueThreshold;
+      const byteThreshold = this.#caps.largeBundleByteThreshold;
+      if (issueCount >= issueThreshold || totalBytes >= byteThreshold) {
+        this.#config.onBundleMetrics({
+          agentId: context.agentId.value,
+          wakeId: context.wakeId.value,
+          issueCount,
+          totalBytes,
+          thresholds: { issues: issueThreshold, bytes: byteThreshold },
+        });
+      }
+    }
 
     return {
       ok: true,
@@ -461,9 +531,14 @@ export class DefaultSignalAggregator implements SignalAggregator {
     // Source answers posted as comments, not just the original body.
     // Comments are wrapped in <untrusted-comment> tags so agents can distinguish
     // user-contributed content from harness-structured signals (prompt injection
-    // boundary). Each comment fetch requests exactly MAX_COMMENTS_PER_ISSUE
+    // boundary). Each comment fetch requests exactly `caps.commentsPerIssue`
     // entries so we never pay for more than we use.
-    const MAX_COMMENTS_PER_ISSUE = 20;
+    //
+    // harness#394: default lowered from 20 → 5 after CW field data showed
+    // comment pages dominate per-issue token cost on chatty threads. Configurable
+    // via `AggregatorCaps.commentsPerIssue` so operators with larger token
+    // budgets can raise it.
+    const commentsPerIssue = this.#caps.commentsPerIssue;
     const enrichedBodies = new Map<string, string>();
     const issuesWithComments = kept.filter(({ issue }) => issue.commentCount > 0);
     if (issuesWithComments.length > 0) {
@@ -471,7 +546,7 @@ export class DefaultSignalAggregator implements SignalAggregator {
         issuesWithComments.map(async ({ issue }) => {
           const key = `${issue.repo.owner.value}/${issue.repo.name.value}#${String(issue.number.value)}`;
           const result = await client.listIssueComments(issue.repo, issue.number, {
-            perPage: MAX_COMMENTS_PER_ISSUE,
+            perPage: commentsPerIssue,
           });
           if (!result.ok) {
             warnings.push(
@@ -479,12 +554,13 @@ export class DefaultSignalAggregator implements SignalAggregator {
             );
             return;
           }
-          const comments = result.value.slice(0, MAX_COMMENTS_PER_ISSUE);
+          const comments = result.value.slice(0, commentsPerIssue);
           if (comments.length === 0) return;
           const shown = comments.length;
+          const omitted = issue.commentCount - shown;
           const truncationNote =
-            issue.commentCount > shown
-              ? ` — showing first ${String(shown)} of ${String(issue.commentCount)}`
+            omitted > 0
+              ? ` — showing first ${String(shown)} of ${String(issue.commentCount)} (+${String(omitted)} more, open issue for full thread)`
               : "";
           const commentSection = comments
             .map((c) => {

--- a/packages/signals/src/signals.test.ts
+++ b/packages/signals/src/signals.test.ts
@@ -595,7 +595,11 @@ describe("DefaultSignalAggregator", () => {
     }
   });
 
-  it("comment enrichment: cap at 20 comments per issue", async () => {
+  it("comment enrichment: caps comments at default commentsPerIssue (5)", async () => {
+    // harness#394: default cap lowered 20 → 5. Only the first 5 comments
+    // surface in the excerpt; the remainder are omitted (with a "+N more"
+    // tail tested separately). The cap is configurable via
+    // `AggregatorCaps.commentsPerIssue` for operators with larger token budgets.
     const issue = fakeIssue({ n: 7, body: "base", commentCount: 30, labels: ["assigned:alpha"] });
     const thirtyComments = Array.from({ length: 30 }, (_, i) =>
       fakeComment({ id: i + 1, body: `comment ${String(i + 1)}`, authorLogin: "source" }),
@@ -612,8 +616,8 @@ describe("DefaultSignalAggregator", () => {
         (s) => s.kind === "github-issue" && (s as unknown as { number: number }).number === 7,
       );
       if (signal?.kind === "github-issue") {
-        expect(signal.excerpt).toContain("comment 20");
-        expect(signal.excerpt).not.toContain("comment 21");
+        expect(signal.excerpt).toContain("comment 5");
+        expect(signal.excerpt).not.toContain("comment 6");
       }
     }
   });
@@ -673,9 +677,10 @@ describe("DefaultSignalAggregator", () => {
     }
   });
 
-  it("comment enrichment: count header reflects shown count with truncation note when total > 20", async () => {
-    // When commentCount exceeds MAX_COMMENTS_PER_ISSUE, the header must say
-    // "showing first N of M" so agents know the thread is truncated.
+  it("comment enrichment: default cap is 5 and truncation note names omitted count", async () => {
+    // harness#394: default `commentsPerIssue` lowered 20 → 5 to cut per-issue
+    // token cost on chatty threads. The truncation note must name the
+    // omitted count so agents know to open the issue for the full thread.
     const issue = fakeIssue({ n: 11, body: "base", commentCount: 25, labels: ["assigned:alpha"] });
     const twentyFiveComments = Array.from({ length: 25 }, (_, i) =>
       fakeComment({ id: i + 1, body: `comment ${String(i + 1)}`, authorLogin: "source" }),
@@ -692,10 +697,107 @@ describe("DefaultSignalAggregator", () => {
         (s) => s.kind === "github-issue" && (s as unknown as { number: number }).number === 11,
       );
       if (signal?.kind === "github-issue") {
-        // Header must show shown count and total, not just issue.commentCount
-        expect(signal.excerpt).toContain("showing first 20 of 25");
+        expect(signal.excerpt).toContain("showing first 5 of 25 (+20 more");
       }
     }
+  });
+
+  it("comment enrichment: commentsPerIssue cap is configurable via AggregatorCaps", async () => {
+    // Operators with larger token budgets can raise commentsPerIssue.
+    // Verifies both the perPage request and the post-fetch slice honour the cap.
+    const issue = fakeIssue({ n: 12, body: "base", commentCount: 25, labels: ["assigned:alpha"] });
+    const twentyFiveComments = Array.from({ length: 25 }, (_, i) =>
+      fakeComment({ id: i + 1, body: `comment ${String(i + 1)}`, authorLogin: "source" }),
+    );
+    const perPageCalls: number[] = [];
+    const recordingClient: GithubClient = {
+      ...makeFakeGithubWithComments([issue], new Map([[12, twentyFiveComments]])),
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async listIssueComments(_repo, _num, opts) {
+        perPageCalls.push(opts?.perPage ?? -1);
+        return { ok: true, value: twentyFiveComments };
+      },
+    };
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: recordingClient,
+      githubScopes: [{ repo: REPO }],
+      caps: { commentsPerIssue: 10 },
+    });
+    const result = await agg.aggregate(mkContext("alpha"));
+    expect(result.ok).toBe(true);
+    expect(perPageCalls).toEqual([10]);
+    if (result.ok) {
+      const signal = result.bundle.signals.find(
+        (s) => s.kind === "github-issue" && (s as unknown as { number: number }).number === 12,
+      );
+      if (signal?.kind === "github-issue") {
+        expect(signal.excerpt).toContain("showing first 10 of 25 (+15 more");
+      }
+    }
+  });
+
+  it("onBundleMetrics: fires when github-issue count crosses threshold", async () => {
+    // harness#394: signal-bundle observability. The aggregator must surface
+    // bundle-size telemetry so the daemon can emit daemon.signal-bundle.large
+    // structured-log lines for operators watching context-burn trends.
+    const issues = Array.from({ length: 6 }, (_, i) =>
+      fakeIssue({ n: 200 + i, body: "x", labels: ["assigned:alpha"] }),
+    );
+    const calls: { issueCount: number; totalBytes: number }[] = [];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO }],
+      caps: { largeBundleIssueThreshold: 5, largeBundleByteThreshold: 1_000_000 },
+      onBundleMetrics: (m) => {
+        calls.push({ issueCount: m.issueCount, totalBytes: m.totalBytes });
+      },
+    });
+    const result = await agg.aggregate(mkContext("alpha"));
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.issueCount).toBe(6);
+  });
+
+  it("onBundleMetrics: fires when total excerpt bytes cross threshold", async () => {
+    const big = "x".repeat(400);
+    const issues = Array.from({ length: 3 }, (_, i) =>
+      fakeIssue({ n: 300 + i, body: big, labels: ["assigned:alpha"] }),
+    );
+    const calls: { issueCount: number; totalBytes: number }[] = [];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO }],
+      caps: { largeBundleIssueThreshold: 100, largeBundleByteThreshold: 1_000 },
+      onBundleMetrics: (m) => {
+        calls.push({ issueCount: m.issueCount, totalBytes: m.totalBytes });
+      },
+    });
+    const result = await agg.aggregate(mkContext("alpha"));
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.totalBytes).toBeGreaterThanOrEqual(1_000);
+  });
+
+  it("onBundleMetrics: does NOT fire when bundle is under both thresholds", async () => {
+    const issues = Array.from({ length: 2 }, (_, i) =>
+      fakeIssue({ n: 400 + i, body: "tiny", labels: ["assigned:alpha"] }),
+    );
+    const calls: number[] = [];
+    const agg = new DefaultSignalAggregator({
+      rootDir,
+      github: makeFakeGithub(issues),
+      githubScopes: [{ repo: REPO }],
+      caps: { largeBundleIssueThreshold: 10, largeBundleByteThreshold: 150_000 },
+      onBundleMetrics: () => {
+        calls.push(1);
+      },
+    });
+    const result = await agg.aggregate(mkContext("alpha"));
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(0);
   });
 
   it("routing filter: filter runs before cap — agent's own issues survive even when cross-agent pool is large", async () => {


### PR DESCRIPTION
## Summary

Two coupled knobs from #394 that cut per-wake input tokens without touching governance or operator interfaces. Architecture and engineering agents conferred and agreed: ship A (comment cap) + C (large-bundle event) as one coherent PR; defer B (\`signal:exclude\` label) until peer-chronicle work in v0.8.1 where it can land as a proper plugin policy hook alongside \`signal:hidden\`.

## What changes

- **\`AggregatorCaps.commentsPerIssue\`** (default 5, was hardcoded 20). CW field data showed comment pages dominate per-issue token cost on chatty threads. Configurable so operators with larger token budgets can raise it. The truncation note now names the omitted count (\`+20 more, open issue for full thread\`) so agents know to fetch the rest when they need it.
- **\`daemon.signal-bundle.large\`** structured-log line via a new optional \`onBundleMetrics\` callback on \`DefaultSignalAggregatorConfig\`. Fires when issue count ≥ \`largeBundleIssueThreshold\` (default 10) OR total github-issue excerpt bytes ≥ \`largeBundleByteThreshold\` (default 150_000). Mirrors the \`daemon.validate.legacy-fallback\` observability precedent — keeps the signals package logger-free; the daemon owns the structured log emission.

## Why both, why now

Lowering the comment cap without observability is unmeasurable — the bundle-size event is the feedback loop that lets operators confirm the change helps (or revert it). The two ship together as a single revertable unit.

## Deferred from #394 (intentionally)

- **\`signal:exclude\` label.** Belongs with the v0.8.1 peer-chronicle \`signal:hidden\` work via a proper \`AggregatorPolicy\` hook on the governance plugin, not as a hardcoded string in the core aggregator. Two parallel exclusion mechanisms would be a regret.
- **\`EXCERPT_MAX_CHARS\` lowering.** Existing comment at \`packages/signals/src/index.ts:160-169\` already documents why substring slicing is the wrong shape — needs LLM summarization, tracked separately.
- **\`murmuration doctor\` stale-issue check.** Scope 1 of #394; its own PR after we see how this PR's data shapes the criteria.

## Test plan

- [x] \`pnpm run check\` — typecheck + lint + format + 1268 tests pass
- [x] Updated existing comment-cap test to reflect new default (5) and \`+N more\` tail wording
- [x] New tests: configurable \`commentsPerIssue\` cap, \`onBundleMetrics\` fires on count threshold, fires on byte threshold, does NOT fire below both
- [ ] Watch \`daemon.signal-bundle.large\` event volume in production for a week; tune defaults if needed

Refs #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)