### PR TITLE
fix(cli): preserve typed-error discriminator in fatal stderr (#360)

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -20,6 +20,7 @@ import { resolve } from "node:path";
 import { runAttach, runUnattachedRepl } from "./attach.js";
 import { runBacklog } from "./backlog.js";
 import { bootDaemon, BootError } from "./boot.js";
+import { formatFatalError } from "./format-error.js";
 import { runGroupWakeCommand } from "./group-wake.js";
 import { runDirective } from "./directive.js";
 import { runInit } from "./init.js";
@@ -657,7 +658,6 @@ main()
       process.stderr.write(`${error.message}\n`);
       process.exit(error.exitCode);
     }
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`murmuration: fatal: ${message}\n`);
+    process.stderr.write(`${formatFatalError(error)}\n`);
     process.exit(1);
   });

--- a/packages/cli/src/format-error.test.ts
+++ b/packages/cli/src/format-error.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { formatFatalError } from "./format-error.js";
+
+describe("formatFatalError (harness#360)", () => {
+  it("formats a generic Error without a class prefix", () => {
+    expect(formatFatalError(new Error("boom"))).toBe("murmuration: fatal: boom");
+  });
+
+  it("preserves typed-error discriminator as [ClassName] prefix", () => {
+    class PluginInitError extends Error {
+      public override readonly name = "PluginInitError";
+    }
+    expect(formatFatalError(new PluginInitError("plugin failed compat check"))).toBe(
+      "murmuration: fatal: [PluginInitError] plugin failed compat check",
+    );
+  });
+
+  it("preserves distinct typed errors so log triage can grep by name", () => {
+    class PluginEventError extends Error {
+      public override readonly name = "PluginEventError";
+    }
+    class PluginTimeoutError extends Error {
+      public override readonly name = "PluginTimeoutError";
+    }
+    expect(formatFatalError(new PluginEventError("event handler threw"))).toContain(
+      "[PluginEventError]",
+    );
+    expect(formatFatalError(new PluginTimeoutError("hook took > 5s"))).toContain(
+      "[PluginTimeoutError]",
+    );
+  });
+
+  it("handles non-Error values via String()", () => {
+    expect(formatFatalError("string thrown directly")).toBe(
+      "murmuration: fatal: string thrown directly",
+    );
+    expect(formatFatalError(42)).toBe("murmuration: fatal: 42");
+    expect(formatFatalError({ shape: "object" })).toBe("murmuration: fatal: [object Object]");
+  });
+
+  it("handles null/undefined cleanly", () => {
+    expect(formatFatalError(undefined)).toBe("murmuration: fatal: undefined");
+    expect(formatFatalError(null)).toBe("murmuration: fatal: null");
+  });
+});

--- a/packages/cli/src/format-error.ts
+++ b/packages/cli/src/format-error.ts
@@ -1,0 +1,30 @@
+/**
+ * Operator-visible fatal-error formatting (harness#360).
+ *
+ * Lives in its own file because `bin.ts` runs the CLI on import (it
+ * calls `main()` at top level), so anything that wants to unit-test
+ * this helper would otherwise trigger the entire daemon command loop.
+ */
+
+/**
+ * Format an unknown error for the operator's stderr.
+ *
+ * Preserves the typed-error discriminator (`error.name`) when it carries
+ * useful information beyond the generic `"Error"`, so plugin-error
+ * classes (`PluginInitError`, `PluginEventError`, `PluginTimeoutError`,
+ * and any future typed daemon errors) remain greppable in operator logs
+ * and telemetry pipelines instead of being flattened to plain
+ * `"fatal: <message>"`.
+ *
+ * Format:
+ *   - Generic Error → `murmuration: fatal: <message>`
+ *   - Typed Error   → `murmuration: fatal: [<ErrorName>] <message>`
+ *   - non-Error     → `murmuration: fatal: <String(error)>`
+ */
+export const formatFatalError = (error: unknown): string => {
+  if (error instanceof Error) {
+    const prefix = error.name && error.name !== "Error" ? `[${error.name}] ` : "";
+    return `murmuration: fatal: ${prefix}${error.message}`;
+  }
+  return `murmuration: fatal: ${String(error)}`;
+};


### PR DESCRIPTION
## Summary

`bin.ts`'s top-level catch handler was flattening every error to \`fatal: <message>\`, dropping \`error.name\` for typed classes whose whole point is to be greppable in operator logs: \`PluginInitError\`, \`PluginEventError\`, \`PluginTimeoutError\`. Phase 3 code review on 2026-05-11 flagged this as a P1 quality issue.

## Fix

New exported \`formatFatalError(error)\` in \`packages/cli/src/format-error.ts\` that prefixes the message with \`[ClassName] \` when the error class is not the generic \`\"Error\"\`. Lives in its own module because bin.ts runs the CLI on import (calls \`main()\` at top level), so unit-testing the formatter in-place would trigger the whole command loop.

Output format:

| Input | Output |
|---|---|
| \`new Error(\"boom\")\` | \`murmuration: fatal: boom\` |
| \`new PluginInitError(\"plugin failed compat check\")\` | \`murmuration: fatal: [PluginInitError] plugin failed compat check\` |
| \`\"raw string\"\` | \`murmuration: fatal: raw string\` |

The bracketed form is unambiguous to grep (\`grep '\\\\[PluginInitError\\\\]'\`) and stays out of the way for vanilla Error instances.

## Test plan

- [x] 5 new tests in format-error.test.ts: generic Error, typed Error, multiple distinct typed errors (greppability), non-Error values, null/undefined
- [x] \`pnpm run typecheck\` — clean across 8 packages
- [x] \`pnpm run test\` — 1303 pass (+5)
- [x] \`pnpm run lint\` — 0 errors
- [x] \`pnpm run format:check\` — clean

Closes #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)