### PR TITLE
feat(cli): list-stale-issues read-only sweep command (#394 scope 3)

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -267,6 +267,8 @@ Usage:
   murmuration init [dir]                Create a new murmuration (interactive)
   murmuration init --example <name> [dir]  Scaffold a bundled example (e.g. hello)
   murmuration doctor [--live] [--fix] [--json]  Diagnose a murmuration's setup
+  murmuration list-stale-issues [--days N] [--silence-days N] [--digest-only] [--json]
+                                        List open GitHub issues bloating the signal bundle
   murmuration directive [options] "msg" Send a directive to agents/groups
   murmuration directive --list          Show all directives and responses
   murmuration convene [options]        Convene a group meeting (on demand)
@@ -496,6 +498,25 @@ const main = async (): Promise<void> => {
         live: liveFlag,
         fix: fixFlag,
         json: jsonFlag,
+      });
+      process.exit(exitCode);
+      break;
+    }
+    case "list-stale-issues": {
+      const { runListStaleIssuesCli } = await import("./list-stale-issues.js");
+      const rest = argv.slice(1);
+      const daysIdx = rest.indexOf("--days");
+      const silenceIdx = rest.indexOf("--silence-days");
+      const ageDays = daysIdx >= 0 ? Number(rest[daysIdx + 1]) : undefined;
+      const silenceDays = silenceIdx >= 0 ? Number(rest[silenceIdx + 1]) : undefined;
+      const exitCode = await runListStaleIssuesCli({
+        rootDir: resolveRoot(rest),
+        ...(Number.isFinite(ageDays) && ageDays !== undefined && ageDays >= 1 ? { ageDays } : {}),
+        ...(Number.isFinite(silenceDays) && silenceDays !== undefined && silenceDays >= 1
+          ? { silenceDays }
+          : {}),
+        digestOnly: rest.includes("--digest-only"),
+        json: rest.includes("--json"),
       });
       process.exit(exitCode);
       break;

--- a/packages/cli/src/list-stale-issues.test.ts
+++ b/packages/cli/src/list-stale-issues.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyStaleIssues, type StaleScanCandidate } from "./list-stale-issues.js";
+
+describe("classifyStaleIssues (harness#394 scope 3)", () => {
+  const NOW = new Date("2026-05-25T12:00:00Z");
+  const daysAgo = (days: number): Date => new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+  const issue = (
+    overrides: Partial<StaleScanCandidate> & { number: number; title: string },
+  ): StaleScanCandidate => ({
+    number: overrides.number,
+    title: overrides.title,
+    htmlUrl: overrides.htmlUrl ?? `https://example/${String(overrides.number)}`,
+    createdAt: overrides.createdAt ?? daysAgo(1),
+    updatedAt: overrides.updatedAt ?? daysAgo(1),
+  });
+
+  it("flags issues older than the age threshold with no recent activity", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({
+          number: 1,
+          title: "Old + silent",
+          createdAt: daysAgo(30),
+          updatedAt: daysAgo(10),
+        }),
+        issue({
+          number: 2,
+          title: "Old but commented recently",
+          createdAt: daysAgo(30),
+          updatedAt: daysAgo(2),
+        }),
+        issue({ number: 3, title: "Brand new" }),
+      ],
+      { now: NOW },
+    );
+    expect(stale.map((s) => s.number)).toEqual([1]);
+    expect(stale[0]?.reason).toBe("by-age");
+  });
+
+  it("flags digest-pattern titles regardless of age", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({ number: 10, title: "[FINANCE] Weekly burn" }),
+        issue({ number: 11, title: "DIGEST: catch-up" }),
+        issue({ number: 12, title: "Real work item" }),
+        issue({ number: 13, title: "[Status] Sprint update" }),
+        issue({ number: 14, title: "[KICKOFF] new initiative" }),
+      ],
+      { now: NOW },
+    );
+    expect(stale.map((s) => s.number).sort((a, b) => a - b)).toEqual([10, 11, 13, 14]);
+    for (const s of stale) expect(s.reason).toBe("digest-pattern");
+  });
+
+  it("marks both reasons when an issue is digest-patterned AND stale", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({
+          number: 20,
+          title: "[DIGEST] 2026-02 monthly",
+          createdAt: daysAgo(90),
+          updatedAt: daysAgo(45),
+        }),
+      ],
+      { now: NOW },
+    );
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe("both");
+  });
+
+  it("respects custom age / silence thresholds", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({
+          number: 30,
+          title: "5 days old, silent",
+          createdAt: daysAgo(5),
+          updatedAt: daysAgo(3),
+        }),
+      ],
+      { now: NOW, ageDays: 3, silenceDays: 2 },
+    );
+    expect(stale).toHaveLength(1);
+  });
+
+  it("--digest-only filters out by-age-only matches", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({
+          number: 40,
+          title: "Old + silent, plain title",
+          createdAt: daysAgo(30),
+          updatedAt: daysAgo(10),
+        }),
+        issue({
+          number: 41,
+          title: "[DIGEST] recent",
+          createdAt: daysAgo(1),
+          updatedAt: daysAgo(1),
+        }),
+      ],
+      { now: NOW, digestOnly: true },
+    );
+    expect(stale.map((s) => s.number)).toEqual([41]);
+  });
+
+  it("sorts oldest-silence first so the most urgent review surface bubbles up", () => {
+    const stale = classifyStaleIssues(
+      [
+        issue({
+          number: 50,
+          title: "Silent 30d",
+          createdAt: daysAgo(60),
+          updatedAt: daysAgo(30),
+        }),
+        issue({
+          number: 51,
+          title: "Silent 90d",
+          createdAt: daysAgo(120),
+          updatedAt: daysAgo(90),
+        }),
+        issue({
+          number: 52,
+          title: "Silent 15d",
+          createdAt: daysAgo(45),
+          updatedAt: daysAgo(15),
+        }),
+      ],
+      { now: NOW },
+    );
+    expect(stale.map((s) => s.number)).toEqual([51, 50, 52]);
+  });
+});

--- a/packages/cli/src/list-stale-issues.ts
+++ b/packages/cli/src/list-stale-issues.ts
@@ -1,0 +1,333 @@
+/**
+ * `murmuration list-stale-issues` — read-only inventory of open GitHub
+ * issues bloating every watching agent's SignalBundle.
+ *
+ * harness#394 scope 3: the diagnostic sibling of the `murmuration doctor`
+ * hygiene check (scope 1). Where doctor surfaces "you have N stale
+ * issues" as a single line in the report, this command lists them
+ * outright so an operator can decide what to close. Replaces the manual
+ * `python + gh issue close` loop run on 2026-05-21.
+ *
+ * Closure is NOT in scope (operator judgement on each issue). A
+ * `--close` mutation flag is a separate, deliberate follow-up.
+ *
+ * Output:
+ *   - Default: human-readable table (number, age, last-activity, reason, title)
+ *   - `--json`: machine-readable array for scripting
+ */
+
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { loadHarnessConfig } from "./harness-config.js";
+
+// ---------------------------------------------------------------------------
+// Heuristics (duplicates doctor.ts scope-1 classifier; intentional —
+// the two PRs ship independently and can be deduped in a follow-up.)
+// ---------------------------------------------------------------------------
+
+const DIGEST_TITLE_PATTERNS: readonly RegExp[] = [
+  /^\s*\[?\s*DIGEST\s*\]?/i,
+  /^\s*\[?\s*FINANCE\s*\]?/i,
+  /^\s*\[?\s*STATUS\s*\]?/i,
+  /^\s*\[?\s*REPORT\s*\]?/i,
+  /^\s*\[?\s*KICKOFF\s*\]?/i,
+];
+
+const DEFAULT_AGE_DAYS = 14;
+const DEFAULT_SILENCE_DAYS = 7;
+
+export type StaleReason = "by-age" | "digest-pattern" | "both";
+
+export interface StaleIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly htmlUrl: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly ageDays: number;
+  readonly silenceDays: number;
+  readonly reason: StaleReason;
+}
+
+export interface StaleScanOptions {
+  /** Age threshold in days (default 14). */
+  readonly ageDays?: number;
+  /** Comment-silence threshold in days (default 7). */
+  readonly silenceDays?: number;
+  /** When true, return only digest-pattern matches (skip by-age-only). */
+  readonly digestOnly?: boolean;
+  /** Clock override for tests. */
+  readonly now?: Date;
+}
+
+/** Pure classifier — given a list of open issues, partition into the
+ *  stale set. Exported so tests don't need an HTTP fixture. */
+export const classifyStaleIssues = (
+  issues: readonly StaleScanCandidate[],
+  options: StaleScanOptions = {},
+): readonly StaleIssue[] => {
+  const ageDays = options.ageDays ?? DEFAULT_AGE_DAYS;
+  const silenceDays = options.silenceDays ?? DEFAULT_SILENCE_DAYS;
+  const now = options.now ?? new Date();
+  const nowMs = now.getTime();
+  const ageThresholdMs = ageDays * 24 * 60 * 60 * 1000;
+  const silenceThresholdMs = silenceDays * 24 * 60 * 60 * 1000;
+
+  const out: StaleIssue[] = [];
+  for (const issue of issues) {
+    const ageMs = nowMs - issue.createdAt.getTime();
+    const silenceMs = nowMs - issue.updatedAt.getTime();
+    const stalledByAge = ageMs > ageThresholdMs && silenceMs > silenceThresholdMs;
+    const matchesDigest = DIGEST_TITLE_PATTERNS.some((p) => p.test(issue.title));
+    if (!stalledByAge && !matchesDigest) continue;
+    if (options.digestOnly && !matchesDigest) continue;
+    const reason: StaleReason =
+      stalledByAge && matchesDigest ? "both" : stalledByAge ? "by-age" : "digest-pattern";
+    out.push({
+      number: issue.number,
+      title: issue.title,
+      htmlUrl: issue.htmlUrl,
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+      ageDays: Math.floor(ageMs / (24 * 60 * 60 * 1000)),
+      silenceDays: Math.floor(silenceMs / (24 * 60 * 60 * 1000)),
+      reason,
+    });
+  }
+  // Sort: oldest activity first (most urgent to review).
+  return out.sort((a, b) => b.silenceDays - a.silenceDays);
+};
+
+// ---------------------------------------------------------------------------
+// GitHub fetch (same shape as doctor.ts; capped pagination)
+// ---------------------------------------------------------------------------
+
+export interface StaleScanCandidate {
+  readonly number: number;
+  readonly title: string;
+  readonly htmlUrl: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+interface RestIssueResponse {
+  readonly number: number;
+  readonly title: string;
+  readonly html_url: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly pull_request?: unknown;
+}
+
+const withTimeout = async <T>(promise: Promise<T>, ms: number, what: string): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => {
+        reject(new Error(`timed out (${String(ms)}ms): ${what}`));
+      }, ms),
+    ),
+  ]);
+};
+
+const splitRepo = (repo: string): { owner: string; name: string } | null => {
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || slash === repo.length - 1) return null;
+  return { owner: repo.slice(0, slash), name: repo.slice(slash + 1) };
+};
+
+const fetchOpenIssues = async (
+  repo: string,
+  token: string,
+): Promise<readonly StaleScanCandidate[]> => {
+  const parts = splitRepo(repo);
+  if (!parts) throw new Error(`invalid collaboration.repo: "${repo}" (expected "owner/name")`);
+  const collected: StaleScanCandidate[] = [];
+  const maxPages = 5;
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `https://api.github.com/repos/${parts.owner}/${parts.name}/issues?state=open&per_page=100&page=${String(page)}`;
+    const res = await withTimeout(
+      fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "murmuration-list-stale-issues",
+        },
+      }),
+      10_000,
+      `GitHub GET /issues page ${String(page)}`,
+    );
+    if (!res.ok) {
+      throw new Error(`${String(res.status)} ${res.statusText}`);
+    }
+    const body: unknown = await res.json();
+    if (!Array.isArray(body)) break;
+    const items = body as RestIssueResponse[];
+    for (const it of items) {
+      if (it.pull_request !== undefined) continue;
+      collected.push({
+        number: it.number,
+        title: it.title,
+        htmlUrl: it.html_url,
+        createdAt: new Date(it.created_at),
+        updatedAt: new Date(it.updated_at),
+      });
+    }
+    if (items.length < 100) break;
+  }
+  return collected;
+};
+
+// ---------------------------------------------------------------------------
+// .env reader (same shape as doctor.ts; small enough to inline)
+// ---------------------------------------------------------------------------
+
+const parseDotEnv = (content: string): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    map.set(key, value);
+  }
+  return map;
+};
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+export interface ListStaleIssuesOptions extends StaleScanOptions {
+  readonly rootDir: string;
+  readonly json?: boolean;
+}
+
+export interface ListStaleIssuesReport {
+  readonly repo: string;
+  readonly scannedAt: string;
+  readonly thresholdDays: { readonly age: number; readonly silence: number };
+  readonly issues: readonly StaleIssue[];
+}
+
+/** Library entry — returns a structured report or throws on
+ *  configuration errors. The CLI wrapper handles formatting. */
+export const runListStaleIssues = async (
+  options: ListStaleIssuesOptions,
+): Promise<ListStaleIssuesReport> => {
+  const rootDir = resolve(options.rootDir);
+  const harness = await loadHarnessConfig(rootDir);
+  if (harness.collaboration.provider !== "github") {
+    throw new Error(
+      `list-stale-issues requires collaboration.provider: "github" (current: ${harness.collaboration.provider}). Local-mode murmurations have no GitHub issues to scan.`,
+    );
+  }
+  const repo = harness.collaboration.repo;
+  if (!repo) {
+    throw new Error(
+      `collaboration.repo not configured in murmuration/harness.yaml. Set it to "owner/name" so the scan knows where to look.`,
+    );
+  }
+  const envPath = join(rootDir, ".env");
+  if (!existsSync(envPath)) {
+    throw new Error(`.env not found at ${envPath}. Cannot authenticate to GitHub without a token.`);
+  }
+  const env = parseDotEnv(await readFile(envPath, "utf8"));
+  const token = env.get("GITHUB_TOKEN");
+  if (!token || token.length === 0 || token === "ghp_your-token-here") {
+    throw new Error(`GITHUB_TOKEN is not set in .env. Cannot authenticate.`);
+  }
+  const issues = await fetchOpenIssues(repo, token);
+  const stale = classifyStaleIssues(issues, options);
+  return {
+    repo,
+    scannedAt: (options.now ?? new Date()).toISOString(),
+    thresholdDays: {
+      age: options.ageDays ?? DEFAULT_AGE_DAYS,
+      silence: options.silenceDays ?? DEFAULT_SILENCE_DAYS,
+    },
+    issues: stale,
+  };
+};
+
+const formatTable = (report: ListStaleIssuesReport): string => {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`Stale open issues in ${report.repo}`);
+  lines.push(
+    `  thresholds: age > ${String(report.thresholdDays.age)}d, silence > ${String(report.thresholdDays.silence)}d`,
+  );
+  lines.push("");
+  if (report.issues.length === 0) {
+    lines.push("  (no stale issues found — your signal bundle is clean)");
+    lines.push("");
+    return lines.join("\n");
+  }
+  // Column widths sized to typical 80-col terminal.
+  const reasonLabel: Record<StaleReason, string> = {
+    "by-age": "age",
+    "digest-pattern": "digest",
+    both: "age+digest",
+  };
+  for (const issue of report.issues) {
+    const num = `#${String(issue.number)}`.padEnd(6);
+    const age = `${String(issue.ageDays)}d`.padStart(5);
+    const silence = `${String(issue.silenceDays)}d`.padStart(5);
+    const reason = reasonLabel[issue.reason].padEnd(11);
+    const title = issue.title.length > 50 ? `${issue.title.slice(0, 47)}...` : issue.title;
+    lines.push(`  ${num} age:${age}  silent:${silence}  ${reason}  ${title}`);
+  }
+  lines.push("");
+  lines.push(`  ${String(report.issues.length)} stale issue(s).`);
+  lines.push(
+    `  Review and close once consumed; see docs/CONVENTIONS-GITHUB-VS-FILES.md for the rationale.`,
+  );
+  lines.push("");
+  return lines.join("\n");
+};
+
+export const runListStaleIssuesCli = async (options: ListStaleIssuesOptions): Promise<number> => {
+  let report: ListStaleIssuesReport;
+  try {
+    report = await runListStaleIssues(options);
+  } catch (err) {
+    console.error(`list-stale-issues: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          repo: report.repo,
+          scannedAt: report.scannedAt,
+          thresholdDays: report.thresholdDays,
+          issues: report.issues.map((i) => ({
+            number: i.number,
+            title: i.title,
+            htmlUrl: i.htmlUrl,
+            createdAt: i.createdAt.toISOString(),
+            updatedAt: i.updatedAt.toISOString(),
+            ageDays: i.ageDays,
+            silenceDays: i.silenceDays,
+            reason: i.reason,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(formatTable(report));
+  }
+  return 0;
+};


### PR DESCRIPTION
## Summary

- New `murmuration list-stale-issues` command that inventories open GitHub issues bloating every watching agent's SignalBundle
- Read-only by design — closure remains operator judgement (no `--close` in this PR; the issue explicitly called that out-of-scope)
- Flags: `--days N`, `--silence-days N`, `--digest-only`, `--json`
- Output: aligned table sorted oldest-silence-first, or full JSON for scripting

Closes scope 3 of #394. With #399 (scope 1) and #400 (scope 2), all three acceptance items in the parent issue have shipping PRs.

## Example

```
$ murmuration list-stale-issues
Stale open issues in xeeban/emergent-praxis
  thresholds: age > 14d, silence > 7d

  #142   age:  62d  silent:  45d  both         [DIGEST] 2026-Q1 catch-up
  #138   age:  47d  silent:  30d  digest       [FINANCE] Weekly burn 2026-04-...
  #129   age:  90d  silent:  15d  age          Old refactor proposal — should...

  3 stale issue(s).
  Review and close once consumed; see docs/CONVENTIONS-GITHUB-VS-FILES.md.
```

## Why

Per #394: every open GitHub issue lands in every watching agent's SignalBundle on every wake. The manual cleanup loop run on 2026-05-21 (python + `gh issue close`, closed 16 issues) cut per-wake input tokens by 20–40% on a 6-agent murmuration. This command makes the inventory step a single subcommand so operators don't have to rediscover the pattern.

## Implementation notes

- Heuristic classifier duplicates the doctor scope-1 classifier (PR #399) intentionally — the two PRs ship independently, and one small function + a regex table is cheaper than coordinating a stack. A follow-up can extract a shared module once both land.
- Pagination capped at 5 pages (500 issues) — same bound as doctor's hygiene scan.
- Same digest title pattern set as scope 1: `DIGEST` / `FINANCE` / `STATUS` / `REPORT` / `KICKOFF` (case-insensitive, optional brackets).
- Errors surface to stderr with a clear remediation message and exit code 1 (mirrors the doctor pattern).

## Test plan

- [x] `pnpm run typecheck` — clean across all 8 packages
- [x] `pnpm run test` — 1270 pass (+6 new for the classifier)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [ ] Live run against an EP-style repo to confirm the table renders cleanly at typical terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)