### PR TITLE
docs: refresh post-v0.8.0 (harness#394 + #380 shipped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the Murmuration Harness are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+**Signal-bundle hygiene + daemon orphan-schedule + Trojan Source hardening.** Operator-visible diagnostics for the silent failure mode that bites every long-running murmuration: stale GitHub issues that bloat every watching agent's per-wake context, and agent directories that quietly wake on the default-agent template after their `role.md` was removed.
+
+### Added
+
+- **`murmuration doctor --live` hygiene category** ([#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) scope 1). New `hygiene` doctor category gated behind `--live` (it needs a GitHub round-trip). Scans `collaboration.repo` for open issues stale by age (>14d open + 7d silent) and digest-pattern titles (`[DIGEST]` / `[FINANCE]` / `[STATUS]` / `[REPORT]` / `[KICKOFF]`); emits info-severity findings with remediation pointing to `docs/CONVENTIONS-GITHUB-VS-FILES.md`. Capped at 5 pages (500 issues) to bound rate-limit cost. Graceful no-op for `collaboration: local` and when `GITHUB_TOKEN` is unset.
+- **Per-wake signal-bundle metric in `index.jsonl`** ([#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) scope 2). New optional `signalBundle: { issueCount }` field on every `RunArtifactIndexEntry`, computed by the daemon from `context.signals` at wake fire time. Persists per-wake "what context did this agent read" so the dashboard can flag bloating.
+- **Dashboard `[b:N]` badge in the agents panel** ([#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) scope 2). Shows the agent's last `github-issue` count. Dim by default; yellow when above the new `signals.spikeThreshold` config knob (default 10).
+- **`signals.spikeThreshold` in `harness.yaml`** ([#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) scope 2). New `signals:` block with `spikeThreshold: number` (default 10). Operator-tunable for chattier repos. Wired through `HarnessConfig` + Zod schema + lenient loader.
+- **`murmuration list-stale-issues` CLI** ([#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) scope 3). Read-only inventory of open issues bloating the signal bundle. Table + `--json` output, sorted oldest-silence-first. Flags: `--days N`, `--silence-days N`, `--digest-only`, `--json`. Closure is operator judgement — no auto-close.
+- **`daemon.signal-bundle.large` event** ([#398](https://github.com/murmurations-ai/murmurations-harness/pull/398)). Daemon emits a structured-log line when an assembled bundle exceeds the configured spike threshold. Mirrors the `daemon.validate.legacy-fallback` observability precedent.
+- **`AggregatorCaps.commentsPerIssue` knob** ([#398](https://github.com/murmurations-ai/murmurations-harness/pull/398)). Comment cap on the signal aggregator now defaults to 5 (was hardcoded 20). Cuts per-wake input tokens on chatty threads. Truncation note names the omitted count.
+- **Daemon orphan-schedule warning** ([#380](https://github.com/murmurations-ai/murmurations-harness/issues/380)). Boot now detects when an agent's `role.md` is missing entirely and refuses to register the cron entry — silent waking via the default-agent template was the silent-drift class EP#874 surfaced. Multi-agent boot warns + skips (`daemon.warn.orphaned-schedule`); single-agent boot (`--agent <id>`) hard-fails with `BootError(kind: "agent-missing-role")`. Predicate `isOrphanedSchedule(loaded)` exported from `@murmurations-ai/core` (type guard).
+- **Trojan Source / Unicode bidi hardening** (review followup to [#380](https://github.com/murmurations-ai/murmurations-harness/issues/380)). `sanitizeForTerminal` now strips C1 controls (incl. 8-bit CSI `\x9b`), Unicode bidi overrides + isolates (U+202A-U+202E, U+2066-U+2069 — CVE-2021-42574), zero-width chars (U+200B-U+200F, U+FEFF), and line separators (U+2028-U+2029). Closes a class of operator-log spoofing via maliciously-named agent directories. Pre-existing surface, but the recent work made the sanitizer flow operator-reachable through several new emission points.
+- **Shared `stale-issues.ts` module** in `@murmurations-ai/cli` ([#402](https://github.com/murmurations-ai/murmurations-harness/pull/402)). `classifyStaleIssues`, `partitionByReason`, `fetchOpenIssues` consolidated from the two original copies that #399 and #401 each shipped independently. `dotenv.ts` extracted the second time the dedupe was needed.
+
+### Internals
+
+- Issue `signalBundle?` field is **optional** — entries written before this batch remain readable. `schemaVersion` stays at 1 (additive).
+- The hygiene + list-stale-issues network paths share a single capped pagination helper and a per-item type guard (`isRestIssueResponse`) so a malformed REST response can't silently produce NaN ageDays.
+- `splitRepo()` validates owner/name against GitHub slug grammar (`^[A-Za-z0-9_][A-Za-z0-9._-]*$`, `..` rejected) so a malicious `collaboration.repo` cannot redirect the Bearer-token-bearing fetch to a non-GitHub host.
+
+### Filed for follow-up
+
+- [#405](https://github.com/murmurations-ai/murmurations-harness/issues/405) — `AgentStateStore` tombstone drift: orphaned agents' state.json records persist forever; needs reconciliation pass.
+- [#406](https://github.com/murmurations-ai/murmurations-harness/issues/406) — privilege amplification via operator-supplied permissive `default-agent/role.md` template.
+
 ## [0.8.0] - 2026-05-19
 
 **Execution contracts — agents declare what completion looks like in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces it.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,10 @@ murmuration groups [--root|--name] [--json]
 murmuration events [--root|--name] [--json]
 murmuration cost   [--root|--name] [--json]
 
+# Diagnostics
+murmuration doctor [--live] [--fix] [--json]                            # Validate setup + (with --live) GitHub signal-bundle hygiene
+murmuration list-stale-issues [--days N] [--silence-days N] [--digest-only] [--json]  # Inventory open issues bloating per-wake context
+
 # Actions
 murmuration directive --root <path> --agent <id> "message"
 murmuration convene --root <path> --group <id> [--governance] [--directive "msg"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 The Murmuration Harness is an open-source TypeScript runtime that lets a single human — the **Source** — coordinate a murmuration of AI agents to do real work. It is not an autonomous agent framework. It is a tool that amplifies human agency.
 
-> **v0.8.0** (current) — Execution contracts: agents declare `done_when` / `committed_artifacts` / `verification_required_for` in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces `[obl-unmet:N]` when output paths go unmet. `validateBehavior` ships warning-only — calibration before hard-fail in v0.8.1. 9 packages, 1240 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
+> **v0.8.0** (current) — Execution contracts: agents declare `done_when` / `committed_artifacts` / `verification_required_for` in `role.md`, the validator scores wakes against the obligation, and the dashboard surfaces `[obl-unmet:N]` when output paths go unmet. `validateBehavior` ships warning-only — calibration before hard-fail in v0.8.1. 9 packages, 1298 tests, 5 governance models. [CHANGELOG](./CHANGELOG.md)
+>
+> **Shipped post-v0.8.0 (May 2026):** Signal-bundle hygiene tooling — `murmuration doctor --live` flags stale issues bloating per-wake context, `murmuration list-stale-issues` inventories them, dashboard `[b:N]` badge spikes when an agent's last bundle exceeded `signals.spikeThreshold` (harness#394). Daemon `daemon.signal-bundle.large` event + per-wake `signalBundle.issueCount` persisted in `index.jsonl`. Orphan-schedule warning when `role.md` is missing (harness#380). Trojan Source / Unicode bidi hardening on operator-facing log paths.
 >
 > **In flight (v0.8.1+):** Promote `validateBehavior` to hard-fail after 14d composite-permission soak; per-segment glob matcher; `verifiedActions` field on `AgentResult` for the long-term subscription-CLI evidence fix.
 
@@ -183,13 +185,14 @@ contract:
 
 **Dashboard surfacing.** The TUI agents panel shows the validation result of the last wake as a colored badge after the wake count:
 
-| Badge           | Meaning                                                                                                               |
-| --------------- | --------------------------------------------------------------------------------------------------------------------- |
-| _(none)_        | Wake productive — all obligations met, no warnings.                                                                   |
-| `[obl-unmet:N]` | **N** `requiredOutputs` had no matching successful evidence (red — load-bearing).                                     |
-| `[dir-unaddr]`  | One or more source directives in the signal bundle were not addressed (yellow).                                       |
-| `[idle-val]`    | Wake produced no artifacts and had no directives (dim).                                                               |
-| `[beh:N]`       | **N** behavior warnings from the narrative-vs-tool-call cross-check (yellow). Warning-only in v0.8.0 — see CHANGELOG. |
+| Badge           | Meaning                                                                                                                                                                                                           |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _(none)_        | Wake productive — all obligations met, no warnings.                                                                                                                                                               |
+| `[obl-unmet:N]` | **N** `requiredOutputs` had no matching successful evidence (red — load-bearing).                                                                                                                                 |
+| `[dir-unaddr]`  | One or more source directives in the signal bundle were not addressed (yellow).                                                                                                                                   |
+| `[idle-val]`    | Wake produced no artifacts and had no directives (dim).                                                                                                                                                           |
+| `[beh:N]`       | **N** behavior warnings from the narrative-vs-tool-call cross-check (yellow). Warning-only in v0.8.0 — see CHANGELOG.                                                                                             |
+| `[b:N]`         | **N** `github-issue` signals in the agent's last bundle. Dim by default; yellow when over `signals.spikeThreshold` (default 10) — see [#394](https://github.com/murmurations-ai/murmurations-harness/issues/394). |
 
 **No `contract:` block?** Agents continue to work with the legacy heuristic: a wake is productive when it produces ≥1 artifact and addresses any source directives in its bundle. The `contract:` block is opt-in.
 
@@ -315,6 +318,11 @@ murmuration agents [--json] [--filter running|idle|failed]
 murmuration groups [--json]
 murmuration events [--json]
 murmuration cost   [--json]
+
+# Diagnostics
+murmuration doctor [--live] [--fix] [--json]    # Validate setup + (with --live) GitHub signal-bundle hygiene
+murmuration list-stale-issues [--days N] [--silence-days N] [--digest-only] [--json]
+                                                # Inventory open GitHub issues bloating per-wake context
 
 # Actions
 murmuration directive [flags] "message"     # Send a Source directive

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Murmuration Harness Architecture
 
-**Status:** Living document — updated 2026-04-15 (v0.3.0)
+**Status:** Living document — updated 2026-05-25 (post-v0.8.0; harness#394 + harness#380 shipped)
 **Principle:** The harness exists to help agents do real work, not to facilitate governance theater.
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,6 +35,9 @@ logging:
 
 spirit:
   maxSteps: 32 # Spirit tool-loop budget per turn
+
+signals:
+  spikeThreshold: 10 # dashboard flags `[b:N]` yellow when an agent's bundle exceeds this
 ```
 
 ## Fields
@@ -98,6 +101,27 @@ When the budget is exhausted the REPL shows:
 ```
 (Spirit ran out of tool-use budget before producing an answer. Try narrowing the question, or ask for a shorter summary.)
 ```
+
+### `signals`
+
+Signal-aggregation hygiene knobs. Added in [harness#394](https://github.com/murmurations-ai/murmurations-harness/issues/394) — every open GitHub issue lands in every watching agent's `SignalBundle` on every wake, so operators need visibility when that load grows.
+
+```yaml
+signals:
+  spikeThreshold: 10
+```
+
+| Field            | Type   | Default | Notes                                                                                                                                                                                                                                                                                                      |
+| ---------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spikeThreshold` | number | `10`    | Per-agent `github-issue` count above which the dashboard renders the `[b:N]` badge in yellow (instead of dim) and the daemon emits `daemon.signal-bundle.large`. Persisted on every wake in `runs/<agent>/index.jsonl` as `signalBundle.issueCount`. Raise for operators with chattier repos. Must be ≥ 1. |
+
+### `agent`
+
+Agent-runtime knobs applied to every agent's wake unless overridden per-agent in `role.md`.
+
+| Field      | Type   | Default | Notes                                                                                                                                |
+| ---------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `maxSteps` | number | `256`   | Tool-use budget per agent wake. Wall-clock and cost budgets are the real circuit-breakers; this is belt-and-suspenders. Must be ≥ 1. |
 
 ## Precedence
 

--- a/docs/EXECUTION-PLAN.md
+++ b/docs/EXECUTION-PLAN.md
@@ -1,6 +1,6 @@
 # Consolidated Execution Plan
 
-**Status:** Active — updated 2026-05-11
+**Status:** Mostly executed — last refreshed 2026-05-25. v0.8.0 shipped 2026-05-19 with execution contracts, signal-bundle hygiene tooling (harness#394), and daemon orphan-schedule warnings (harness#380). The current short list is in [README.md](../README.md) "In flight" and [CHANGELOG.md](../CHANGELOG.md); this doc is retained for the longer-horizon roadmap.
 **Inputs:** Intelligence Circle architecture review (2026-04-12), MURMURATION-HARNESS-SPEC.md, PHASE-2-PLAN.md, CIRCLE-WAKE-SPEC.md, GITHUB-AS-SYSTEM-OF-RECORD.md, Proposal 07 ratified ADRs (0045/0046/0047)
 **For:** Coding agents implementing the next phases
 

--- a/docs/PHASE-2-PLAN.md
+++ b/docs/PHASE-2-PLAN.md
@@ -1,6 +1,6 @@
 # Phase 2 Implementation Plan — Murmuration Harness
 
-**Status:** Active
+**Status:** COMPLETED — shipped through v0.8.0 (2026-05-19). Retained for historical reference. See [CHANGELOG.md](../CHANGELOG.md) for shipment notes; for the post-v0.8.0 hygiene + diagnostics work see [docs/ARCHITECTURE.md](./ARCHITECTURE.md) and the issue history (#394, #380).
 **Authored:** 2026-04-09 (Engineering Lead #22, Engineering Circle Phase 0 mode)
 **Spec reference:** [`MURMURATION-HARNESS-SPEC.md`](https://github.com/xeeban/emergent-praxis/blob/main/docs/MURMURATION-HARNESS-SPEC.md) §15 Phase 2
 **Sibling doc:** [`PHASE-1-PLAN.md`](./PHASE-1-PLAN.md)


### PR DESCRIPTION
## Summary

After shipping eight PRs (#394 scopes 1-3, #398, #404 + the four review-followups), several operator-facing docs were stale enough that a new operator opening the repo wouldn't find the new commands or the new config knob. This is the documentation refresh pass.

## Changed

| File | What |
|---|---|
| `README.md` | Post-v0.8.0 callout, `[b:N]` badge in the table, `doctor` + `list-stale-issues` in CLI listing, test count 1240 → 1298 |
| `docs/CONFIGURATION.md` | New `signals.spikeThreshold` and `agent.maxSteps` sections + example update |
| `docs/ARCHITECTURE.md` | Status header bump v0.3.0 / 2026-04-15 → post-v0.8.0 / 2026-05-25 |
| `docs/PHASE-2-PLAN.md` | Marked COMPLETED |
| `docs/EXECUTION-PLAN.md` | Marked mostly-executed; points at README + CHANGELOG for short list |
| `CHANGELOG.md` | New Unreleased section capturing the eight post-v0.8.0 PRs + the two follow-up issues filed (#405, #406) |
| `CLAUDE.md` | `doctor` + `list-stale-issues` added to the CLI block so future agents in this repo see the diagnostic surface |

## Not changed

- 51 ADRs — none of the recent work shipped an ADR; the operator-facing surface area was the gap
- `docs/GETTING-STARTED.md` — still accurate
- `docs/OBSERVABILITY.md` — that doc is about Langfuse; the new `daemon.signal-bundle.large` event lives in CHANGELOG which is enough
- `docs/threat-model.md` — Trojan Source hardening was an implementation tightening rather than a new threat-model entry; flag if you want it called out separately

## Follow-up (separate task in same session)

HTML landing page using Claude's frontend-design skill is queued — that's the "get someone up to speed really fast" deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)