### PR TITLE
feat(dashboard,daemon): per-wake signal-bundle metrics + TUI column (#394 scope 2)

### DIFF
--- a/packages/cli/src/harness-config.test.ts
+++ b/packages/cli/src/harness-config.test.ts
@@ -244,6 +244,7 @@ describe("mergeWithCliFlags", () => {
       logging: { level: "info" as const },
       spirit: { maxSteps: 256 },
       agent: { maxSteps: 256 },
+      signals: { spikeThreshold: 10 },
     };
 
     const merged = mergeWithCliFlags(config, {
@@ -266,6 +267,7 @@ describe("mergeWithCliFlags", () => {
       logging: { level: "warn" as const },
       spirit: { maxSteps: 256 },
       agent: { maxSteps: 256 },
+      signals: { spikeThreshold: 10 },
     };
 
     const merged = mergeWithCliFlags(config, {});
@@ -284,6 +286,7 @@ describe("mergeWithCliFlags", () => {
       logging: { level: "info" as const },
       spirit: { maxSteps: 256 },
       agent: { maxSteps: 256 },
+      signals: { spikeThreshold: 10 },
     };
 
     const merged = mergeWithCliFlags(config, { logLevel: "debug" });

--- a/packages/cli/src/harness-config.ts
+++ b/packages/cli/src/harness-config.ts
@@ -72,6 +72,15 @@ export interface HarnessConfig {
      */
     readonly maxSteps: number;
   };
+  /** Signal-aggregation hygiene knobs (harness#394). */
+  readonly signals: {
+    /**
+     * Per-agent github-issue-count threshold above which the dashboard
+     * flags the agent's signal bundle as "spiked" (yellow highlight).
+     * Default 10. Operators with chattier repos can raise this.
+     */
+    readonly spikeThreshold: number;
+  };
 }
 
 const DEFAULTS: HarnessConfig = {
@@ -82,6 +91,7 @@ const DEFAULTS: HarnessConfig = {
   logging: { level: "info" },
   spirit: { maxSteps: 256 },
   agent: { maxSteps: 256 },
+  signals: { spikeThreshold: 10 },
 };
 
 const isLLMProvider = (v: unknown): v is LLMProvider =>
@@ -152,6 +162,12 @@ const harnessConfigSchema = z
     agent: z
       .object({
         maxSteps: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    signals: z
+      .object({
+        spikeThreshold: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),
@@ -241,6 +257,7 @@ export async function loadHarnessConfig(rootDir: string): Promise<HarnessConfig>
   const logging = raw.logging as Record<string, unknown> | undefined;
   const spirit = raw.spirit as Record<string, unknown> | undefined;
   const agent = raw.agent as Record<string, unknown> | undefined;
+  const signals = raw.signals as Record<string, unknown> | undefined;
 
   const collabProvider = collab?.provider;
   const logLevel = logging?.level;
@@ -258,6 +275,13 @@ export async function loadHarnessConfig(rootDir: string): Promise<HarnessConfig>
     rawAgentMaxSteps >= 1
       ? Math.floor(rawAgentMaxSteps)
       : DEFAULTS.agent.maxSteps;
+  const rawSpikeThreshold = signals?.spikeThreshold;
+  const spikeThreshold =
+    typeof rawSpikeThreshold === "number" &&
+    Number.isFinite(rawSpikeThreshold) &&
+    rawSpikeThreshold >= 1
+      ? Math.floor(rawSpikeThreshold)
+      : DEFAULTS.signals.spikeThreshold;
 
   return {
     llm: {
@@ -296,6 +320,7 @@ export async function loadHarnessConfig(rootDir: string): Promise<HarnessConfig>
     },
     spirit: { maxSteps: spiritMaxSteps },
     agent: { maxSteps: agentMaxSteps },
+    signals: { spikeThreshold },
   };
 }
 
@@ -326,5 +351,6 @@ export function mergeWithCliFlags(
     },
     spirit: config.spirit,
     agent: config.agent,
+    signals: config.signals,
   };
 }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -1007,11 +1007,19 @@ export class Daemon {
         // Pass the validation result so the index entry can record
         // validationStatus, obligationStatus, and the unmet-required-output
         // count for dashboard surfacing.
+        // Compute bundle metrics from the assembled context (harness#394
+        // scope 2). Records per-wake signal-bundle load so the dashboard
+        // can flag agents whose context is bloating.
+        const bundleMetrics = {
+          issueCount: context.signals.signals.filter((s) => s.kind === "github-issue").length,
+          totalSignals: context.signals.signals.length,
+        };
         await this.#runArtifactWriter.record(
           recordedResult,
           result.costRecord,
           this.#logger,
           isCompleted(result) ? validation : undefined,
+          bundleMetrics,
         );
       }
 

--- a/packages/core/src/daemon/runs.test.ts
+++ b/packages/core/src/daemon/runs.test.ts
@@ -229,6 +229,33 @@ describe("RunArtifactWriter", () => {
     expect(warnings[0]?.data.wakeId).toBe(WAKE_ID);
   });
 
+  describe("signalBundle metrics (harness#394 scope 2)", () => {
+    it("includes signalBundle block when bundleMetrics is passed", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord(), undefined, undefined, {
+        issueCount: 23,
+        totalSignals: 47,
+      });
+      const indexContents = await readFile(join(rootDir, "index.jsonl"), "utf8");
+      const entry = JSON.parse(indexContents.trim()) as RunArtifactIndexEntry;
+      expect(entry.signalBundle).toEqual({ issueCount: 23, totalSignals: 47 });
+    });
+
+    it("omits signalBundle block when not supplied (legacy / no signal aggregator)", async () => {
+      const writer = new RunArtifactWriter({
+        rootDir,
+        now: () => new Date("2026-04-12T18:00:04.000Z"),
+      });
+      await writer.record(makeResult(), makeCostRecord());
+      const indexContents = await readFile(join(rootDir, "index.jsonl"), "utf8");
+      const entry = JSON.parse(indexContents.trim()) as RunArtifactIndexEntry;
+      expect(entry.signalBundle).toBeUndefined();
+    });
+  });
+
   describe("subscriptionCli audit context (T-CLI-9 / harness#301)", () => {
     const auditContext: SubscriptionCliAuditContext = {
       cliName: "claude",

--- a/packages/core/src/daemon/runs.ts
+++ b/packages/core/src/daemon/runs.ts
@@ -71,6 +71,24 @@ export interface SubscriptionCliAuditContext {
   readonly envAllowlistApplied: true;
 }
 
+/**
+ * Per-wake signal-bundle observability metrics (harness#394 scope 2).
+ *
+ * Captured at wake fire time from the assembled SignalBundle so dashboards
+ * can show which agents are reading the most context per wake. Naturally
+ * complements `daemon.signal-bundle.large` event observability — that fires
+ * on threshold; this records every wake's actual numbers.
+ */
+export interface SignalBundleMetrics {
+  /** Count of `github-issue` signals in the bundle. The primary
+   *  "signal-bundle load" metric — every open issue lands in every
+   *  watching agent's bundle on every wake. */
+  readonly issueCount: number;
+  /** Total signals across all sources (issues, private notes, governance
+   *  inbox, action items, etc.). */
+  readonly totalSignals: number;
+}
+
 /** Configuration for a {@link RunArtifactWriter}. */
 export interface RunArtifactWriterConfig {
   /**
@@ -202,6 +220,11 @@ export interface RunArtifactIndexEntry {
    * wakes; absent for API-provider wakes.
    */
   readonly subscriptionCli?: SubscriptionCliAuditContext;
+  /**
+   * Per-wake signal-bundle metrics (harness#394 scope 2). Optional so
+   * legacy entries written before the metric was added stay readable.
+   */
+  readonly signalBundle?: SignalBundleMetrics;
 }
 
 export class RunArtifactWriter {
@@ -228,6 +251,7 @@ export class RunArtifactWriter {
     costRecord: WakeCostRecord | undefined,
     logger?: RunArtifactLogger,
     validation?: WakeValidationResult,
+    bundleMetrics?: SignalBundleMetrics,
   ): Promise<void> {
     try {
       const now = this.#now();
@@ -255,6 +279,7 @@ export class RunArtifactWriter {
         digestRelativePath,
         this.#subscriptionCli,
         validation,
+        bundleMetrics,
       );
       // Newline-terminated so readers can stream line-by-line.
       await appendFile(indexAbsolutePath, `${JSON.stringify(entry)}\n`, "utf8");
@@ -308,6 +333,7 @@ const buildIndexEntry = (
   digestRelativePath: string,
   subscriptionCli?: SubscriptionCliAuditContext,
   validation?: WakeValidationResult,
+  bundleMetrics?: SignalBundleMetrics,
 ): RunArtifactIndexEntry => {
   const outcome = outcomeKindOf(result);
   const durationMs = result.finishedAt.getTime() - result.startedAt.getTime();
@@ -347,6 +373,7 @@ const buildIndexEntry = (
     },
     digestPath: digestRelativePath,
     ...(subscriptionCli !== undefined ? { subscriptionCli } : {}),
+    ...(bundleMetrics !== undefined ? { signalBundle: bundleMetrics } : {}),
     ...(validation !== undefined
       ? {
           productive: validation.productive,
@@ -422,6 +449,7 @@ export class DispatchRunArtifactWriter {
     costRecord: WakeCostRecord | undefined,
     logger?: RunArtifactLogger,
     validation?: WakeValidationResult,
+    bundleMetrics?: SignalBundleMetrics,
   ): Promise<void> {
     const writer = this.#writers.get(result.agentId.value);
     if (!writer) {
@@ -432,6 +460,6 @@ export class DispatchRunArtifactWriter {
       });
       return;
     }
-    await writer.record(result, costRecord, logger, validation);
+    await writer.record(result, costRecord, logger, validation, bundleMetrics);
   }
 }

--- a/packages/dashboard-tui/src/dashboard.ts
+++ b/packages/dashboard-tui/src/dashboard.ts
@@ -15,6 +15,7 @@ import {
   readGovernanceState,
   readCostSummary,
   readMetricsSnapshot,
+  readSignalBundleSpikeThreshold,
   type AgentStatus,
   type ActivityEntry,
   type GovernanceEntry,
@@ -86,7 +87,11 @@ const renderOverview = (
 // Agents panel — combined pipeline + cost, inactive agents collapsed
 // ---------------------------------------------------------------------------
 
-const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string => {
+const renderAgents = (
+  agents: readonly AgentStatus[],
+  cost: CostSummary,
+  signalBundleSpikeThreshold: number,
+): string => {
   const lines = [` ${bold("Agents")}`, ` ${HR}`];
   if (agents.length === 0) {
     lines.push(`  ${dim("No agents discovered. Run: murmuration start --root <dir>")}`);
@@ -145,6 +150,14 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
       a.behaviorWarningCount !== null && a.behaviorWarningCount > 0
         ? yellow(` [beh:${String(a.behaviorWarningCount)}]`)
         : "";
+    // harness#394 scope 2: surface signal-bundle issue count. Yellow when
+    // the agent's last wake exceeded the configured spike threshold.
+    const bundleStr =
+      a.signalBundleIssueCount !== null
+        ? a.signalBundleIssueCount > signalBundleSpikeThreshold
+          ? yellow(` [b:${String(a.signalBundleIssueCount)}]`)
+          : dim(` [b:${String(a.signalBundleIssueCount)}]`)
+        : "";
 
     const time = a.lastWake!.toISOString().slice(11, 16);
     const next = a.nextWakeCountdown !== "--" ? a.nextWakeCountdown.padEnd(8) : dim("--".padEnd(8));
@@ -161,7 +174,7 @@ const renderAgents = (agents: readonly AgentStatus[], cost: CostSummary): string
         : dim("░".repeat(BAR_WIDTH));
 
     lines.push(
-      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}${validStr}${behStr}`,
+      `  ${marker.padEnd(6)} ${a.agentId.padEnd(24)} ${time}  ${dim("next")} ${next} ${totalCost} ${bar} ${wakes}w${failStr}${permStr}${validStr}${behStr}${bundleStr}`,
     );
   }
 
@@ -408,18 +421,20 @@ export const startDashboard = async (rootDir: string): Promise<void> => {
       return;
     }
 
-    const [pipeline, activity, governance, cost, metrics] = await Promise.all([
-      readPipelineState(root),
-      readRecentActivity(root),
-      readGovernanceState(root),
-      readCostSummary(root),
-      readMetricsSnapshot(root),
-    ]);
+    const [pipeline, activity, governance, cost, metrics, signalBundleSpikeThreshold] =
+      await Promise.all([
+        readPipelineState(root),
+        readRecentActivity(root),
+        readGovernanceState(root),
+        readCostSummary(root),
+        readMetricsSnapshot(root),
+        readSignalBundleSpikeThreshold(root),
+      ]);
 
     const header = `  ${bold("Murmuration Dashboard")} ${dim("—")} ${dim(root)}  ${dim("[q] quit  [r] refresh")}\n`;
     const overview = renderOverview(pipeline, governance, cost);
     const panels = [
-      renderAgents(pipeline, cost),
+      renderAgents(pipeline, cost, signalBundleSpikeThreshold),
       renderCostSummary(cost),
       renderGovernance(governance),
       renderMetrics(metrics),

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -10,6 +10,36 @@ import { join } from "node:path";
 import { computeMetricsFromDisk, type DiskMetricsSnapshot } from "@murmurations-ai/core";
 import cronParser from "cron-parser";
 
+/**
+ * Per-agent signal-bundle issue count threshold above which the dashboard
+ * highlights the agent's bundle as "spiked". Defaults to 10 when no
+ * murmuration/harness.yaml is present or `signals.spikeThreshold` is
+ * unset (matches the CLI HarnessConfig default).
+ */
+export const DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD = 10;
+
+/** Best-effort read of `signals.spikeThreshold` from harness.yaml. Uses a
+ *  scoped regex (matches the convention used elsewhere in this file for
+ *  role.md frontmatter) so dashboard-tui does not take a YAML dep. The
+ *  CLI's full Zod-validated loader is the source of truth at runtime;
+ *  this reader exists only so the dashboard can highlight spikes. */
+export const readSignalBundleSpikeThreshold = async (rootDir: string): Promise<number> => {
+  try {
+    const content = await readFile(join(rootDir, "murmuration", "harness.yaml"), "utf8");
+    // Anchor to the `signals:` block so we don't accidentally pick up a
+    // `spikeThreshold:` written under some other top-level key.
+    const signalsBlock = /^signals:\s*\n((?:[ \t]+.*\n?)+)/m.exec(content);
+    if (!signalsBlock) return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
+    const match = /^[ \t]+spikeThreshold:\s*(\d+)/m.exec(signalsBlock[1] ?? "");
+    if (!match) return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
+    const n = Number(match[1]);
+    if (Number.isFinite(n) && n >= 1) return Math.floor(n);
+  } catch {
+    /* fall through to default */
+  }
+  return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
+};
+
 // ---------------------------------------------------------------------------
 // Panel 1: Pipeline State — last wake per agent
 // ---------------------------------------------------------------------------
@@ -61,6 +91,12 @@ export interface AgentStatus {
    * a yellow `[beh:N]` badge for operator review.
    */
   readonly behaviorWarningCount: number | null;
+  /**
+   * Count of `github-issue` signals in the agent's last wake bundle
+   * (harness#394 scope 2). Null when no wake has been recorded or the
+   * entry pre-dates the field.
+   */
+  readonly signalBundleIssueCount: number | null;
   readonly stale: boolean; // stalled or no wake in > 48h
   readonly consecutiveFailures: number;
   readonly totalWakes: number;
@@ -153,6 +189,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
         behaviorWarningCount: null,
+        signalBundleIssueCount: null,
         stale: false,
         consecutiveFailures: a.consecutiveFailures,
         totalWakes: a.totalWakes,
@@ -240,6 +277,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
       let obligationStatus: AgentStatus["obligationStatus"] = null;
       let unmetRequiredOutputsCount: AgentStatus["unmetRequiredOutputsCount"] = null;
       let behaviorWarningCount: AgentStatus["behaviorWarningCount"] = null;
+      let signalBundleIssueCount: AgentStatus["signalBundleIssueCount"] = null;
       try {
         const indexContent = await readFile(join(runsDir, agentId, "index.jsonl"), "utf8");
         const lines = indexContent
@@ -262,6 +300,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
             obligationStatus?: string;
             unmetRequiredOutputsCount?: number;
             behaviorWarningCount?: number;
+            signalBundle?: { issueCount?: number; totalSignals?: number };
           };
           costMicros = entry.llm?.costMicros ?? 0;
           costFormatted = `$${entry.llm?.costUsdFormatted ?? "0.0000"}`;
@@ -294,6 +333,9 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           if (typeof entry.behaviorWarningCount === "number") {
             behaviorWarningCount = entry.behaviorWarningCount;
           }
+          if (typeof entry.signalBundle?.issueCount === "number") {
+            signalBundleIssueCount = entry.signalBundle.issueCount;
+          }
         }
       } catch {
         /* no cost data */
@@ -313,6 +355,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         obligationStatus,
         unmetRequiredOutputsCount,
         behaviorWarningCount,
+        signalBundleIssueCount,
         stale,
         consecutiveFailures: agentState.consecutiveFailures,
         totalWakes: agentState.totalWakes,
@@ -346,6 +389,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           obligationStatus: null,
           unmetRequiredOutputsCount: null,
           behaviorWarningCount: null,
+          signalBundleIssueCount: null,
           stale: true,
           consecutiveFailures: 0,
           totalWakes: 0,
@@ -364,6 +408,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           shadowCostUsdFormatted?: string | null;
         };
         subscriptionCli?: { permissionMode?: string };
+        signalBundle?: { issueCount?: number; totalSignals?: number };
       };
       const lastWake = entry.finishedAt ? new Date(entry.finishedAt) : null;
       const stale = lastWake ? Date.now() - lastWake.getTime() > 48 * 3600 * 1000 : true;
@@ -389,6 +434,8 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
         behaviorWarningCount: null,
+        signalBundleIssueCount:
+          typeof entry.signalBundle?.issueCount === "number" ? entry.signalBundle.issueCount : null,
         stale,
         consecutiveFailures: 0,
         totalWakes: 0,
@@ -410,6 +457,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
         obligationStatus: null,
         unmetRequiredOutputsCount: null,
         behaviorWarningCount: null,
+        signalBundleIssueCount: null,
         stale: true,
         consecutiveFailures: 0,
         totalWakes: 0,


### PR DESCRIPTION
## Summary

- New optional `signalBundle: { issueCount, totalSignals }` field on every `index.jsonl` entry, computed at wake fire time from the assembled `SignalBundle`
- New `signals.spikeThreshold` knob in `murmuration/harness.yaml` (default 10)
- New `[b:N]` badge in the TUI agents panel — yellow when the agent's last wake exceeded the threshold, dim otherwise

Closes scope 2 of #394. Scope 3 (`murmuration sweep` / `list-stale-issues`) follows in its own PR.

## Why

Per #394: every open GitHub issue lands in every watching agent's SignalBundle on every wake. Operators today have no visibility into which agents are eating the most context — the bundle size is computed and logged at fire time but nothing persists it. This PR makes that load surface in the dashboard's existing badge row, so an agent bloated by stale issues stands out at a glance.

## Implementation notes

- `RunArtifactIndexEntry.signalBundle` is **optional** — legacy entries written before this change remain readable. SchemaVersion stays at 1 (additive).
- Daemon computes the metric from `context.signals.signals` (already in scope at the record callsite); no new aggregator changes.
- Dashboard reads the threshold via a scoped regex on `harness.yaml`, matching the existing convention in `data.ts` (role.md frontmatter is read the same way). Avoids adding a YAML dep to dashboard-tui just for one field.
- The CLI's Zod-validated loader remains the runtime source of truth — the dashboard's reader exists only so the TUI can highlight spikes without booting boot.ts.

## Test plan

- [x] `pnpm run typecheck` — clean across all 8 packages (including the test-fixture default I had to add)
- [x] `pnpm run test` — 1266 pass (+2 new in `runs.test.ts`)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [ ] Run dashboard against an agent with > 10 issue signals to eyeball the yellow `[b:N]` badge (worth a quick verify in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)