### PR TITLE
fix(ci): stop setup-node from shadowing OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,17 @@ jobs:
         with:
           node-version: "22.x"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          # NOTE: deliberately NO `registry-url:` here. setup-node's
+          # registry-url writes an .npmrc line
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and exports
+          # an (empty, since we keep no NPM_TOKEN secret) NODE_AUTH_TOKEN.
+          # That empty token shadows OIDC Trusted Publishing: npm sends an
+          # empty bearer instead of performing the OIDC exchange, and the
+          # registry rejects the PUT with E404 (this broke the first OIDC
+          # release, v0.9.0). pnpm publishes to the default npmjs.org
+          # registry and performs the OIDC exchange itself when `id-token:
+          # write` is granted and no token is configured — so the registry
+          # must NOT be pre-wired with an auth token here.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why

The v0.9.0 release workflow **failed at the publish step** — it was the first release to actually exercise OIDC Trusted Publishing (migrated in #391; v0.8.0 and earlier used the old `NPM_TOKEN`). Nothing published (npm `latest` is still `0.8.0`) and the GitHub Release was not created. Clean failure — no partial publish, nothing to deprecate.

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@murmurations-ai%2fcore - Not found
npm error 404  '@murmurations-ai/core@0.9.0' is not in this registry.
```

## Root cause

`actions/setup-node` with `registry-url:` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and exports an **empty** `NODE_AUTH_TOKEN` (we keep no npm token secret after the OIDC migration). The empty token shadows the OIDC exchange: npm sends an empty bearer token instead of exchanging the GitHub OIDC token for a short-lived publish token, and the registry rejects the `PUT` with `E404`.

## Fix

Remove `registry-url` from the setup-node step so no auth token is wired into `.npmrc`. `pnpm -r publish --provenance` publishes to the default npmjs.org registry and performs the OIDC exchange itself when `id-token: write` is granted and no token is configured. Rationale documented inline so it isn't reintroduced.

## ⚠️ Operator action that may also be required

This fixes the *workflow*. If the `E404` is compounded by a missing Trusted Publisher binding, the affected package(s) will fail with a **different** error — `no trusted publisher configured` — which can only be resolved in each package's **npmjs.com → Settings → Publishing access** tab (repo + workflow + branch). Please confirm all 8 `@murmurations-ai/*` packages have the binding before re-tagging.

## Recovery path (per docs/RELEASE-RECOVERY.md)

Nothing published, infra-not-code failure, <24h → clean retry: after merge, delete + re-create the `v0.9.0` tag on the new `main` tip (same as the v0.8.0 re-tag precedent) to re-trigger publish with the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)