### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-**Signal-bundle hygiene + daemon orphan-schedule + tombstone reconciliation + Trojan Source hardening.** Operator-visible diagnostics for the silent failure mode that bites every long-running murmuration: stale GitHub issues that bloat every watching agent's per-wake context, and agent directories that quietly wake on the default-agent template after their `role.md` was removed — plus reconciliation of the state.json records those removed agents leave behind.
+## [0.9.0] - 2026-06-10
+
+**Operational hygiene, agent-lifecycle reconciliation, and contract-validation hardening.** A cycle of operator-visible diagnostics and correctness fixes for the silent failure modes that bite long-running murmurations: stale GitHub issues that bloat every watching agent's per-wake context, agent directories that wake on the default-agent template after their `role.md` was removed (and the `state.json` tombstones they leave behind), subscription-CLI agents whose declared file writes silently no-op'd in headless mode, and contract obligations that could be satisfied by a path the operator never declared. Behavioral validation remains warning-only — its promotion to hard-fail, and the `verifiedActions` evidence channel it depends on, are deferred to the next release ([#376](https://github.com/murmurations-ai/murmurations-harness/issues/376)).
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
## v0.9.0 — Operational hygiene, agent-lifecycle reconciliation, contract-validation hardening

Bumps root + 8 workspace packages `0.8.0 → 0.9.0` and retitles the CHANGELOG `[Unreleased]` → `[0.9.0]`.

**Minor bump per RELEASE-POLICY** — the cycle since v0.8.0 added features and behavior changes, not just patches:

- `murmuration list-stale-issues` CLI + `doctor --live` hygiene category + per-wake signal-bundle metrics (#394)
- Daemon orphan-schedule warning (#380) + `AgentStateStore` tombstone reconciliation (#405/#415)
- Subscription-CLI `permissionMode` auto-derivation from `branch_commits` (#392/#412)
- Per-segment glob matcher for contract obligations (#363/#417)
- Spirit MCP-config sweep race fix (#362/#414), typed-error name preservation (#360/#413)
- Trojan Source / bidi terminal hardening
- Behavior changes: comment cap 20→5 (#398), boot refusing orphaned schedules (#380)

**Deferred to the next release (#376):** `validateBehavior` hard-fail promotion + `verifiedActions` (#364B) + the #379 security gate — the soak that gates the flip is not met and `verifiedActions` needs proper design (see #376 re-scope comment).

### Release mechanics
After merge, tagging `v0.9.0` on the merge commit triggers `release.yml`: version-match check (all 9 `package.json` = `0.9.0` ✓), full gate, OIDC publish of all `@murmurations-ai/*` packages, GitHub Release.

Full gate green locally: build / typecheck / lint / format / 1323 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)