### PR TITLE
fix(spirit): move MCP-config sweep from per-attach to daemon-start (#362)

### DIFF
--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -146,7 +146,7 @@ import { validateHarnessYaml } from "./harness-config.js";
 import { resolveBundledGovernancePlugin } from "./governance-plugin-resolver.js";
 import { buildMemoryToolsForAgent } from "./memory/index.js";
 import { registerRunningSocket, unregisterRunningSocket } from "./running-sessions.js";
-import { writeAgentMcpConfig } from "./spirit/mcp-config.js";
+import { sweepOrphanedSpiritMcpConfigs, writeAgentMcpConfig } from "./spirit/mcp-config.js";
 
 // ---------------------------------------------------------------------------
 // CLI binary resolution — launchd / cron safe (harness#XXX)
@@ -1062,6 +1062,16 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
       dryRun,
     })}\n`,
   );
+
+  // harness#362: sweep orphaned Spirit MCP config files from prior
+  // crashed attach sessions. Previously this ran on every attach, which
+  // races when two attaches start within the same sub-second window —
+  // attach C's sweep could delete attach B's still-live ephemeral file.
+  // Moving the sweep to daemon-start makes it deterministic: the
+  // daemon owns the directory at boot time, no attach is in-flight, so
+  // any leftover file is genuinely orphaned. Per-attach code now only
+  // WRITES; cleanup is the daemon's job.
+  sweepOrphanedSpiritMcpConfigs(exampleRoot);
 
   // Load identities + build triggers for every agent. harness#380:
   // when `role.md` is missing entirely, IdentityLoader falls back to

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -1063,16 +1063,6 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
     })}\n`,
   );
 
-  // harness#362: sweep orphaned Spirit MCP config files from prior
-  // crashed attach sessions. Previously this ran on every attach, which
-  // races when two attaches start within the same sub-second window —
-  // attach C's sweep could delete attach B's still-live ephemeral file.
-  // Moving the sweep to daemon-start makes it deterministic: the
-  // daemon owns the directory at boot time, no attach is in-flight, so
-  // any leftover file is genuinely orphaned. Per-attach code now only
-  // WRITES; cleanup is the daemon's job.
-  sweepOrphanedSpiritMcpConfigs(exampleRoot);
-
   // Load identities + build triggers for every agent. harness#380:
   // when `role.md` is missing entirely, IdentityLoader falls back to
   // the default-agent template — that's intentional for fresh scaffolding,
@@ -2071,6 +2061,28 @@ export const bootDaemon = async (options: BootDaemonOptions = {}): Promise<void>
         }
       }
     }
+  }
+
+  // harness#362: sweep orphaned Spirit MCP config files from prior
+  // crashed attach sessions. This previously ran on every attach, which
+  // races when two attaches start within the same sub-second window —
+  // attach C's sweep could delete attach B's still-live ephemeral file.
+  //
+  // The sweep belongs HERE — after the pidfile guard above has confirmed
+  // this process owns the persistent daemon role, and only in `!once`
+  // mode. The sweep is not liveness-aware (it deletes by pattern, which
+  // is exactly why per-attach sweeping was racy), so it must never run in
+  // a context that coexists with a live attach. A `murmuration start
+  // --now/--once` immediate wake runs as a SEPARATE short-lived process
+  // alongside the real daemon and an operator's interactive attach; if
+  // the sweep ran before the `!once` guard it would delete that live
+  // attach's config out from under it. By gating on `!once` and placing
+  // it after pidfile acquisition, only the one process that legitimately
+  // owns the daemon — and at a moment no attach can be in-flight, since
+  // attach hard-exits without a bound socket — performs the cleanup.
+  // Per-attach code now only WRITES; cleanup is the daemon's job.
+  if (!once) {
+    sweepOrphanedSpiritMcpConfigs(exampleRoot);
   }
 
   // Start daemon control socket

--- a/packages/cli/src/spirit/client.ts
+++ b/packages/cli/src/spirit/client.ts
@@ -38,7 +38,7 @@ import {
   type SubscriptionCliPermissionMode,
   type SubscriptionCli,
 } from "../harness-config.js";
-import { sweepOrphanedSpiritMcpConfigs, writeEphemeralSpiritMcpConfig } from "./mcp-config.js";
+import { writeEphemeralSpiritMcpConfig } from "./mcp-config.js";
 import { buildSpiritSystemPrompt } from "./system-prompt.js";
 import { buildSpiritTools } from "./tools.js";
 
@@ -205,11 +205,14 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
     // Claude is the only CLI with `--mcp-config` support today (ADR-0038).
     // Codex/gemini fall through without an MCP bridge — they can converse
     // but cannot invoke harness-internal tools yet.
-    // CF-F (harness#278): sweep any orphaned per-attach configs from a
-    // prior crashed session, then write a fresh ephemeral one for this attach.
+    // CF-F (harness#278): write a fresh ephemeral config for this attach.
+    // The sweep of orphaned configs from prior crashed sessions runs once
+    // at daemon-start (harness#362) — moving it out of the per-attach path
+    // closes the race where two near-simultaneous attaches could delete
+    // each other's still-live config files. Per-attach code is now
+    // write-only; cleanup is the daemon's job.
     let mcpConfigPath: string | undefined;
     if (cli === "claude") {
-      sweepOrphanedSpiritMcpConfigs(rootDir);
       const ephemeral = writeEphemeralSpiritMcpConfig(rootDir);
       mcpConfigPath = ephemeral.configPath;
       mcpConfigCleanup = ephemeral.cleanup;


### PR DESCRIPTION
## Summary

Security review (CF-F / harness#278 audit, 2026-05-11) identified a race in \`packages/cli/src/spirit/client.ts\`: each attach called \`sweepOrphanedSpiritMcpConfigs\` immediately before writing its own ephemeral config. Two near-simultaneous attaches could interleave their sweep/write calls such that attach C's sweep deletes attach B's still-live config file. Failure mode is recoverable (operator re-attaches, loses MCP tools for the dropped session) but the structural fix is small.

## Fix

Move the sweep from per-attach to \`bootDaemon\` startup. Per-attach code becomes write-only.

Justified because at daemon-start the daemon owns the \`.murmuration/\` directory and no attach can be in-flight (attaches require the daemon socket, which the daemon hasn't bound yet). Any config file present is genuinely orphaned. Aligns with the engineering-standard \"single owner for mutable state\" — the daemon owns lifecycle cleanup, the attach session owns its own file from creation to cleanup.

Behaviour is otherwise identical: orphaned configs from prior crashed sessions are still cleaned up on the next daemon start, which is when operators typically restart after a crash anyway.

## Test plan

- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test\` — 1298 pass (no test changes needed; behaviour identical, just relocated)
- [x] \`pnpm run lint\` — 0 errors
- [x] \`pnpm run format:check\` — clean

Closes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)