### PR TITLE
feat(agents,daemon,dashboard): reconcile AgentStateStore tombstones (#405)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ vite.config.ts.timestamp-*
 # Local Claude Code settings (operator machine)
 .claude/
 
+# Local scratch / nested operator checkouts (never part of the harness)
+.playwright-mcp/
+ep-work/
+

--- a/packages/cli/src/spirit/reports.test.ts
+++ b/packages/cli/src/spirit/reports.test.ts
@@ -34,6 +34,14 @@ const fakeSend = (
   };
 };
 
+/**
+ * ISO timestamp N days before now. `fetchMetrics` windows wakes and
+ * accountability observations to `[now - sinceDays, now]`, so fixtures must
+ * be anchored relative to the wall clock — hardcoded calendar dates rot out
+ * of the window once enough real time passes and fail on no code change.
+ */
+const daysAgo = (n: number): string => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+
 describe("fetchMetrics + renderMetricsMarkdown (Workstream Q)", () => {
   let root = "";
 
@@ -133,9 +141,9 @@ describe("buildAttentionQueue (Workstream Q)", () => {
   it("flags low-met-rate accountabilities", async () => {
     mkdirSync(join(root, ".murmuration"), { recursive: true });
     const obs = [
-      { accountabilityId: "weekly", agentId: "x", observedAt: "2026-04-30T10:00:00Z", met: false },
-      { accountabilityId: "weekly", agentId: "x", observedAt: "2026-05-01T10:00:00Z", met: false },
-      { accountabilityId: "weekly", agentId: "x", observedAt: "2026-05-02T10:00:00Z", met: true },
+      { accountabilityId: "weekly", agentId: "x", observedAt: daysAgo(3), met: false },
+      { accountabilityId: "weekly", agentId: "x", observedAt: daysAgo(2), met: false },
+      { accountabilityId: "weekly", agentId: "x", observedAt: daysAgo(1), met: true },
     ]
       .map((o) => JSON.stringify(o))
       .join("\n");
@@ -175,9 +183,9 @@ describe("buildAttentionQueue (Workstream Q)", () => {
     writeFileSync(
       join(root, ".murmuration", "accountability-observations.jsonl"),
       [
-        { accountabilityId: "x", agentId: "a", observedAt: "2026-05-01T10:00:00Z", met: false },
-        { accountabilityId: "x", agentId: "a", observedAt: "2026-05-02T10:00:00Z", met: true },
-        { accountabilityId: "x", agentId: "a", observedAt: "2026-05-03T10:00:00Z", met: false },
+        { accountabilityId: "x", agentId: "a", observedAt: daysAgo(3), met: false },
+        { accountabilityId: "x", agentId: "a", observedAt: daysAgo(2), met: true },
+        { accountabilityId: "x", agentId: "a", observedAt: daysAgo(1), met: false },
       ]
         .map((o) => JSON.stringify(o))
         .join("\n") + "\n",

--- a/packages/cli/src/spirit/spirit-meta-fixture.test.ts
+++ b/packages/cli/src/spirit/spirit-meta-fixture.test.ts
@@ -185,6 +185,14 @@ describe("Spirit meta-agent fixture — Workstream R (skill overlay)", () => {
 // Fixture builder
 // ---------------------------------------------------------------------------
 
+/**
+ * Base timestamp for synthetic runs + accountability observations: 3 days
+ * before now. fetchMetrics windows both to `[now - 30d, now]`, so the
+ * fixture must be anchored relative to the wall clock — a hardcoded calendar
+ * date silently rots out of the window and fails CI on no code change.
+ */
+const FIXTURE_BASE_MS = Date.now() - 3 * 24 * 60 * 60 * 1000;
+
 const buildFixture = (rootDir: string): void => {
   // murmuration/harness.yaml + soul.md
   const muDir = join(rootDir, "murmuration");
@@ -229,7 +237,10 @@ group_memberships: [${agentId === "facilitator-agent" ? "facilitation" : "resear
     mkdirSync(runsDir, { recursive: true });
     const lines: string[] = [];
     for (let i = 0; i < 4; i++) {
-      const startedAt = new Date("2026-04-30T10:00:00Z");
+      // Anchor a few days before now so the records stay inside the
+      // fetchMetrics 30-day window on whatever date the suite runs (a
+      // hardcoded calendar date rots out of the window — harness#405 CI).
+      const startedAt = new Date(FIXTURE_BASE_MS);
       startedAt.setUTCHours(startedAt.getUTCHours() + i);
       lines.push(
         JSON.stringify({
@@ -292,7 +303,7 @@ facilitator: research-agent
   mkdirSync(obsDir, { recursive: true });
   const obsLines: string[] = [];
   for (let i = 0; i < 4; i++) {
-    const t = new Date("2026-04-30T10:00:00Z");
+    const t = new Date(FIXTURE_BASE_MS);
     t.setUTCHours(t.getUTCHours() + i);
     obsLines.push(
       JSON.stringify({

--- a/packages/core/src/agents/agents.test.ts
+++ b/packages/core/src/agents/agents.test.ts
@@ -236,3 +236,91 @@ describe("AgentStateStore persistence", () => {
     expect(wakes[0]?.costMicros).toBe(5000);
   });
 });
+
+describe("AgentStateStore orphan reconciliation (harness#405)", () => {
+  it("markOrphaned transitions a known agent to 'orphaned'", () => {
+    const store = new AgentStateStore();
+    store.register("test-agent", 10_000);
+    store.transition("test-agent", "idle");
+    expect(store.getAgent("test-agent")?.currentState).toBe("idle");
+
+    store.markOrphaned("test-agent");
+    expect(store.getAgent("test-agent")?.currentState).toBe("orphaned");
+  });
+
+  it("markOrphaned is idempotent (re-calling on orphaned is a no-op)", () => {
+    const store = new AgentStateStore();
+    store.register("test-agent", 10_000);
+    store.markOrphaned("test-agent");
+    const first = store.getAgent("test-agent");
+    store.markOrphaned("test-agent");
+    const second = store.getAgent("test-agent");
+    expect(second).toEqual(first);
+  });
+
+  it("markOrphaned is a no-op on unknown agentId", () => {
+    const store = new AgentStateStore();
+    expect(() => store.markOrphaned("ghost")).not.toThrow();
+    expect(store.getAgent("ghost")).toBeUndefined();
+  });
+
+  it("markOrphaned clears currentWakeId and currentWakeStartedAt", () => {
+    const store = new AgentStateStore();
+    store.register("test-agent", 10_000);
+    store.transition("test-agent", "waking", "w-1");
+    expect(store.getAgent("test-agent")?.currentWakeId).toBe("w-1");
+
+    store.markOrphaned("test-agent");
+    expect(store.getAgent("test-agent")?.currentWakeId).toBeNull();
+    expect(store.getAgent("test-agent")?.currentWakeStartedAt).toBeNull();
+  });
+
+  it("register resurrects orphaned agents and resets failure counters", () => {
+    const store = new AgentStateStore();
+    store.register("test-agent", 10_000);
+    // Simulate a history: 5 wakes, then 3 consecutive failures
+    store.transition("test-agent", "waking", "w1");
+    store.recordWakeOutcome("w1", "success");
+    store.transition("test-agent", "waking", "w2");
+    store.recordWakeOutcome("w2", "failure", { errorMessage: "boom" });
+    store.transition("test-agent", "waking", "w3");
+    store.recordWakeOutcome("w3", "failure", { errorMessage: "boom" });
+    store.transition("test-agent", "waking", "w4");
+    store.recordWakeOutcome("w4", "failure", { errorMessage: "boom" });
+
+    const beforeOrphan = store.getAgent("test-agent");
+    expect(beforeOrphan?.consecutiveFailures).toBe(3);
+    expect(beforeOrphan?.totalWakes).toBe(4);
+
+    // Operator removes role.md, daemon reconciles
+    store.markOrphaned("test-agent");
+    expect(store.getAgent("test-agent")?.currentState).toBe("orphaned");
+
+    // Operator restores role.md (possibly a new, different agent at the
+    // same slug). Next boot calls register() again.
+    store.register("test-agent", 12_000);
+    const after = store.getAgent("test-agent");
+    expect(after?.currentState).toBe("registered");
+    expect(after?.consecutiveFailures).toBe(0); // RESET — old failures don't apply to new role.md
+    expect(after?.idleSkipStreak).toBe(0);
+    expect(after?.currentWakeId).toBeNull();
+    expect(after?.lastFiredContextHash).toBeNull();
+    // Historical totals preserved so the audit trail isn't lost.
+    expect(after?.totalWakes).toBe(4);
+    expect(after?.maxWallClockMs).toBe(12_000); // updated to new
+  });
+
+  it("normal re-registration (non-orphaned) only updates maxWallClockMs (existing behaviour preserved)", () => {
+    const store = new AgentStateStore();
+    store.register("test-agent", 10_000);
+    store.transition("test-agent", "waking", "w1");
+    store.recordWakeOutcome("w1", "failure", { errorMessage: "boom" });
+    expect(store.getAgent("test-agent")?.consecutiveFailures).toBe(1);
+
+    // Daemon restart — agent is still live, register() called again
+    store.register("test-agent", 15_000);
+    const after = store.getAgent("test-agent");
+    expect(after?.consecutiveFailures).toBe(1); // PRESERVED — not orphaned
+    expect(after?.maxWallClockMs).toBe(15_000);
+  });
+});

--- a/packages/core/src/agents/agents.test.ts
+++ b/packages/core/src/agents/agents.test.ts
@@ -305,6 +305,8 @@ describe("AgentStateStore orphan reconciliation (harness#405)", () => {
     expect(after?.idleSkipStreak).toBe(0);
     expect(after?.currentWakeId).toBeNull();
     expect(after?.lastFiredContextHash).toBeNull();
+    expect(after?.lastOutcome).toBeNull(); // CLEARED — old life's failure doesn't carry forward
+    expect(after?.lastWokenAt).toBeNull(); // CLEARED — not "last woken weeks ago"
     // Historical totals preserved so the audit trail isn't lost.
     expect(after?.totalWakes).toBe(4);
     expect(after?.maxWallClockMs).toBe(12_000); // updated to new

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -29,7 +29,17 @@ export type AgentLifecycleState =
   | "completed"
   | "failed"
   | "timed-out"
-  | "spawn-failed";
+  | "spawn-failed"
+  /**
+   * The agent has a record in `state.json` from a prior session but is
+   * no longer present in the daemon's live `agents/<id>/role.md` set —
+   * the operator removed the agent directory or its role.md (harness#405).
+   * The daemon does not schedule wakes for orphaned agents, and dashboard
+   * surfaces should filter them out of the active set. If the operator
+   * later restores the role.md, `register()` will resurrect the agent
+   * by resetting failure counters while keeping historical totals.
+   */
+  | "orphaned";
 
 export type WakeOutcome = "success" | "failure" | "timeout" | "killed" | "spawn-failed";
 
@@ -102,6 +112,14 @@ export interface IAgentStateStore {
    * outcome was successful. Increments `idleSkipStreak`.
    */
   recordIdleSkip(agentId: string): void;
+  /**
+   * Mark an agent as orphaned (harness#405) — its record persists in
+   * state.json from a prior session, but no live role.md backs it.
+   * Idempotent: a no-op if the agent is already "orphaned" or unknown.
+   * Used by the boot reconciliation pass to flag agents the operator
+   * removed without crashing the daemon.
+   */
+  markOrphaned(agentId: string): void;
   getAgent(agentId: string): AgentRecord | undefined;
   getAllAgents(): readonly AgentRecord[];
   getRecentWakes(agentId: string, limit?: number): readonly AgentWakeInstance[];
@@ -190,6 +208,29 @@ export class AgentStateStore implements IAgentStateStore {
     this.#guardWrite("register");
     const existing = this.#agents.get(agentId);
     if (existing) {
+      if (existing.currentState === "orphaned") {
+        // Resurrection (harness#405): the operator removed this agent's
+        // role.md, the daemon marked it orphaned, and now the role.md is
+        // back. The new role.md may have completely different scopes,
+        // schedule, write surface — so the OLD failure history doesn't
+        // necessarily apply. Reset current-state counters (consecutive
+        // failures could trip the circuit breaker on the new agent's
+        // first wake for reasons that have nothing to do with it) but
+        // KEEP historical totals (totalWakes, totalArtifacts, idleWakes,
+        // registeredAt) as audit signal that this slot has prior lives.
+        this.#agents.set(agentId, {
+          ...existing,
+          currentState: "registered",
+          maxWallClockMs,
+          consecutiveFailures: 0,
+          idleSkipStreak: 0,
+          currentWakeId: null,
+          currentWakeStartedAt: null,
+          lastFiredContextHash: null,
+        });
+        void this.#persist();
+        return;
+      }
       // Update maxWallClockMs but preserve history
       this.#agents.set(agentId, { ...existing, maxWallClockMs });
       return;
@@ -359,6 +400,30 @@ export class AgentStateStore implements IAgentStateStore {
     this.#agents.set(agentId, {
       ...agent,
       idleSkipStreak: agent.idleSkipStreak + 1,
+    });
+    void this.#persist();
+  }
+
+  /**
+   * Mark an agent as orphaned (harness#405). Idempotent.
+   *
+   * The record is preserved (historical totals + last known state) so
+   * downstream readers can distinguish "this slot used to exist" from
+   * "this slot has no history." But the daemon will not schedule wakes
+   * against it, and dashboard surfaces should filter it out of the
+   * active set. If the operator later restores the role.md, the next
+   * `register()` call resurrects the agent with reset failure counters.
+   */
+  public markOrphaned(agentId: string): void {
+    this.#guardWrite("markOrphaned");
+    const agent = this.#agents.get(agentId);
+    if (!agent) return;
+    if (agent.currentState === "orphaned") return;
+    this.#agents.set(agentId, {
+      ...agent,
+      currentState: "orphaned",
+      currentWakeId: null,
+      currentWakeStartedAt: null,
     });
     void this.#persist();
   }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -218,6 +218,10 @@ export class AgentStateStore implements IAgentStateStore {
         // first wake for reasons that have nothing to do with it) but
         // KEEP historical totals (totalWakes, totalArtifacts, idleWakes,
         // registeredAt) as audit signal that this slot has prior lives.
+        // Also clear last-life status fields (lastOutcome, lastWokenAt) so
+        // the restored agent doesn't surface as "failed, last woken weeks
+        // ago" in the dashboard before its first new wake — the same
+        // phantom-state confusion this reconciliation exists to remove.
         this.#agents.set(agentId, {
           ...existing,
           currentState: "registered",
@@ -227,6 +231,8 @@ export class AgentStateStore implements IAgentStateStore {
           currentWakeId: null,
           currentWakeStartedAt: null,
           lastFiredContextHash: null,
+          lastOutcome: null,
+          lastWokenAt: null,
         });
         void this.#persist();
         return;

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -654,7 +654,13 @@ export class Daemon {
     // scheduler start happens in the .then() callback so stats from
     // the previous run are restored before register() creates fresh records.
     const doRegisterAndStart = (): void => {
+      // Register live agents first. For agents whose prior state was
+      // "orphaned" (operator removed and then restored the role.md),
+      // `register()` now resets failure counters automatically while
+      // keeping historical totals — see harness#405.
+      const liveAgentIds = new Set<string>();
       for (const agent of this.#agents) {
+        liveAgentIds.add(agent.agentId);
         this.#agentStateStore?.register(agent.agentId, agent.maxWallClockMs);
         this.#agentStateStore?.transition(agent.agentId, "idle");
         this.#scheduler.schedule(makeAgentId(agent.agentId), agent.trigger);
@@ -662,6 +668,26 @@ export class Daemon {
           agentId: agent.agentId,
           trigger: agent.trigger,
         });
+      }
+      // harness#405: reconcile tombstones. Any record in state.json that
+      // ISN'T in the live agent set — and isn't already orphaned — gets
+      // marked orphaned now. Without this, removed agents persist forever
+      // in dashboards, accumulate over months of iteration, and re-add
+      // would inherit stale circuit-breaker failure counts.
+      const store = this.#agentStateStore;
+      if (store) {
+        for (const record of store.getAllAgents()) {
+          if (liveAgentIds.has(record.agentId)) continue;
+          if (record.currentState === "orphaned") continue;
+          store.markOrphaned(record.agentId);
+          this.#logger.warn("daemon.agent.stale-record", {
+            agentId: record.agentId,
+            previousState: record.currentState,
+            registeredAt: record.registeredAt,
+            lastWokenAt: record.lastWokenAt,
+            totalWakes: record.totalWakes,
+          });
+        }
       }
       this.#scheduleGovernanceCrons();
       this.#scheduler.start();

--- a/packages/dashboard-tui/src/data.ts
+++ b/packages/dashboard-tui/src/data.ts
@@ -498,6 +498,7 @@ export const readRecentActivity = async (
   try {
     const content = await readFile(stateFile, "utf8");
     const data = JSON.parse(content) as {
+      agents?: Record<string, { currentState?: string }>;
       wakes?: Record<
         string,
         {
@@ -510,9 +511,19 @@ export const readRecentActivity = async (
         }
       >;
     };
+    // harness#405: skip wakes belonging to orphaned agents — their
+    // role.md was removed but the wake history persists in state.json.
+    // Showing stale wakes in the activity feed misleads operators into
+    // thinking an agent they removed is still active.
+    const orphanedAgents = new Set<string>();
+    if (data.agents) {
+      for (const [id, rec] of Object.entries(data.agents)) {
+        if (rec.currentState === "orphaned") orphanedAgents.add(id);
+      }
+    }
     if (data.wakes) {
       const allWakes = Object.values(data.wakes)
-        .filter((w) => w.startedAt)
+        .filter((w) => w.startedAt && !orphanedAgents.has(w.agentId))
         .sort((a, b) => (a.startedAt ?? "").localeCompare(b.startedAt ?? ""))
         .slice(-maxEntries);
 


### PR DESCRIPTION
## Summary

PR #404 (harness#380, orphan-schedule warning) made the daemon refuse to schedule wakes for agents whose role.md was removed. But the architecture review on that PR flagged a HIGH finding: the **state.json records** for those removed agents persist indefinitely. Tombstone accumulation, stale circuit-breaker counts on resurrection, phantom agents in the dashboard, stale wakes in the activity feed.

This PR closes the loop.

## Three-part reconciliation

**Core** — \`packages/core/src/agents/index.ts\`
- New \`\"orphaned\"\` member on \`AgentLifecycleState\`
- New \`markOrphaned(agentId)\` method — idempotent, no-op on unknown id, clears current-wake fields
- \`register()\` now detects re-registration of an orphaned agent and **resets failure counters** (\`consecutiveFailures\`, \`idleSkipStreak\`, \`currentWakeId\`, \`lastFiredContextHash\`) while **preserving historical totals** (\`totalWakes\`, \`totalArtifacts\`, \`idleWakes\`, \`registeredAt\`) — so the audit trail isn't lost but the new role.md doesn't inherit a tripped circuit breaker

**Daemon** — \`packages/core/src/daemon/index.ts\`
- After registering all live agents in \`doRegisterAndStart()\`, iterate every record in the store
- Anything not in the live set AND not already orphaned → \`markOrphaned()\` + \`daemon.agent.stale-record\` warn with previousState / registeredAt / lastWokenAt / totalWakes
- Operators see the divergence in logs the first boot after they remove an agent

**Dashboard** — \`packages/dashboard-tui/src/data.ts\`
- \`readRecentActivity\` now reads \`state.json.agents\` for the orphaned set and filters wake entries against it
- Removed agents stop appearing in the activity feed on the next refresh

## Test plan

- [x] 6 new tests on AgentStateStore: markOrphaned happy path, idempotency, no-op on unknown id, current-wake field clearing, register() resurrection (counter reset + total preservation), normal re-registration unchanged
- [x] \`pnpm run typecheck\` — clean across 8 packages
- [x] \`pnpm run test\` — 1304 pass (+6)
- [x] \`pnpm run lint\` — 0 errors
- [x] \`pnpm run format:check\` — clean

Closes #405.

## Follow-ups from local review (added before merge)

- **`d6bad29` fix(agents): clear last-life status on orphan resurrection** — `register()` resurrection now also nulls `lastOutcome`/`lastWokenAt`, so a restored role.md doesn't surface as "failed, last woken weeks ago" before its first new wake. Test assertions added.
- **`1c14741` test(spirit): anchor reporting fixtures to relative time** — pre-existing, repo-wide CI blocker surfaced by this PR's re-run: the spirit reporting fixtures pinned wakes/observations to hardcoded April–May 2026 dates, but `fetchMetrics` windows to `[now − 30d, now]`. The data aged out of the window (~May 31), failing every PR's CI on no code change. Fixtures are now anchored to `now` (`daysAgo()` / `FIXTURE_BASE_MS`); awaiting-close digest dirs stay as fixed names (that path selects latest-by-name, not by window).
- **`f195f44` chore:** gitignore local scratch (`.playwright-mcp/`, `ep-work/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
