### PR TITLE
feat(doctor): hygiene category — stale signal-bundle inputs (#394 scope 1)

### DIFF
--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { applyFixes, runDoctor } from "./doctor.js";
+import { applyFixes, classifyStaleIssues, runDoctor } from "./doctor.js";
 
 describe("runDoctor (v0.5.0 Milestone 3)", () => {
   let rootDir = "";
@@ -159,5 +159,105 @@ describe("runDoctor (v0.5.0 Milestone 3)", () => {
     await writeHealthy();
     const report = await runDoctor({ rootDir });
     expect(report.skipped).toContain("live");
+  });
+
+  it("hygiene category is skipped by default and listed under --live (harness#394)", async () => {
+    await writeHealthy();
+    const reportNoLive = await runDoctor({ rootDir });
+    expect(reportNoLive.skipped).toContain("hygiene");
+    // Local-only collaboration: even with --live, no network call should fire
+    // and no hygiene findings should be emitted. Test confirms graceful no-op.
+    const reportLive = await runDoctor({ rootDir, live: true });
+    expect(reportLive.skipped).not.toContain("hygiene");
+    expect(reportLive.findings.filter((f) => f.category === "hygiene")).toEqual([]);
+  });
+});
+
+describe("classifyStaleIssues (harness#394 scope 1)", () => {
+  const NOW = new Date("2026-05-25T12:00:00Z");
+  const daysAgo = (days: number): Date => new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+
+  it("flags issues older than 14d with no comment activity in 7d", () => {
+    const result = classifyStaleIssues(
+      [
+        {
+          number: 1,
+          title: "Ancient stale issue",
+          htmlUrl: "https://example/1",
+          createdAt: daysAgo(30),
+          updatedAt: daysAgo(10),
+        },
+        {
+          number: 2,
+          title: "Old but recently commented",
+          htmlUrl: "https://example/2",
+          createdAt: daysAgo(30),
+          updatedAt: daysAgo(2),
+        },
+        {
+          number: 3,
+          title: "Brand new",
+          htmlUrl: "https://example/3",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        },
+      ],
+      NOW,
+    );
+    expect(result.byAge.map((i) => i.number)).toEqual([1]);
+  });
+
+  it("flags digest-pattern titles regardless of age", () => {
+    const result = classifyStaleIssues(
+      [
+        {
+          number: 10,
+          title: "[FINANCE] Weekly burn 2026-05-25",
+          htmlUrl: "https://example/10",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        },
+        {
+          number: 11,
+          title: "DIGEST: catch-up",
+          htmlUrl: "https://example/11",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        },
+        {
+          number: 12,
+          title: "Implement feature X",
+          htmlUrl: "https://example/12",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        },
+        {
+          number: 13,
+          title: "[Status] Sprint update",
+          htmlUrl: "https://example/13",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        },
+      ],
+      NOW,
+    );
+    expect(result.byDigestPattern.map((i) => i.number).sort((a, b) => a - b)).toEqual([10, 11, 13]);
+  });
+
+  it("issue can appear in both buckets when stale AND digest-patterned", () => {
+    const result = classifyStaleIssues(
+      [
+        {
+          number: 20,
+          title: "[DIGEST] 2026-02 monthly",
+          htmlUrl: "https://example/20",
+          createdAt: daysAgo(90),
+          updatedAt: daysAgo(45),
+        },
+      ],
+      NOW,
+    );
+    expect(result.byAge.map((i) => i.number)).toEqual([20]);
+    expect(result.byDigestPattern.map((i) => i.number)).toEqual([20]);
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -5,8 +5,9 @@
  * Runs a battery of checks against a root directory and tells the
  * operator what will (or won't) work. `--fix` attempts safe
  * auto-remediations (backing up originals to `.bak`). `--live` opts
- * into provider API calls to verify secrets actually authenticate.
- * `--json` emits machine-readable results for CI or monitoring.
+ * into network-dependent checks: provider API key validation AND the
+ * GitHub signal-bundle hygiene scan (harness#394). `--json` emits
+ * machine-readable results for CI or monitoring.
  *
  * Designed to be the one-stop setup validator: after `init`, run
  * `doctor`; before filing a bug, run `doctor`; after migrating a
@@ -41,7 +42,14 @@ const which = (bin: string): boolean => {
 // Types
 // ---------------------------------------------------------------------------
 
-export type DoctorCategory = "layout" | "schema" | "secrets" | "governance" | "live" | "drift";
+export type DoctorCategory =
+  | "layout"
+  | "schema"
+  | "secrets"
+  | "governance"
+  | "live"
+  | "drift"
+  | "hygiene";
 
 export type DoctorSeverity = "error" | "warning" | "info";
 
@@ -846,6 +854,197 @@ const validateLLMKey = async (provider: string, token: string): Promise<void> =>
 };
 
 // ---------------------------------------------------------------------------
+// Category 7: Hygiene — stale signal-bundle inputs (harness#394 scope 1)
+// ---------------------------------------------------------------------------
+//
+// Every open GitHub issue lands in every watching agent's SignalBundle on
+// every wake. Operator repos accumulate digest issues, status pings, and
+// "report" issues that never get closed; each one is re-fetched and re-read
+// by every agent daily. Cleanup sweeps that close ~15 stale issues reduce
+// per-wake input tokens by 20–40% on 6–10 agent murmurations.
+//
+// This check surfaces those candidates so operators don't have to discover
+// the cleanup pattern manually. It does not auto-close (operator judgement);
+// see also `murmuration sweep` (harness#394 scope 3) for the interactive tool.
+
+/** Subset of a GitHub issue this check needs. Kept narrow so the function
+ *  is testable without an HTTP fixture for the whole REST shape. */
+export interface StaleIssueCandidate {
+  readonly number: number;
+  readonly title: string;
+  readonly htmlUrl: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface StaleIssueClassification {
+  readonly byAge: readonly StaleIssueCandidate[];
+  readonly byDigestPattern: readonly StaleIssueCandidate[];
+}
+
+const DIGEST_TITLE_PATTERNS: readonly RegExp[] = [
+  /^\s*\[?\s*DIGEST\s*\]?/i,
+  /^\s*\[?\s*FINANCE\s*\]?/i,
+  /^\s*\[?\s*STATUS\s*\]?/i,
+  /^\s*\[?\s*REPORT\s*\]?/i,
+  /^\s*\[?\s*KICKOFF\s*\]?/i,
+];
+
+const AGE_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000;
+const SILENCE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Pure classifier — given a list of open issues, partition into the two
+ *  buckets that the doctor check emits. Exported for direct unit testing. */
+export const classifyStaleIssues = (
+  issues: readonly StaleIssueCandidate[],
+  now: Date = new Date(),
+): StaleIssueClassification => {
+  const byAge: StaleIssueCandidate[] = [];
+  const byDigestPattern: StaleIssueCandidate[] = [];
+  const nowMs = now.getTime();
+  for (const issue of issues) {
+    const ageMs = nowMs - issue.createdAt.getTime();
+    const silenceMs = nowMs - issue.updatedAt.getTime();
+    if (ageMs > AGE_THRESHOLD_MS && silenceMs > SILENCE_THRESHOLD_MS) {
+      byAge.push(issue);
+    }
+    if (DIGEST_TITLE_PATTERNS.some((p) => p.test(issue.title))) {
+      byDigestPattern.push(issue);
+    }
+  }
+  return { byAge, byDigestPattern };
+};
+
+/** Parse `owner/repo` into separate parts. Returns null on malformed input. */
+const splitRepo = (repo: string): { owner: string; name: string } | null => {
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || slash === repo.length - 1) return null;
+  return { owner: repo.slice(0, slash), name: repo.slice(slash + 1) };
+};
+
+interface RestIssueResponse {
+  readonly number: number;
+  readonly title: string;
+  readonly html_url: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly pull_request?: unknown;
+}
+
+/** Page through `GET /repos/{owner}/{name}/issues?state=open` and return
+ *  issues (excluding PRs, which the REST API mixes in). Capped at 5 pages
+ *  (500 issues) to bound rate-limit cost. */
+const fetchOpenIssues = async (
+  repo: string,
+  token: string,
+): Promise<readonly StaleIssueCandidate[]> => {
+  const parts = splitRepo(repo);
+  if (!parts) return [];
+  const collected: StaleIssueCandidate[] = [];
+  const maxPages = 5;
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `https://api.github.com/repos/${parts.owner}/${parts.name}/issues?state=open&per_page=100&page=${String(page)}`;
+    const res = await withTimeout(
+      fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "murmuration-doctor",
+        },
+      }),
+      10_000,
+      `GitHub GET /issues page ${String(page)}`,
+    );
+    if (!res.ok) {
+      throw new Error(`${String(res.status)} ${res.statusText}`);
+    }
+    const body: unknown = await res.json();
+    if (!Array.isArray(body)) break;
+    const items = body as RestIssueResponse[];
+    for (const it of items) {
+      // REST /issues returns PRs alongside issues; skip them.
+      if (it.pull_request !== undefined) continue;
+      collected.push({
+        number: it.number,
+        title: it.title,
+        htmlUrl: it.html_url,
+        createdAt: new Date(it.created_at),
+        updatedAt: new Date(it.updated_at),
+      });
+    }
+    if (items.length < 100) break;
+  }
+  return collected;
+};
+
+const formatStaleDetail = (issues: readonly StaleIssueCandidate[], limit = 10): string => {
+  const shown = issues.slice(0, limit).map((i) => `#${String(i.number)} ${i.title}`);
+  const overflow = issues.length - shown.length;
+  return overflow > 0 ? `${shown.join("; ")}; +${String(overflow)} more` : shown.join("; ");
+};
+
+const runHygieneChecks = async (ctx: CheckContext): Promise<void> => {
+  const { rootDir, findings, harness } = ctx;
+  if (harness.collaboration.provider !== "github") return;
+
+  const envPath = join(rootDir, ".env");
+  if (!existsSync(envPath)) return;
+  const env = parseDotEnv(await readFile(envPath, "utf8"));
+  const token = env.get("GITHUB_TOKEN");
+  if (!token || token.length === 0 || token === "ghp_your-token-here") return;
+
+  const repo = harness.collaboration.repo;
+  if (!repo) {
+    findings.push({
+      checkId: "hygiene.no-repo",
+      category: "hygiene",
+      severity: "info",
+      title: "hygiene checks skipped: collaboration.repo not configured",
+      detail:
+        'Stale-issue scan needs a target repo. Set collaboration.repo in murmuration/harness.yaml (e.g. "owner/name").',
+    });
+    return;
+  }
+
+  let issues: readonly StaleIssueCandidate[];
+  try {
+    issues = await fetchOpenIssues(repo, token);
+  } catch (err) {
+    findings.push({
+      checkId: "hygiene.fetch-failed",
+      category: "hygiene",
+      severity: "warning",
+      title: `Could not list open issues for ${repo}`,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  const { byAge, byDigestPattern } = classifyStaleIssues(issues);
+
+  if (byAge.length > 0) {
+    findings.push({
+      checkId: "hygiene.stale-issues.by-age",
+      category: "hygiene",
+      severity: "info",
+      title: `${String(byAge.length)} open issue(s) >14d old with no activity in 7d`,
+      detail: formatStaleDetail(byAge),
+      remediation: `Every open issue lands in every watching agent's signal bundle on every wake. Review and close stale issues, or move informational content to chronicles/ per docs/CONVENTIONS-GITHUB-VS-FILES.md.`,
+    });
+  }
+  if (byDigestPattern.length > 0) {
+    findings.push({
+      checkId: "hygiene.stale-issues.digest-pattern",
+      category: "hygiene",
+      severity: "info",
+      title: `${String(byDigestPattern.length)} open issue(s) match digest/report title pattern`,
+      detail: formatStaleDetail(byDigestPattern),
+      remediation: `Issues prefixed [DIGEST]/[FINANCE]/[STATUS]/[REPORT]/[KICKOFF] are typically informational. Close once consumed, or move to chronicles/ per docs/CONVENTIONS-GITHUB-VS-FILES.md.`,
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
 
@@ -864,8 +1063,10 @@ export const runDoctor = async (options: DoctorOptions): Promise<DoctorReport> =
 
   if (options.live) {
     await runLiveChecks(ctx);
+    await runHygieneChecks(ctx);
   } else {
     skipped.push("live");
+    skipped.push("hygiene");
   }
 
   return {
@@ -914,6 +1115,7 @@ const CATEGORY_LABEL: Record<DoctorCategory, string> = {
   governance: "Governance",
   live: "Live validation",
   drift: "Drift / best-practice",
+  hygiene: "Hygiene (signal bundle)",
 };
 
 export const formatReport = (report: DoctorReport): string => {


### PR DESCRIPTION
## Summary

- New `hygiene` doctor category, gated behind `--live`, that surfaces open issues bloating every watching agent's SignalBundle
- Two heuristics: stale-by-age (>14d open + 7d silent) and digest-pattern title prefix
- `info` severity only — no auto-close; operator judgement on what to clean up
- Classification split into a pure `classifyStaleIssues` function for testability without HTTP fixtures

Closes scope 1 of #394. Scopes 2 (TUI signal-bundle column) and 3 (`murmuration sweep`) follow in separate PRs.

## Why

Per #394: every open issue lands in every watching agent's SignalBundle on every wake. Operator repos accumulate digest/status/report issues; cleanup sweeps that close ~15 stale items cut per-wake input tokens by 20–40% on 6–10 agent murmurations. Doctor surfaces the candidates so operators don't have to discover the pattern manually.

## Behaviour

- `murmuration doctor` (no flags): hygiene category appears in "skipped" alongside `live`. No network call.
- `murmuration doctor --live`: scans `collaboration.repo` (capped at 5 pages / 500 issues), emits at most 2 info findings.
- `collaboration.provider: local`: graceful no-op (no findings).
- `collaboration.repo` unset under `github`: one `hygiene.no-repo` info finding directing operator to set it.

## Test plan

- [x] `pnpm run test` — 1268 pass, 2 skipped
- [x] `pnpm run typecheck` — clean across all 8 packages
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm run format:check` — clean
- [x] New tests cover the classifier (age boundary, digest patterns, both-bucket overlap) and the `--live` skip/run gating
- [ ] Live run against a real EP-style repo with stale issues to eyeball the output formatting (would be good to do in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)