### PR TITLE
feat(boot): auto-derive permissionMode trusted when branch_commits declared (#392)

### DIFF
--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -405,4 +405,20 @@ describe("deriveSubscriptionCliPermissionMode (harness#392)", () => {
     ]);
     expect(deriveSubscriptionCliPermissionMode(agent, undefined)).toBe("trusted");
   });
+
+  it("an explicit restricted suppresses branch_commits auto-elevation (harness-level policy)", () => {
+    // The caller (buildAgentClients) resolves precedence
+    // `effectiveLlm.permissionMode ?? harnessLlm.permissionMode` before
+    // calling this helper, so a murmuration-wide `llm.permissionMode:
+    // restricted` in harness.yaml reaches the helper as declaredMode even
+    // when the agent pins its own llm block (the role-defaults cascade is
+    // all-or-nothing). The security-critical direction: a declared
+    // restricted must NEVER be silently broadened to trusted by a
+    // branch_commits declaration. (Mirrors the caller's `?? harnessLlm`
+    // fallback added with this PR — guards against a refactor dropping it.)
+    const agent = makeAgent([{ repo: "org/repo", paths: ["drafts/**"] }]);
+    // Resolved declaredMode the caller passes when role.md is unset but
+    // harness.yaml declares `restricted` (`undefined ?? "restricted"`).
+    expect(deriveSubscriptionCliPermissionMode(agent, "restricted")).toBe("restricted");
+  });
 });

--- a/packages/cli/src/boot.test.ts
+++ b/packages/cli/src/boot.test.ts
@@ -21,7 +21,11 @@ import {
   type LoadedAgentIdentity,
 } from "@murmurations-ai/core";
 
-import { makeDaemonHook, sanitizeForTerminal } from "./boot.js";
+import {
+  deriveSubscriptionCliPermissionMode,
+  makeDaemonHook,
+  sanitizeForTerminal,
+} from "./boot.js";
 
 describe("makeDaemonHook", () => {
   const builder = (): WakeCostBuilder =>
@@ -333,5 +337,72 @@ describe("sanitizeForTerminal (harness#380 review hardening)", () => {
   it("passes through ordinary Unicode unchanged", () => {
     // CJK + accented letters are not security-relevant — keep them.
     expect(sanitizeForTerminal("agent-名前-é")).toBe("agent-名前-é");
+  });
+});
+
+describe("deriveSubscriptionCliPermissionMode (harness#392)", () => {
+  // Minimal RegisteredAgent factory — only `githubWriteScopes` is read by
+  // the helper, so we synthesise a fixture that fills exactly that shape.
+  const makeAgent = (
+    branchCommits: readonly { readonly repo: string; readonly paths: readonly string[] }[],
+  ): Parameters<typeof deriveSubscriptionCliPermissionMode>[0] => {
+    return {
+      agentId: "test-agent",
+      displayName: "Test",
+      modelTier: "balanced",
+      maxWallClockMs: 10_000,
+      identity: {
+        agentId: makeAgentId("test-agent"),
+        layers: [],
+        frontmatter: {
+          agentId: makeAgentId("test-agent"),
+          name: "test",
+          modelTier: "balanced",
+          groupMemberships: [],
+        },
+      },
+      githubWriteScopes: {
+        issueComments: [],
+        branchCommits,
+        labels: [],
+        issues: [],
+      },
+      trigger: { kind: "interval", intervalMs: 60_000 },
+      groupMemberships: [],
+    } as unknown as Parameters<typeof deriveSubscriptionCliPermissionMode>[0];
+  };
+
+  it("operator-set permissionMode wins, even when branch_commits is non-empty", () => {
+    const agent = makeAgent([{ repo: "org/repo", paths: ["drafts/**"] }]);
+    expect(deriveSubscriptionCliPermissionMode(agent, "restricted")).toBe("restricted");
+    expect(deriveSubscriptionCliPermissionMode(agent, "operator-approved")).toBe(
+      "operator-approved",
+    );
+    expect(deriveSubscriptionCliPermissionMode(agent, "trusted")).toBe("trusted");
+  });
+
+  it("auto-elevates to trusted when permissionMode is unset AND branch_commits has paths", () => {
+    const agent = makeAgent([{ repo: "org/repo", paths: ["drafts/**", "pipeline/**"] }]);
+    expect(deriveSubscriptionCliPermissionMode(agent, undefined)).toBe("trusted");
+  });
+
+  it("returns undefined when permissionMode is unset AND no branch_commits", () => {
+    const agent = makeAgent([]);
+    expect(deriveSubscriptionCliPermissionMode(agent, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when branch_commits entries exist but all have empty paths", () => {
+    // Edge case: operator declared the repo block but no paths. Treat as
+    // no write intent — don't auto-elevate.
+    const agent = makeAgent([{ repo: "org/repo", paths: [] }]);
+    expect(deriveSubscriptionCliPermissionMode(agent, undefined)).toBeUndefined();
+  });
+
+  it("auto-elevates when at least one branch_commits entry has paths (mixed case)", () => {
+    const agent = makeAgent([
+      { repo: "org/empty-repo", paths: [] },
+      { repo: "org/real-repo", paths: ["src/**"] },
+    ]);
+    expect(deriveSubscriptionCliPermissionMode(agent, undefined)).toBe("trusted");
   });
 });

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -240,6 +240,37 @@ const GITHUB_TOKEN = makeSecretKey("GITHUB_TOKEN");
  * first time each pair is seen, with dedupe state held on the hook
  * instance so test wakes don't bleed into each other.
  */
+/**
+ * Resolve the effective subscription-CLI permission mode for an agent
+ * (harness#392). The operator's explicit setting wins; otherwise, when
+ * the agent declares non-empty `branch_commits` paths, auto-elevate to
+ * `"trusted"` so headless `-p` wakes can actually write the files the
+ * operator declared intent to commit to. Returning `undefined` lets the
+ * subscription-cli adapter fall back to its own default (`"restricted"`).
+ *
+ * The original silent failure (EP#896): agents declared `branch_commits`
+ * for `drafts/**` and `pipeline/**` but never set `permissionMode`,
+ * so file writes silently no-op'd in headless mode. Six+ consecutive
+ * wakes filed TENSION issues before the cause surfaced. This helper
+ * makes the declaration surface itself enough to grant the permission.
+ *
+ * Why a small exported helper instead of inlining the logic in
+ * `buildAgentClients`: pure predicate over the two inputs — testable in
+ * isolation without scaffolding a full agent + client harness.
+ */
+export const deriveSubscriptionCliPermissionMode = (
+  agent: RegisteredAgent,
+  declaredMode: "restricted" | "operator-approved" | "trusted" | undefined,
+): "restricted" | "operator-approved" | "trusted" | undefined => {
+  // Operator's explicit setting always wins — never silently override a
+  // decision the operator made, even when it might be tighter than the
+  // auto-derivation would have chosen.
+  if (declaredMode !== undefined) return declaredMode;
+  // Auto-elevate when the agent declares write intent via branch_commits.
+  const hasBranchCommits = agent.githubWriteScopes.branchCommits.some((b) => b.paths.length > 0);
+  return hasBranchCommits ? "trusted" : undefined;
+};
+
 export const makeDaemonHook = (
   builder: WakeCostBuilder,
   logger?: { warn: (event: string, fields?: Record<string, unknown>) => void },
@@ -590,12 +621,36 @@ const buildAgentClients = ({
         // `--allowedTools mcp__<name>__*` flag on the claude CLI call.
         const allowedMcpServerNames =
           mcpConfigPath !== undefined ? agent.tools.mcp.map((s) => s.name) : undefined;
+        // harness#392: auto-derive permissionMode from branch_commits
+        // declarations. Operator's explicit role.md setting still wins;
+        // when it's unset and the agent declares branch_commits paths,
+        // elevate to "trusted" so headless writes actually land.
+        const resolvedPermissionMode = deriveSubscriptionCliPermissionMode(
+          agent,
+          effectiveLlm.permissionMode,
+        );
+        if (effectiveLlm.permissionMode === undefined && resolvedPermissionMode === "trusted") {
+          // Surface the auto-elevation so an operator scanning daemon
+          // logs can see when their declared write intent triggered a
+          // permission change they didn't explicitly configure.
+          logger?.warn("daemon.agent.permission-mode.auto-elevated", {
+            agentId: agent.agentId,
+            from: "restricted",
+            to: "trusted",
+            reason: "branch_commits-declared",
+            branchCommitsRepoCount: agent.githubWriteScopes.branchCommits.length,
+            branchCommitsPathCount: agent.githubWriteScopes.branchCommits.reduce(
+              (sum, b) => sum + b.paths.length,
+              0,
+            ),
+          });
+        }
         result.llm = createSubscriptionCliClient({
           cli,
           model,
           ...(effectiveLlm.timeoutMs !== undefined ? { timeoutMs: effectiveLlm.timeoutMs } : {}),
-          ...(effectiveLlm.permissionMode !== undefined
-            ? { permissionMode: effectiveLlm.permissionMode }
+          ...(resolvedPermissionMode !== undefined
+            ? { permissionMode: resolvedPermissionMode }
             : {}),
           ...(mcpConfigPath !== undefined ? { mcpConfigPath } : {}),
           ...(allowedMcpServerNames !== undefined ? { allowedMcpServerNames } : {}),

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -622,14 +622,22 @@ const buildAgentClients = ({
         const allowedMcpServerNames =
           mcpConfigPath !== undefined ? agent.tools.mcp.map((s) => s.name) : undefined;
         // harness#392: auto-derive permissionMode from branch_commits
-        // declarations. Operator's explicit role.md setting still wins;
-        // when it's unset and the agent declares branch_commits paths,
-        // elevate to "trusted" so headless writes actually land.
+        // declarations. Operator's explicit setting still wins; we honour
+        // it at BOTH levels of precedence: the agent's role.md, then the
+        // harness.yaml `llm.permissionMode`. The role-defaults cascade is
+        // all-or-nothing (identity/index.ts only merges roleDefaults.llm
+        // when the agent has NO llm block at all), so an agent that pins
+        // its own llm block to set e.g. a model would otherwise never see
+        // the operator's harness-wide permissionMode — and auto-elevation
+        // would silently override a murmuration-level `restricted` policy.
+        // Consulting harnessLlm here keeps "operator's explicit setting
+        // always wins" true at harness.yaml granularity, not just role.md.
+        const declaredPermissionMode = effectiveLlm.permissionMode ?? harnessLlm.permissionMode;
         const resolvedPermissionMode = deriveSubscriptionCliPermissionMode(
           agent,
-          effectiveLlm.permissionMode,
+          declaredPermissionMode,
         );
-        if (effectiveLlm.permissionMode === undefined && resolvedPermissionMode === "trusted") {
+        if (declaredPermissionMode === undefined && resolvedPermissionMode === "trusted") {
           // Surface the auto-elevation so an operator scanning daemon
           // logs can see when their declared write intent triggered a
           // permission change they didn't explicitly configure.
@@ -1239,7 +1247,19 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         ? {
             cliName: agentCli,
             resolvedPath: resolvedCliPath ?? agentCli,
-            permissionMode: agent.llm?.permissionMode ?? "restricted",
+            // harness#392: record the EFFECTIVE permission mode, not the
+            // raw declaration. When branch_commits auto-elevates an agent
+            // to "trusted", the subprocess runs with --dangerously-skip-
+            // permissions, so the audit record under runs/<agentId>/ must
+            // say "trusted" too — otherwise a security review of the run
+            // artifacts concludes the wake ran sandboxed when it had full
+            // write access. Mirrors the buildAgentClients derivation
+            // (role.md → harness.yaml → branch_commits auto-elevation).
+            permissionMode:
+              deriveSubscriptionCliPermissionMode(
+                agent,
+                agent.llm?.permissionMode ?? config.llm.permissionMode,
+              ) ?? "restricted",
             allowedTools:
               agentCli === "claude" ? agent.tools.mcp.map((s) => `mcp__${s.name}__*`) : [],
             envAllowlistApplied: true,


### PR DESCRIPTION
## Summary

EP#896 surfaced a silent capability gap: agents declaring \`branch_commits\` paths (e.g. \`drafts/**\`, \`pipeline/**\`) in their role.md couldn't actually write those files under headless \`claude -p\` because \`permissionMode\` defaulted to \`\"restricted\"\`. Six+ wakes across creative-agent, content-agent, intelligence-agent silently no-op'd file commits before the cause surfaced.

This PR ships **Option B** from the issue: auto-derive \`permissionMode: trusted\` when the agent declares non-empty \`branch_commits\`. Operator's explicit setting always wins.

## Logic

New exported predicate \`deriveSubscriptionCliPermissionMode(agent, declared)\`:

- Operator explicitly set permissionMode → use it (always wins; never silently overridden, even for explicit \`\"restricted\"\`)
- Operator unset AND agent declares branch_commits with ≥1 path → \`\"trusted\"\`
- Else → undefined (adapter default = \"restricted\")

When auto-elevation fires, boot emits \`daemon.agent.permission-mode.auto-elevated\` warn so operators see the change in logs.

## Why Option B over Option A

Option A (derive per-path \`--allowedPaths\` from each glob) is the more precise long-term answer, but needs glob-to-prefix translation and operator-aware config logic that this fix sidesteps. Option B closes the silent-failure class today; Option A can refine the surface later if needed.

## Test plan

- [x] 5 new unit tests on the predicate: operator-set wins (all three modes), auto-elevate on non-empty branch_commits, undefined on no branch_commits, undefined when branch_commits entries have empty paths, auto-elevates when at least one entry has paths
- [x] \`pnpm run typecheck\` — clean across 8 packages
- [x] \`pnpm run test\` — 1303 pass (+5)
- [x] \`pnpm run lint\` — 0 errors
- [x] \`pnpm run format:check\` — clean

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)