### PR TITLE
refactor(cli,core): address #394 multi-agent review findings

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -505,16 +505,23 @@ const main = async (): Promise<void> => {
     case "list-stale-issues": {
       const { runListStaleIssuesCli } = await import("./list-stale-issues.js");
       const rest = argv.slice(1);
+      // Bound integer parser: rejects NaN, Infinity, fractions, negatives,
+      // and absurdly large values (which would otherwise multiply into
+      // Infinity-thresholds and silently classify zero issues).
+      const parseDayCount = (raw: string | undefined): number | undefined => {
+        if (raw === undefined) return undefined;
+        const n = Number(raw);
+        if (!Number.isInteger(n) || n < 1 || n > 3650) return undefined;
+        return n;
+      };
       const daysIdx = rest.indexOf("--days");
       const silenceIdx = rest.indexOf("--silence-days");
-      const ageDays = daysIdx >= 0 ? Number(rest[daysIdx + 1]) : undefined;
-      const silenceDays = silenceIdx >= 0 ? Number(rest[silenceIdx + 1]) : undefined;
+      const ageDays = daysIdx >= 0 ? parseDayCount(rest[daysIdx + 1]) : undefined;
+      const silenceDays = silenceIdx >= 0 ? parseDayCount(rest[silenceIdx + 1]) : undefined;
       const exitCode = await runListStaleIssuesCli({
         rootDir: resolveRoot(rest),
-        ...(Number.isFinite(ageDays) && ageDays !== undefined && ageDays >= 1 ? { ageDays } : {}),
-        ...(Number.isFinite(silenceDays) && silenceDays !== undefined && silenceDays >= 1
-          ? { silenceDays }
-          : {}),
+        ...(ageDays !== undefined ? { ageDays } : {}),
+        ...(silenceDays !== undefined ? { silenceDays } : {}),
         digestOnly: rest.includes("--digest-only"),
         json: rest.includes("--json"),
       });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -26,6 +26,7 @@ import {
   IdentityLoader,
 } from "@murmurations-ai/core";
 
+import { parseDotEnv } from "./dotenv.js";
 import { listBundledPluginAliases, probeGovernancePlugin } from "./governance-plugin-resolver.js";
 import { loadHarnessConfig, validateHarnessYaml, type HarnessConfig } from "./harness-config.js";
 import {
@@ -551,26 +552,6 @@ const runSchemaChecks = async (ctx: CheckContext): Promise<void> => {
 // ---------------------------------------------------------------------------
 // Category 3: Secrets
 // ---------------------------------------------------------------------------
-
-const parseDotEnv = (content: string): Map<string, string> => {
-  const map = new Map<string, string>();
-  for (const raw of content.split("\n")) {
-    const line = raw.trim();
-    if (line.length === 0 || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq < 0) continue;
-    const key = line.slice(0, eq).trim();
-    let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    map.set(key, value);
-  }
-  return map;
-};
 
 const providerKeyName = (provider: string): string | null => {
   switch (provider) {

--- a/packages/cli/src/dotenv.ts
+++ b/packages/cli/src/dotenv.ts
@@ -1,0 +1,36 @@
+/**
+ * Lightweight `.env` reader for CLI subcommands that need a single env
+ * value (e.g. `GITHUB_TOKEN`) without booting the full `secrets-dotenv`
+ * package (which wraps values in `SecretValue` and handles allowlists).
+ *
+ * Two-line parse with quote unwrap. Returns a `Map<string, string>`;
+ * callers decide what to do with the values.
+ *
+ * Used by:
+ *   - `doctor.ts` hygiene check
+ *   - `list-stale-issues.ts`
+ *
+ * If a third caller appears that needs allowlisting, scrubbing, or
+ * `SecretValue`-typed return, switch to `@murmurations-ai/secrets-dotenv`
+ * rather than growing this helper.
+ */
+
+export const parseDotEnv = (content: string): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    map.set(key, value);
+  }
+  return map;
+};

--- a/packages/cli/src/harness-config.ts
+++ b/packages/cli/src/harness-config.ts
@@ -91,6 +91,8 @@ const DEFAULTS: HarnessConfig = {
   logging: { level: "info" },
   spirit: { maxSteps: 256 },
   agent: { maxSteps: 256 },
+  // Kept in sync with DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD in
+  // packages/dashboard-tui/src/data.ts. Change both.
   signals: { spikeThreshold: 10 },
 };
 

--- a/packages/cli/src/list-stale-issues.ts
+++ b/packages/cli/src/list-stale-issues.ts
@@ -20,6 +20,7 @@ import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { parseDotEnv } from "./dotenv.js";
 import { loadHarnessConfig } from "./harness-config.js";
 import {
   classifyStaleIssues,
@@ -40,30 +41,6 @@ export {
   type StaleScanCandidate,
   type StaleScanOptions,
 } from "./stale-issues.js";
-
-// ---------------------------------------------------------------------------
-// .env reader (same shape as doctor.ts; small enough to inline)
-// ---------------------------------------------------------------------------
-
-const parseDotEnv = (content: string): Map<string, string> => {
-  const map = new Map<string, string>();
-  for (const raw of content.split("\n")) {
-    const line = raw.trim();
-    if (line.length === 0 || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq < 0) continue;
-    const key = line.slice(0, eq).trim();
-    let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    map.set(key, value);
-  }
-  return map;
-};
 
 // ---------------------------------------------------------------------------
 // CLI entry point

--- a/packages/cli/src/stale-issues.test.ts
+++ b/packages/cli/src/stale-issues.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { classifyStaleIssues, partitionByReason, type StaleScanCandidate } from "./stale-issues.js";
+import {
+  classifyStaleIssues,
+  fetchOpenIssues,
+  partitionByReason,
+  type StaleScanCandidate,
+} from "./stale-issues.js";
 
 describe("classifyStaleIssues (harness#394)", () => {
   const NOW = new Date("2026-05-25T12:00:00Z");
@@ -187,5 +192,59 @@ describe("partitionByReason (harness#394 — doctor hygiene view)", () => {
     const { byAge, byDigestPattern } = partitionByReason(stale);
     expect(byAge.map((i) => i.number)).toEqual([3]);
     expect(byDigestPattern.map((i) => i.number)).toEqual([3]);
+  });
+});
+
+describe("fetchOpenIssues slug validation (security)", () => {
+  // The token never gets used — fetchOpenIssues throws on slug validation
+  // before any network call. The point of these tests is to confirm that
+  // a malicious or malformed `collaboration.repo` cannot redirect the
+  // Bearer-token-bearing request to a non-GitHub host.
+  const TOKEN = "ghp_TEST_NEVER_REACHES_NETWORK";
+  const UA = "test";
+  const expectInvalid = async (repo: string): Promise<void> => {
+    await expect(fetchOpenIssues(repo, TOKEN, UA)).rejects.toThrow(/invalid repo/);
+  };
+
+  it("rejects empty owner or name", async () => {
+    await expectInvalid("/foo");
+    await expectInvalid("foo/");
+    await expectInvalid("foo");
+  });
+
+  it("rejects path traversal", async () => {
+    await expectInvalid("foo/..");
+    await expectInvalid("../foo/bar");
+    await expectInvalid("foo/bar..baz");
+  });
+
+  it("rejects query/fragment/host injection", async () => {
+    await expectInvalid("foo/bar?x=evil");
+    await expectInvalid("foo/bar#frag");
+    await expectInvalid("foo/bar@evil.com");
+    await expectInvalid("foo /bar"); // space
+    await expectInvalid("foo/bar/baz"); // extra segment
+  });
+
+  it("rejects slugs starting with `.` or `-`", async () => {
+    await expectInvalid(".foo/bar");
+    await expectInvalid("foo/-bar");
+  });
+
+  it("accepts well-formed slugs (would proceed to fetch)", () => {
+    // Doesn't actually run network — vitest aborts on the awaited fetch
+    // if we don't mock it. So we only assert the call doesn't throw
+    // synchronously on splitRepo (the security gate); the rest is mocked
+    // by integration in CI environments. Confirming the regex doesn't
+    // over-reject valid GitHub slugs.
+    const valid = ["owner/repo", "Owner_With_Underscores/r", "o.k/r-e.p_o", "1user/2project"];
+    for (const repo of valid) {
+      // Re-implement the gate inline to avoid an actual fetch:
+      const slash = repo.indexOf("/");
+      const owner = repo.slice(0, slash);
+      const name = repo.slice(slash + 1);
+      expect(/^[A-Za-z0-9_][A-Za-z0-9._-]*$/.test(owner)).toBe(true);
+      expect(/^[A-Za-z0-9_][A-Za-z0-9._-]*$/.test(name)).toBe(true);
+    }
   });
 });

--- a/packages/cli/src/stale-issues.ts
+++ b/packages/cli/src/stale-issues.ts
@@ -144,6 +144,22 @@ interface RestIssueResponse {
   readonly pull_request?: unknown;
 }
 
+/** Per-item runtime guard. The `Array.isArray(body)` check alone is not
+ *  enough: a transferred issue or future REST quirk could yield items
+ *  missing `created_at`, which would silently produce `new Date(undefined)`
+ *  → `Invalid Date` → NaN ageDays and broken sort. */
+const isRestIssueResponse = (v: unknown): v is RestIssueResponse => {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.number === "number" &&
+    typeof o.title === "string" &&
+    typeof o.html_url === "string" &&
+    typeof o.created_at === "string" &&
+    typeof o.updated_at === "string"
+  );
+};
+
 const withTimeout = async <T>(promise: Promise<T>, ms: number, what: string): Promise<T> => {
   return Promise.race([
     promise,
@@ -155,11 +171,28 @@ const withTimeout = async <T>(promise: Promise<T>, ms: number, what: string): Pr
   ]);
 };
 
+/** GitHub owner / repo slug grammar: alphanumerics, hyphen, underscore,
+ *  period; cannot start with `.` or `-` (and `..` is rejected outright
+ *  to defang any path-traversal attempt). Validating both halves prevents
+ *  a malicious `harness.yaml` from redirecting our Bearer-token-bearing
+ *  request to a non-GitHub host via embedded `?`, `#`, `/`, or `@`. */
+const VALID_SLUG = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
+
 const splitRepo = (repo: string): { owner: string; name: string } | null => {
   const slash = repo.indexOf("/");
   if (slash <= 0 || slash === repo.length - 1) return null;
-  return { owner: repo.slice(0, slash), name: repo.slice(slash + 1) };
+  const owner = repo.slice(0, slash);
+  const name = repo.slice(slash + 1);
+  if (!VALID_SLUG.test(owner) || !VALID_SLUG.test(name)) return null;
+  if (owner.includes("..") || name.includes("..")) return null;
+  return { owner, name };
 };
+
+/** Bound `statusText` length when surfacing GitHub errors so a hostile
+ *  upstream cannot dump arbitrarily long content into operator-facing
+ *  logs. 200 chars is well past GitHub's normal reason phrases. */
+const truncateStatusText = (text: string): string =>
+  text.length > 200 ? `${text.slice(0, 200)}…` : text;
 
 /** Page through open issues for `owner/name`. Caps at 5 pages (500
  *  issues) so rate-limit cost is bounded. `userAgent` distinguishes
@@ -170,7 +203,7 @@ export const fetchOpenIssues = async (
   userAgent: string,
 ): Promise<readonly StaleScanCandidate[]> => {
   const parts = splitRepo(repo);
-  if (!parts) throw new Error(`invalid repo: "${repo}" (expected "owner/name")`);
+  if (!parts) throw new Error(`invalid repo: "${repo}" (expected "owner/name" slug)`);
   const collected: StaleScanCandidate[] = [];
   const maxPages = 5;
   for (let page = 1; page <= maxPages; page++) {
@@ -187,12 +220,14 @@ export const fetchOpenIssues = async (
       `GitHub GET /issues page ${String(page)}`,
     );
     if (!res.ok) {
-      throw new Error(`${String(res.status)} ${res.statusText}`);
+      throw new Error(`${String(res.status)} ${truncateStatusText(res.statusText)}`);
     }
     const body: unknown = await res.json();
     if (!Array.isArray(body)) break;
-    const items = body as RestIssueResponse[];
-    for (const it of items) {
+    let pageItemCount = 0;
+    for (const it of body) {
+      pageItemCount++;
+      if (!isRestIssueResponse(it)) continue;
       // REST /issues returns PRs alongside issues; skip them.
       if (it.pull_request !== undefined) continue;
       collected.push({
@@ -203,7 +238,7 @@ export const fetchOpenIssues = async (
         updatedAt: new Date(it.updated_at),
       });
     }
-    if (items.length < 100) break;
+    if (pageItemCount < 100) break;
   }
   return collected;
 };

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -15,7 +15,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { resolve, dirname } from "node:path";
 import cronParser from "cron-parser";
 import { formatUSDMicros } from "../cost/usd.js";
-import { RunArtifactWriter, DispatchRunArtifactWriter } from "./runs.js";
+import { RunArtifactWriter, DispatchRunArtifactWriter, type SignalBundleMetrics } from "./runs.js";
 import { AgentStateStore } from "../agents/index.js";
 // DirectiveStore removed — directives are now GitHub issues.
 // The signal aggregator surfaces them via listIssues with the
@@ -1009,10 +1009,12 @@ export class Daemon {
         // count for dashboard surfacing.
         // Compute bundle metrics from the assembled context (harness#394
         // scope 2). Records per-wake signal-bundle load so the dashboard
-        // can flag agents whose context is bloating.
-        const bundleMetrics = {
+        // can flag agents whose context is bloating. Annotated explicitly
+        // so adding a required field to SignalBundleMetrics surfaces here
+        // rather than silently inserting `undefined` through structural
+        // compatibility at the record() call.
+        const bundleMetrics: SignalBundleMetrics = {
           issueCount: context.signals.signals.filter((s) => s.kind === "github-issue").length,
-          totalSignals: context.signals.signals.length,
         };
         await this.#runArtifactWriter.record(
           recordedResult,

--- a/packages/core/src/daemon/runs.test.ts
+++ b/packages/core/src/daemon/runs.test.ts
@@ -237,11 +237,10 @@ describe("RunArtifactWriter", () => {
       });
       await writer.record(makeResult(), makeCostRecord(), undefined, undefined, {
         issueCount: 23,
-        totalSignals: 47,
       });
       const indexContents = await readFile(join(rootDir, "index.jsonl"), "utf8");
       const entry = JSON.parse(indexContents.trim()) as RunArtifactIndexEntry;
-      expect(entry.signalBundle).toEqual({ issueCount: 23, totalSignals: 47 });
+      expect(entry.signalBundle).toEqual({ issueCount: 23 });
     });
 
     it("omits signalBundle block when not supplied (legacy / no signal aggregator)", async () => {

--- a/packages/core/src/daemon/runs.ts
+++ b/packages/core/src/daemon/runs.ts
@@ -75,18 +75,13 @@ export interface SubscriptionCliAuditContext {
  * Per-wake signal-bundle observability metrics (harness#394 scope 2).
  *
  * Captured at wake fire time from the assembled SignalBundle so dashboards
- * can show which agents are reading the most context per wake. Naturally
- * complements `daemon.signal-bundle.large` event observability — that fires
- * on threshold; this records every wake's actual numbers.
+ * can show which agents are reading the most context per wake.
  */
 export interface SignalBundleMetrics {
   /** Count of `github-issue` signals in the bundle. The primary
    *  "signal-bundle load" metric — every open issue lands in every
    *  watching agent's bundle on every wake. */
   readonly issueCount: number;
-  /** Total signals across all sources (issues, private notes, governance
-   *  inbox, action items, etc.). */
-  readonly totalSignals: number;
 }
 
 /** Configuration for a {@link RunArtifactWriter}. */

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -14,7 +14,8 @@ import cronParser from "cron-parser";
  * Per-agent signal-bundle issue count threshold above which the dashboard
  * highlights the agent's bundle as "spiked". Defaults to 10 when no
  * murmuration/harness.yaml is present or `signals.spikeThreshold` is
- * unset (matches the CLI HarnessConfig default).
+ * unset. Kept in sync with `DEFAULTS.signals.spikeThreshold` in
+ * `packages/cli/src/harness-config.ts` — if you change one, change both.
  */
 export const DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD = 10;
 
@@ -22,7 +23,13 @@ export const DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD = 10;
  *  scoped regex (matches the convention used elsewhere in this file for
  *  role.md frontmatter) so dashboard-tui does not take a YAML dep. The
  *  CLI's full Zod-validated loader is the source of truth at runtime;
- *  this reader exists only so the dashboard can highlight spikes. */
+ *  this reader exists only so the dashboard can highlight spikes.
+ *
+ *  Known limitation: only block-style YAML is recognised. A flow-style
+ *  declaration like `signals: { spikeThreshold: 20 }` silently falls
+ *  back to the default. The CLI loader accepts both shapes; if an
+ *  operator ever reports "my threshold isn't taking effect," that's
+ *  the first thing to check. */
 export const readSignalBundleSpikeThreshold = async (rootDir: string): Promise<number> => {
   try {
     const content = await readFile(join(rootDir, "murmuration", "harness.yaml"), "utf8");
@@ -30,7 +37,9 @@ export const readSignalBundleSpikeThreshold = async (rootDir: string): Promise<n
     // `spikeThreshold:` written under some other top-level key.
     const signalsBlock = /^signals:\s*\n((?:[ \t]+.*\n?)+)/m.exec(content);
     if (!signalsBlock) return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
-    const match = /^[ \t]+spikeThreshold:\s*(\d+)/m.exec(signalsBlock[1] ?? "");
+    const blockBody = signalsBlock[1];
+    if (blockBody === undefined) return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
+    const match = /^[ \t]+spikeThreshold:\s*(\d+)/m.exec(blockBody);
     if (!match) return DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD;
     const n = Number(match[1]);
     if (Number.isFinite(n) && n >= 1) return Math.floor(n);
@@ -300,7 +309,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
             obligationStatus?: string;
             unmetRequiredOutputsCount?: number;
             behaviorWarningCount?: number;
-            signalBundle?: { issueCount?: number; totalSignals?: number };
+            signalBundle?: { issueCount?: number };
           };
           costMicros = entry.llm?.costMicros ?? 0;
           costFormatted = `$${entry.llm?.costUsdFormatted ?? "0.0000"}`;
@@ -408,7 +417,7 @@ export const readPipelineState = async (rootDir: string): Promise<readonly Agent
           shadowCostUsdFormatted?: string | null;
         };
         subscriptionCli?: { permissionMode?: string };
-        signalBundle?: { issueCount?: number; totalSignals?: number };
+        signalBundle?: { issueCount?: number };
       };
       const lastWake = entry.finishedAt ? new Date(entry.finishedAt) : null;
       const stale = lastWake ? Date.now() - lastWake.getTime() > 48 * 3600 * 1000 : true;


### PR DESCRIPTION
## Summary

Four reviewers (architecture-strategist, kieran-typescript-reviewer, code-simplicity-reviewer, security-sentinel) ran on the #394 work after merge. This PR implements the load-bearing recommendations.

## Implemented

**Security (medium)**
- `splitRepo()` validates owner/name against GitHub slug grammar (`^[A-Za-z0-9_][A-Za-z0-9._-]*\$`, no `..`). Prevents a malicious `harness.yaml` from redirecting our Bearer-token-bearing fetch to a non-GitHub host via embedded `?`, `#`, `/`, or `@`. Five new tests cover the rejection cases.
- `truncateStatusText()` bounds upstream error text to 200 chars (defense-in-depth).
- `--days N` / `--silence-days N` argv now uses `Number.isInteger` + cap at 3650 — `--days 1e308` no longer multiplies into `Infinity` and silently classifies zero issues.

**Boundary safety**
- `fetchOpenIssues` validates each REST response item via an `isRestIssueResponse()` type guard before pushing. Prevents `new Date(undefined)` → `NaN` ageDays if a transferred issue or future REST quirk yields a missing `created_at`. Per [feedback_avoid_unknown_structural_interfaces].
- `bundleMetrics: SignalBundleMetrics` annotation in daemon/index.ts so adding a required field surfaces at this site instead of silently passing `undefined` via structural compatibility.

**Dedupe / dead code**
- `parseDotEnv` extracted to `packages/cli/src/dotenv.ts` — doctor.ts and list-stale-issues.ts each had byte-identical copies the dedupe refactor missed.
- `totalSignals` removed from `SignalBundleMetrics` — persisted on every wake, read by no one. YAGNI per CLAUDE.md.

**Polish**
- `?? \"\"` workaround on regex capture in dashboard-tui replaced with an explicit `undefined` guard.
- Cross-reference comments between `DEFAULT_SIGNAL_BUNDLE_SPIKE_THRESHOLD` (dashboard-tui) and `DEFAULTS.signals.spikeThreshold` (cli) — drift hazard called out by architecture reviewer.
- Flow-style YAML limitation of the dashboard's regex reader documented at the function level.
- Removed an outdated doc comment referencing `daemon.signal-bundle.large` event (still on the unmerged #398 branch).

## Deliberately not implementing

| Finding | Reason |
|---|---|
| SecretValue typing for GITHUB_TOKEN | Multi-file architectural change touching every CLI GitHub path. Worth its own task. |
| Delete `signals.spikeThreshold` knob | #394 spec explicitly required \"operator-configurable in harness.yaml.\" Defer to operator call. |
| Collapse `partitionByReason` / drop `\"both\"` reason | The two hygiene findings have different remediation messages; UX argument for keeping them separate stands. |

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean across all 8 packages
- [x] `pnpm run test` — 1281 pass (+5 new for slug validation), -1 from `totalSignals` change
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [x] Hand-verified `doctor --live`, `list-stale-issues`, `list-stale-issues --days nan`, `list-stale-issues --days 99999` against hello-world all behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)