### PR TITLE
feat(daemon): skip cron registration for orphaned agent directories (#380)

### DIFF
--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -20,7 +20,7 @@ import {
   type LoadedAgentIdentity,
 } from "@murmurations-ai/core";
 
-import { makeDaemonHook } from "./boot.js";
+import { isOrphanedSchedule, makeDaemonHook } from "./boot.js";
 
 describe("makeDaemonHook", () => {
   const builder = (): WakeCostBuilder =>
@@ -215,5 +215,80 @@ describe("registeredAgentFromLoadedIdentity — routing label wiring (QA #2, har
     // derived labels should NOT be present when operator overrides
     expect(anyLabel).not.toContain("scope:group:engineering");
     expect(anyLabel).not.toContain("assigned:agent-c");
+  });
+});
+
+describe("isOrphanedSchedule (harness#380)", () => {
+  const baseLoaded = (fallback?: LoadedAgentIdentity["fallback"]): LoadedAgentIdentity => ({
+    agentId: makeAgentId("test"),
+    chain: makeMinimalChain("test"),
+    frontmatter: roleFrontmatterSchema.parse({
+      agent_id: "test",
+      name: "test",
+      model_tier: "balanced",
+      group_memberships: [],
+      signals: { sources: ["github-issue"], github_scopes: [] },
+    }),
+    ...(fallback !== undefined ? { fallback } : {}),
+  });
+
+  it("returns false for a fully-loaded agent (no fallback)", () => {
+    expect(isOrphanedSchedule(baseLoaded())).toBe(false);
+  });
+
+  it("returns true when role.md is in the missing-files list", () => {
+    expect(
+      isOrphanedSchedule(
+        baseLoaded({
+          reason: "missing-files",
+          missingFiles: ["role.md"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when both role.md and soul.md are missing", () => {
+    expect(
+      isOrphanedSchedule(
+        baseLoaded({
+          reason: "missing-files",
+          missingFiles: ["soul.md", "role.md"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when only soul.md is missing (operator iterating)", () => {
+    expect(
+      isOrphanedSchedule(
+        baseLoaded({
+          reason: "missing-files",
+          missingFiles: ["soul.md"],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for missing-frontmatter fallback (role.md exists)", () => {
+    expect(
+      isOrphanedSchedule(
+        baseLoaded({
+          reason: "missing-frontmatter",
+          missingFiles: [],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for invalid-frontmatter fallback (role.md exists)", () => {
+    expect(
+      isOrphanedSchedule(
+        baseLoaded({
+          reason: "invalid-frontmatter",
+          missingFiles: [],
+          detail: "YAML parse failed",
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -48,6 +48,7 @@ export const sanitizeForTerminal = (s: string): string =>
 export class BootError extends Error {
   public readonly kind:
     | "incomplete-agent-single"
+    | "agent-missing-role"
     | "no-agents-found"
     | "governance-plugin-invalid"
     | "secrets-load-failed";
@@ -85,6 +86,7 @@ import {
   type BudgetCeiling,
   type CollaborationProvider,
   type DaemonConfig,
+  type LoadedAgentIdentity,
   type RegisteredAgent,
   type SecretDeclaration,
   type SecretKey,
@@ -222,6 +224,21 @@ const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
  * first time each pair is seen, with dedupe state held on the hook
  * instance so test wakes don't bleed into each other.
  */
+/**
+ * Predicate (harness#380): the agent's `role.md` was missing entirely
+ * and the loader synthesised a fallback identity from default-agent/.
+ *
+ * Distinguished from other fallback reasons (`missing-frontmatter`,
+ * `invalid-frontmatter`) which usually mean the operator is iterating
+ * on a partially-edited role.md — those keep the agent scheduled.
+ * A missing role.md, by contrast, means either the operator removed
+ * it deliberately or the directory was never finished; either way the
+ * cron entry should be suppressed so the agent doesn't quietly wake
+ * with template behaviour.
+ */
+export const isOrphanedSchedule = (loaded: LoadedAgentIdentity): boolean =>
+  loaded.fallback?.missingFiles.includes("role.md") ?? false;
+
 export const makeDaemonHook = (
   builder: WakeCostBuilder,
   logger?: { warn: (event: string, fields?: Record<string, unknown>) => void },
@@ -1039,10 +1056,32 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     })}\n`,
   );
 
-  // Load identities + build triggers for every agent.
+  // Load identities + build triggers for every agent. harness#380:
+  // when `role.md` is missing entirely, IdentityLoader falls back to
+  // the default-agent template — that's intentional for fresh scaffolding,
+  // but a daemon-startup *schedule* derived from a synthesized identity
+  // means the agent would wake on cron with template behaviour (drift).
+  // Skip the cron registration in that case and emit a visible warning
+  // so the operator notices the missing file. In single-agent mode
+  // (`--agent <id>`) the operator named this agent explicitly — fail
+  // hard instead of silently dropping the only requested agent.
   const allRegistered: RegisteredAgent[] = [];
   for (const agentDir of agentDirs) {
     const loaded = await loader.load(agentDir);
+    if (isOrphanedSchedule(loaded)) {
+      if (options.agentDir !== undefined) {
+        throw new BootError(
+          "agent-missing-role",
+          `murmuration: agent "${sanitizeForTerminal(agentDir)}" has no role.md — refusing to wake via the default-agent template. Add a role.md or remove the agent directory.`,
+        );
+      }
+      logger.warn("daemon.warn.orphaned-schedule", {
+        agentDir,
+        missingFiles: loaded.fallback?.missingFiles ?? [],
+        reason: loaded.fallback?.reason ?? "missing-files",
+      });
+      continue;
+    }
     const wakeSchedule = loaded.frontmatter.wake_schedule ?? { delayMs: EVENT_FALLBACK_DELAY_MS };
     const trigger: WakeTrigger = options.now
       ? { kind: "delay-once", delayMs: 100 }


### PR DESCRIPTION
## Summary

When an agent's `role.md` is missing entirely, `IdentityLoader` (ADR-0027) falls back to the `default-agent/` template. That's right for fresh scaffolding, but if the daemon then *schedules* a cron entry against that synthesised identity, the agent silently keeps waking with template behaviour. That's the silent drift EP#874 surfaced.

This PR makes the daemon detect orphaned agent directories at boot and refuse to schedule them.

## Behaviour

| Mode | Orphan detected → |
|---|---|
| Multi-agent boot | Emit `daemon.warn.orphaned-schedule`, skip the cron registration, continue with the agents that ARE fully configured |
| Single-agent boot (`--agent <id>`) | Throw `BootError(kind: "agent-missing-role")` — the operator named this agent explicitly; silently dropping the only requested agent would be worse than failing |

The detection is the new exported predicate `isOrphanedSchedule(loaded)`:

```ts
loaded.fallback?.missingFiles.includes("role.md") ?? false
```

The distinction matters: file-missing means "operator removed something or never finished"; frontmatter-broken (existing `missing-frontmatter` / `invalid-frontmatter` fallback reasons) means "operator is mid-edit." The first deserves skipping; the second keeps the existing `daemon.agent.fallback` warning and a chance to wake — preserving ADR-0027's scaffolding intent.

## Test plan

- [x] 6 new tests for `isOrphanedSchedule` covering all five fallback reasons + the happy path
- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean across all 8 packages
- [x] `pnpm run test` — 1291 pass (+6 new)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)