### PR TITLE
fix(landing): preserve newlines in quickstart terminal panes

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -401,7 +401,12 @@
         color: var(--ink);
         position: relative;
       }
-      .terminal-pane { display: none; padding: 1.6rem 1.5rem 1.8rem; overflow-x: auto; }
+      .terminal-pane {
+        display: none;
+        padding: 1.6rem 1.5rem 1.8rem;
+        overflow-x: auto;
+        white-space: pre;
+      }
       .terminal-pane.active { display: block; }
       .terminal .comment { color: var(--ink-faint); }
       .terminal .prompt { color: var(--ember); user-select: none; margin-right: 0.4em; }


### PR DESCRIPTION
Caught after Nori opened the page — the quickstart subscription-CLI and API-key terminal panes were collapsing all whitespace (newlines + multi-space runs) into a single wrapped paragraph because `.terminal-pane` was missing `white-space: pre`.

One-line CSS fix. The `.role-sample` block (which renders the `role.md` excerpt below) already had the rule; the terminal pane was the outlier.

Before: see screenshot in the original report
After: lines render one-per-line, run-of-dots in the doctor output preserved, indentation honoured