### PR TITLE
refactor(boot,core): address #404 multi-agent review findings

### DIFF
--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  isOrphanedSchedule,
   makeAgentId,
   makeWakeId,
   registeredAgentFromLoadedIdentity,
@@ -20,7 +21,7 @@ import {
   type LoadedAgentIdentity,
 } from "@murmurations-ai/core";
 
-import { isOrphanedSchedule, makeDaemonHook } from "./boot.js";
+import { makeDaemonHook, sanitizeForTerminal } from "./boot.js";
 
 describe("makeDaemonHook", () => {
   const builder = (): WakeCostBuilder =>
@@ -290,5 +291,47 @@ describe("isOrphanedSchedule (harness#380)", () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("sanitizeForTerminal (harness#380 review hardening)", () => {
+  it("strips C0 controls and DEL", () => {
+    expect(sanitizeForTerminal("a\x00b\x1bc\x7fd")).toBe("a?b?c?d");
+  });
+
+  it("strips C1 controls including 8-bit CSI (\\x9b)", () => {
+    // \x9b renders as ESC [ in xterm / Terminal.app — leaving it
+    // unfiltered would let a malicious dir name inject color/cursor codes.
+    expect(sanitizeForTerminal("a\x80b\x9bc\x9fd")).toBe("a?b?c?d");
+  });
+
+  it("strips Unicode bidi overrides (CVE-2021-42574 Trojan Source)", () => {
+    // U+202E (RIGHT-TO-LEFT OVERRIDE) is the classic Trojan Source primitive:
+    // a directory named `agent-‮dm.elor` renders as `agent-role.md`.
+    const tricked = "agent-‮dm.elor";
+    expect(sanitizeForTerminal(tricked)).toBe("agent-?dm.elor");
+    // Also covers isolates U+2066-U+2069.
+    expect(sanitizeForTerminal("⁦hidden⁩")).toBe("?hidden?");
+  });
+
+  it("strips zero-width and format characters", () => {
+    // U+200B zero-width space — invisible filename padding.
+    expect(sanitizeForTerminal("foo​bar")).toBe("foo?bar");
+    // U+FEFF BOM — also invisible.
+    expect(sanitizeForTerminal("﻿foo")).toBe("?foo");
+  });
+
+  it("strips line/paragraph separators", () => {
+    // U+2028 / U+2029 break terminal line accounting in some renderers.
+    expect(sanitizeForTerminal("a b c")).toBe("a?b?c");
+  });
+
+  it("passes through safe ASCII unchanged", () => {
+    expect(sanitizeForTerminal("agent-name_42.dir")).toBe("agent-name_42.dir");
+  });
+
+  it("passes through ordinary Unicode unchanged", () => {
+    // CJK + accented letters are not security-relevant — keep them.
+    expect(sanitizeForTerminal("agent-名前-é")).toBe("agent-名前-é");
   });
 });

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -27,6 +27,32 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 /**
+ * Replace bytes that can spoof terminal output (or pretend a filename
+ * is something it isn't) with `?` before writing operator-visible
+ * text to stderr or daemon logs. Used for filesystem entries
+ * (directory names from `readdir`) and CLI argv values that an
+ * attacker could plant.
+ *
+ * Strips:
+ *   - C0 controls + DEL (`\x00`-`\x1f`, `\x7f`) — ANSI escape building blocks
+ *   - C1 controls (`\x80`-`\x9f`) — includes 8-bit CSI `\x9b` which xterm
+ *     and Terminal.app render as ESC `[`
+ *   - Unicode bidi overrides + isolates (U+202A-U+202E, U+2066-U+2069) —
+ *     the "Trojan Source" attack class (CVE-2021-42574): a directory
+ *     named `agent-‮drm.elor` renders as `agent-role.md`
+ *   - Zero-width / format chars (U+200B-U+200F, U+FEFF) — invisible
+ *     padding that hides the real filename
+ *   - Line/paragraph separators (U+2028-U+2029) — break terminal line
+ *     accounting
+ */
+export const sanitizeForTerminal = (s: string): string =>
+  s.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1f\x7f-\x9f\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]/g,
+    "?",
+  );
+
+/**
  * Typed boot-time error. Thrown instead of `process.exit` so the
  * composition root stays library-like — `bin.ts` is the only place
  * that turns errors into exit codes (Engineering Standard #6).
@@ -35,16 +61,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
  * `exitCode` is the conventional sysexits value the bin entrypoint
  * should propagate (78 = configuration error per `sysexits.h`).
  */
-/**
- * Replace ANSI/control bytes with `?` before writing operator-visible
- * text to stderr. Used for filesystem entries (directory names from
- * `readdir`) and CLI argv values that an attacker could plant with
- * escape sequences to spoof terminal output.
- */
-export const sanitizeForTerminal = (s: string): string =>
-  // eslint-disable-next-line no-control-regex
-  s.replace(/[\x00-\x1f\x7f]/g, "?");
-
 export class BootError extends Error {
   public readonly kind:
     | "incomplete-agent-single"
@@ -74,6 +90,7 @@ import {
   DispatchRunArtifactWriter,
   IdentityLoader,
   InProcessExecutor,
+  isOrphanedSchedule,
   PluginInitError,
   RunArtifactWriter,
   SubprocessExecutor,
@@ -86,7 +103,6 @@ import {
   type BudgetCeiling,
   type CollaborationProvider,
   type DaemonConfig,
-  type LoadedAgentIdentity,
   type RegisteredAgent,
   type SecretDeclaration,
   type SecretKey,
@@ -224,21 +240,6 @@ const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
  * first time each pair is seen, with dedupe state held on the hook
  * instance so test wakes don't bleed into each other.
  */
-/**
- * Predicate (harness#380): the agent's `role.md` was missing entirely
- * and the loader synthesised a fallback identity from default-agent/.
- *
- * Distinguished from other fallback reasons (`missing-frontmatter`,
- * `invalid-frontmatter`) which usually mean the operator is iterating
- * on a partially-edited role.md — those keep the agent scheduled.
- * A missing role.md, by contrast, means either the operator removed
- * it deliberately or the directory was never finished; either way the
- * cron entry should be suppressed so the agent doesn't quietly wake
- * with template behaviour.
- */
-export const isOrphanedSchedule = (loaded: LoadedAgentIdentity): boolean =>
-  loaded.fallback?.missingFiles.includes("role.md") ?? false;
-
 export const makeDaemonHook = (
   builder: WakeCostBuilder,
   logger?: { warn: (event: string, fields?: Record<string, unknown>) => void },
@@ -963,6 +964,12 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     rootDir: exampleRoot,
     fallbackOnMissing: true,
     onFallback: (agentDir, reason) => {
+      // harness#380: when role.md is missing, the call site will emit
+      // a strictly more informative `daemon.warn.orphaned-schedule` event
+      // (with the schedule-skip / hard-fail outcome). Suppress the
+      // lower-level `daemon.agent.fallback` here so operators don't see
+      // two warnings for the same condition.
+      if (reason.missingFiles.includes("role.md")) return;
       logger.warn("daemon.agent.fallback", {
         agentDir,
         reason: reason.reason,
@@ -1061,10 +1068,18 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
   // the default-agent template — that's intentional for fresh scaffolding,
   // but a daemon-startup *schedule* derived from a synthesized identity
   // means the agent would wake on cron with template behaviour (drift).
-  // Skip the cron registration in that case and emit a visible warning
-  // so the operator notices the missing file. In single-agent mode
-  // (`--agent <id>`) the operator named this agent explicitly — fail
-  // hard instead of silently dropping the only requested agent.
+  //
+  // The orphan check is intentionally defensive. In multi-agent mode,
+  // `loader.discover()` (line 1018) already filters out dirs lacking
+  // `role.md`, so the check here is belt-and-suspenders against future
+  // call sites that build agentDirs differently (e.g. an operator-supplied
+  // list, a state-store-driven re-registration, etc.). In single-agent
+  // mode (`--agent <id>`) the check IS reachable: `findIncompleteAgents`
+  // (line 1000) only flags dirs with EXACTLY ONE of role.md/soul.md, so a
+  // dir with NEITHER file slips past that gate and lands here. We throw
+  // rather than warn-and-skip because the operator named the agent
+  // explicitly; silently dropping the only requested agent is worse than
+  // failing fast.
   const allRegistered: RegisteredAgent[] = [];
   for (const agentDir of agentDirs) {
     const loaded = await loader.load(agentDir);
@@ -1075,10 +1090,12 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
           `murmuration: agent "${sanitizeForTerminal(agentDir)}" has no role.md — refusing to wake via the default-agent template. Add a role.md or remove the agent directory.`,
         );
       }
+      // `isOrphanedSchedule` is a type guard — `loaded.fallback` is
+      // narrowed to defined here, no optional-chain noise needed.
       logger.warn("daemon.warn.orphaned-schedule", {
         agentDir,
-        missingFiles: loaded.fallback?.missingFiles ?? [],
-        reason: loaded.fallback?.reason ?? "missing-files",
+        missingFiles: loaded.fallback.missingFiles,
+        reason: loaded.fallback.reason,
       });
       continue;
     }

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -576,6 +576,31 @@ export interface LoadedAgentIdentity {
 }
 
 /**
+ * Type guard for the "orphaned schedule" condition (harness#380): the
+ * agent's `role.md` file was missing entirely and the loader synthesized
+ * a fallback identity from `default-agent/`. The narrowed return type
+ * lets callers access `loaded.fallback` without optional-chain noise.
+ *
+ * `role.md` is load-bearing for scheduling — it declares the cron,
+ * scopes, budgets, and write surface. The other fallback reasons
+ * (`missing-frontmatter`, `invalid-frontmatter`) mean the file exists
+ * and the operator is mid-edit; those should NOT be treated as
+ * orphans, since iterative editing is the documented ADR-0027 flow.
+ * Likewise a missing `soul.md` alone doesn't qualify — the synthesized
+ * soul is a benign character file, not the operator-authored agent
+ * contract.
+ *
+ * Lives in core (next to `LoadedAgentIdentity`) so any consumer of
+ * `IdentityLoader.load()` can apply the same check — today only `boot.ts`
+ * enables `fallbackOnMissing`, but a future `runGroupWake` or
+ * `convene` path that opts in will need the same predicate.
+ */
+export const isOrphanedSchedule = (
+  loaded: LoadedAgentIdentity,
+): loaded is LoadedAgentIdentity & { fallback: IdentityFallbackReason } =>
+  loaded.fallback?.missingFiles.includes("role.md") ?? false;
+
+/**
  * Phase 1B identity loader. Reads the four layer files from disk,
  * parses and validates the role frontmatter, and returns an
  * {@link IdentityChain} ready to hand to {@link AgentExecutor.spawn}.


### PR DESCRIPTION
## Summary

Four reviewers ran on PR #404 (harness#380 orphan-schedule). This implements the load-bearing recommendations and files the rest as follow-up issues.

## Implemented

| Severity | Finding | Action |
|---|---|---|
| Architecture P2 | `isOrphanedSchedule` lived in cli but inspected a core type | Moved to `packages/core/src/identity/index.ts` next to `LoadedAgentIdentity` |
| TypeScript P1 | Predicate wasn't a type guard → dead `?? "missing-files"` fallbacks at call site | Lifted to `loaded is LoadedAgentIdentity & { fallback: IdentityFallbackReason }`; call-site fallbacks removed |
| Architecture P2 | `daemon.agent.fallback` + `daemon.warn.orphaned-schedule` both fired for the same condition | Suppress the fallback event when `missingFiles.includes("role.md")` — orphan event carries strictly more info |
| Security MEDIUM | `sanitizeForTerminal` only stripped C0+DEL, leaving Trojan Source primitives + 8-bit CSI through | Added C1 controls + Unicode bidi/format/separator classes. 7 new tests including CVE-2021-42574 |
| Polish | Stray duplicate JSDoc + reachability claim unclear | Doc block moved back; comment added explaining empty-dir reachability for single-agent throw |

## Filed as follow-up issues

- **#405** — `AgentStateStore` tombstone drift: orphaned agents' records persist forever; new state needed (architecture-strategist HIGH finding, pre-existing but #404 made it operator-reachable)
- **#406** — privilege amplification via operator-supplied permissive `default-agent/role.md` template (security-sentinel LOW finding; structural footgun for future `loader.load` consumers)

## Disagreed with / kept as-is

- Simplicity reviewer suggested inlining the predicate + deleting most tests. Disagreed: now that the predicate lives in core and is a type guard, extraction value goes up, not down. The 6 tests document the semantic boundary between "destructive" (file deleted) and "constructive" (mid-edit) fallback reasons clearly.
- Simplicity reviewer claimed the single-agent throw branch is unreachable. Actually reachable for the empty-dir case (`findIncompleteAgents` requires at least one file to flag, so empty dirs slip past). Added a clarifying comment.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 1298 pass (+7 new for sanitizer)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — clean
- [x] Hand-verified `doctor` still works against hello-world

🤖 Generated with [Claude Code](https://claude.com/claude-code)