### PR TITLE
feat(identity,scheduler): multiple cron wake schedules per agent (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Multiple cron wake schedules per agent** ([#420](https://github.com/murmurations-ai/murmurations-harness/issues/420)). `wake_schedule` in `role.md` now accepts an array of trigger objects in addition to the single-object form, so an agent can wake on more than one schedule — e.g. a facilitator that runs a `setup` pass before its circle's domain agents and a `summary` pass after. Each entry takes an optional `label` (surfaced in logs). The scheduler gains a `multi` `WakeTrigger` that fans out into one independently-armed, independently-re-arming timer per sub-trigger; `unschedule` clears them all. Single-object `wake_schedule` is unchanged.
+
 ## [0.9.0] - 2026-06-10
 
 **Operational hygiene, agent-lifecycle reconciliation, and contract-validation hardening.** A cycle of operator-visible diagnostics and correctness fixes for the silent failure modes that bite long-running murmurations: stale GitHub issues that bloat every watching agent's per-wake context, agent directories that wake on the default-agent template after their `role.md` was removed (and the `state.json` tombstones they leave behind), subscription-CLI agents whose declared file writes silently no-op'd in headless mode, and contract obligations that could be satisfied by a path the operator never declared. Behavioral validation remains warning-only — its promotion to hard-fail, and the `verifiedActions` evidence channel it depends on, are deferred to the next release ([#376](https://github.com/murmurations-ai/murmurations-harness/issues/376)).

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -822,14 +822,42 @@ const discoverGroupConfigs = async (
   return configs;
 };
 
+interface SingleWakeSchedule {
+  readonly cron?: string | undefined;
+  readonly delayMs?: number | undefined;
+  readonly intervalMs?: number | undefined;
+  readonly events?: readonly string[] | undefined;
+  readonly tz?: string | undefined;
+  readonly label?: string | undefined;
+}
+
+/**
+ * Build a {@link WakeTrigger} from a role.md `wake_schedule`, which may be a
+ * single trigger object or — for agents that wake on multiple schedules
+ * (harness#420) — an array of them. An array yields a composite `multi`
+ * trigger (a single-element array collapses to its lone trigger).
+ */
 const triggerFromFrontmatter = (
-  wakeSchedule: {
-    readonly cron?: string | undefined;
-    readonly delayMs?: number | undefined;
-    readonly intervalMs?: number | undefined;
-    readonly events?: readonly string[] | undefined;
-    readonly tz?: string | undefined;
-  },
+  wakeSchedule: SingleWakeSchedule | readonly SingleWakeSchedule[],
+  agentId: string,
+): WakeTrigger => {
+  if (Array.isArray(wakeSchedule)) {
+    // Array.isArray narrows to `any[]`; re-type for a safe `.map`.
+    const list = wakeSchedule as readonly SingleWakeSchedule[];
+    const triggers = list.map((s) => triggerFromSingleSchedule(s, agentId));
+    if (triggers.length === 1) {
+      const [only] = triggers;
+      if (only) return only;
+    }
+    return { kind: "multi", triggers };
+  }
+  // Not an array → a single schedule object. (Array.isArray doesn't narrow
+  // the readonly-array union member, so assert the single shape explicitly.)
+  return triggerFromSingleSchedule(wakeSchedule as SingleWakeSchedule, agentId);
+};
+
+const triggerFromSingleSchedule = (
+  wakeSchedule: SingleWakeSchedule,
   agentId: string,
 ): WakeTrigger => {
   if (wakeSchedule.cron !== undefined) {

--- a/packages/cli/src/spirit/overview.ts
+++ b/packages/cli/src/spirit/overview.ts
@@ -187,9 +187,14 @@ const readAgentRole = async (rootDir: string, agentDir: string): Promise<AgentSu
     const parsed = parseYaml(yamlText) as RoleYamlShape | undefined;
     if (!parsed) return blankAgent(agentDir);
 
-    const cron =
-      typeof parsed.wake_schedule?.cron === "string" ? parsed.wake_schedule.cron : undefined;
-    const tz = typeof parsed.wake_schedule?.tz === "string" ? ` ${parsed.wake_schedule.tz}` : "";
+    // wake_schedule may be a single object or an array of them (harness#420);
+    // for the overview we surface the first schedule's cron/tz.
+    const wsRaw: unknown = parsed.wake_schedule;
+    const firstSchedule = (Array.isArray(wsRaw) ? wsRaw[0] : wsRaw) as
+      | { cron?: unknown; tz?: unknown }
+      | undefined;
+    const cron = typeof firstSchedule?.cron === "string" ? firstSchedule.cron : undefined;
+    const tz = typeof firstSchedule?.tz === "string" ? ` ${firstSchedule.tz}` : "";
 
     const groupsRaw = parsed.group_memberships;
     const groups = Array.isArray(groupsRaw)

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -1387,6 +1387,8 @@ const formatTrigger = (trigger: WakeTrigger): string => {
       return `interval: ${String(trigger.intervalMs)}ms`;
     case "delay-once":
       return `delay-once: ${String(trigger.delayMs)}ms`;
+    case "multi":
+      return `multi: [${trigger.triggers.map(formatTrigger).join(", ")}]`;
     default:
       return "unknown";
   }

--- a/packages/core/src/identity/identity.test.ts
+++ b/packages/core/src/identity/identity.test.ts
@@ -12,6 +12,16 @@ import {
   splitFrontmatter,
 } from "./index.js";
 
+/**
+ * Extract a cron from a `wake_schedule`, which may be a single object or an
+ * array of them (harness#420). For the array form, returns the first entry's
+ * cron. Keeps the single-schedule assertions below concise + type-safe.
+ */
+const cronOf = (ws: unknown): string | undefined => {
+  const obj = (Array.isArray(ws) ? ws[0] : ws) as { cron?: unknown } | undefined;
+  return typeof obj?.cron === "string" ? obj.cron : undefined;
+};
+
 describe("splitFrontmatter", () => {
   it("extracts frontmatter and body from a well-formed file", () => {
     const source = `---
@@ -214,6 +224,78 @@ model_tier: galactic
     const loader = new IdentityLoader({ rootDir });
 
     await expect(loader.load("13-badtier")).rejects.toBeInstanceOf(FrontmatterInvalidError);
+  });
+
+  describe("multi wake_schedule (harness#420)", () => {
+    const writeMultiScheduleAgent = async (wakeScheduleYaml: string): Promise<void> => {
+      await writeFixture("murmuration/soul.md", "# Soul\n");
+      await writeFixture("agents/14-multi/soul.md", "# Agent Soul\n");
+      await writeFixture(
+        "agents/14-multi/role.md",
+        `---
+agent_id: "14-multi"
+name: "Multi"
+model_tier: balanced
+${wakeScheduleYaml}---
+
+# Multi
+`,
+      );
+    };
+
+    it("parses an array wake_schedule into a list of triggers (with labels)", async () => {
+      await writeMultiScheduleAgent(
+        `wake_schedule:
+  - cron: "40 22 * * 1"
+    tz: America/Vancouver
+    label: setup
+  - cron: "0 3 * * 2"
+    tz: America/Vancouver
+    label: summary
+`,
+      );
+      const loaded = await new IdentityLoader({ rootDir }).load("14-multi");
+      const ws = loaded.frontmatter.wake_schedule;
+      expect(Array.isArray(ws)).toBe(true);
+      const list = ws as readonly { cron?: string; tz?: string; label?: string }[];
+      expect(list).toHaveLength(2);
+      expect(list[0]).toMatchObject({
+        cron: "40 22 * * 1",
+        tz: "America/Vancouver",
+        label: "setup",
+      });
+      expect(list[1]).toMatchObject({ cron: "0 3 * * 2", label: "summary" });
+    });
+
+    it("still accepts the single-object form unchanged", async () => {
+      await writeMultiScheduleAgent(
+        `wake_schedule:
+  cron: "0 9 * * *"
+`,
+      );
+      const loaded = await new IdentityLoader({ rootDir }).load("14-multi");
+      expect(Array.isArray(loaded.frontmatter.wake_schedule)).toBe(false);
+      expect(cronOf(loaded.frontmatter.wake_schedule)).toBe("0 9 * * *");
+    });
+
+    it("rejects an empty array wake_schedule", async () => {
+      await writeMultiScheduleAgent(`wake_schedule: []\n`);
+      await expect(new IdentityLoader({ rootDir }).load("14-multi")).rejects.toBeInstanceOf(
+        FrontmatterInvalidError,
+      );
+    });
+
+    it("rejects an array with an invalid cron expression", async () => {
+      await writeMultiScheduleAgent(
+        `wake_schedule:
+  - cron: "40 22 * * 1"
+  - cron: "not a cron"
+`,
+      );
+      await expect(new IdentityLoader({ rootDir }).load("14-multi")).rejects.toBeInstanceOf(
+        FrontmatterInvalidError,
+      );
+    });
   });
 
   describe("Zod issue annotation (v0.5.0 Milestone 1)", () => {
@@ -553,7 +635,7 @@ describe("roleFrontmatterSchema (ADR-0016 extensions)", () => {
     const loaded = await loader.load("01-research");
     expect(loaded.frontmatter.llm?.provider).toBe("gemini");
     expect(loaded.frontmatter.llm?.model).toBe("gemini-2.5-pro");
-    expect(loaded.frontmatter.wake_schedule?.cron).toBe("0 18 * * 0");
+    expect(cronOf(loaded.frontmatter.wake_schedule)).toBe("0 18 * * 0");
     expect(loaded.frontmatter.signals.github_scopes).toHaveLength(1);
     expect(loaded.frontmatter.github.write_scopes.issue_comments).toEqual([
       "xeeban/emergent-praxis",
@@ -901,7 +983,7 @@ describe("examples/research-agent identity chain", () => {
     const loader = new IdentityLoader({ rootDir: exampleRoot });
     const loaded = await loader.load("01-research");
 
-    expect(loaded.frontmatter.wake_schedule?.cron).toBe("0 18 * * 0");
+    expect(cronOf(loaded.frontmatter.wake_schedule)).toBe("0 18 * * 0");
   });
 
   it("parses the ADR-0017 write scopes — notes/weekly/** on emergent-praxis", async () => {
@@ -990,7 +1072,7 @@ describe("examples/facilitator-agent identity chain", () => {
     const loader = new IdentityLoader({ rootDir: exampleRoot });
     const loaded = await loader.load("facilitator-agent");
 
-    expect(loaded.frontmatter.wake_schedule?.cron).toBe("0 7,18 * * *");
+    expect(cronOf(loaded.frontmatter.wake_schedule)).toBe("0 7,18 * * *");
   });
 
   it("parses the four ADR-0042 accountabilities with done_when blocks", async () => {

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -273,6 +273,10 @@ const wakeScheduleSchema = z
     /** IANA timezone for the cron expression (e.g. "America/Vancouver").
      *  If absent, cron fires in UTC. Only meaningful when `cron` is set. */
     tz: z.string().min(1).optional(),
+    /** Optional human label for this trigger — surfaced in logs/telemetry.
+     *  Useful to distinguish the entries of a multi-schedule (harness#420),
+     *  e.g. `setup` vs `summary`. Ignored by the scheduler itself. */
+    label: z.string().min(1).optional(),
   })
   .refine(
     (s) =>
@@ -282,6 +286,17 @@ const wakeScheduleSchema = z
       (s.events !== undefined && s.events.length > 0),
     { message: "wake_schedule must declare at least one trigger" },
   );
+
+/**
+ * A role may declare a single wake trigger (object) OR several (harness#420):
+ * an array of trigger objects whose wakes are unioned — e.g. a facilitator
+ * that runs a setup pass before its circle and a summary pass after. The
+ * single-object form is unchanged; the array form is new.
+ */
+const wakeScheduleFieldSchema = z.union([
+  wakeScheduleSchema,
+  z.array(wakeScheduleSchema).min(1, "wake_schedule list must declare at least one trigger"),
+]);
 
 // ---------------------------------------------------------------------------
 // ADR-0016 extensions — llm, signals, github, prompt, budget, secrets
@@ -429,7 +444,7 @@ export const roleFrontmatterSchema = z.object({
 
   // legacy compat (Phase 1B)
   model_tier: modelTierSchema,
-  wake_schedule: wakeScheduleSchema.optional(),
+  wake_schedule: wakeScheduleFieldSchema.optional(),
   group_memberships: z.array(identifierSchema).default([]),
   // Default 2 minutes. A single LLM wake with a few tool calls takes
   // 30–90s on Sonnet/GPT-class models; the prior 15s default killed

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -1,13 +1,15 @@
 /**
  * Scheduler — fires agent wakes on cron + event triggers.
  *
- * `TimerScheduler` supports four trigger kinds:
+ * `TimerScheduler` supports five trigger kinds:
  *
  *   - `delay-once`  — one-shot setTimeout after N ms
  *   - `interval`    — setInterval repeating every N ms
  *   - `cron`        — compute the next fire time via cron-parser,
  *                     setTimeout to that delta, and re-arm on fire
  *   - `event`       — still a stub (Phase 3 event bus)
+ *   - `multi`       — fire on ANY of several sub-triggers (harness#420);
+ *                     expanded by schedule() into independent sub-entries
  *
  * Cron support landed in Phase 2D step 2D4. Expressions are parsed
  * with `tz: "UTC"` always — `0 18 * * 0` means Sunday 18:00 UTC
@@ -44,7 +46,17 @@ export type WakeTrigger =
   | { readonly kind: "interval"; readonly intervalMs: number }
   | { readonly kind: "cron"; readonly expression: string; readonly tz?: string }
   // TODO(phase-3): event bus wiring
-  | { readonly kind: "event"; readonly eventType: string };
+  | { readonly kind: "event"; readonly eventType: string }
+  /**
+   * Composite trigger: fire on ANY of several sub-triggers (harness#420).
+   * For agents with multiple cron wake schedules — e.g. a facilitator that
+   * runs a setup pass before its circle's domain agents and a summary pass
+   * after. {@link TimerScheduler.schedule} expands a `multi` into one
+   * independently-armed sub-entry per sub-trigger (keyed `agentId#i`), all
+   * cleared together by `unschedule(agentId)`. Sub-triggers must be
+   * non-`multi` (single level only).
+   */
+  | { readonly kind: "multi"; readonly triggers: readonly WakeTrigger[] };
 
 // ---------------------------------------------------------------------------
 // Scheduled event payload
@@ -87,6 +99,12 @@ export interface Scheduler {
 // ---------------------------------------------------------------------------
 
 interface ScheduledEntry {
+  /**
+   * Key in {@link TimerScheduler.#entries}. `agentId.value` for a single
+   * trigger; `${agentId.value}#${i}` for the i-th sub-trigger of a `multi`.
+   * Agent IDs never contain `#`, so the prefix is unambiguous.
+   */
+  readonly key: string;
   readonly agentId: AgentId;
   readonly trigger: WakeTrigger;
   timerHandle: NodeJS.Timeout | undefined;
@@ -103,29 +121,44 @@ export class TimerScheduler implements Scheduler {
   #running = false;
 
   public schedule(agentId: AgentId, trigger: WakeTrigger): void {
-    // Replace any existing entry for this agent (idempotent per spec).
+    // Replace any existing entry/entries for this agent (idempotent per spec).
     this.unschedule(agentId);
-    const entry: ScheduledEntry = {
-      agentId,
-      trigger,
-      timerHandle: undefined,
-    };
-    this.#entries.set(agentId.value, entry);
+    // A `multi` trigger fans out into one independently-armed sub-entry per
+    // sub-trigger (harness#420). Each cron sub-entry keeps its own re-arm
+    // loop, so they fire independently and `unschedule` clears them all.
+    if (trigger.kind === "multi") {
+      trigger.triggers.forEach((sub, i) => {
+        this.#addEntry(`${agentId.value}#${String(i)}`, agentId, sub);
+      });
+      return;
+    }
+    this.#addEntry(agentId.value, agentId, trigger);
+  }
+
+  #addEntry(key: string, agentId: AgentId, trigger: WakeTrigger): void {
+    const entry: ScheduledEntry = { key, agentId, trigger, timerHandle: undefined };
+    this.#entries.set(key, entry);
     if (this.#running) {
       this.#arm(entry);
     }
   }
 
   public unschedule(agentId: AgentId): boolean {
-    const entry = this.#entries.get(agentId.value);
-    if (!entry) return false;
-    if (entry.timerHandle) {
-      clearTimeout(entry.timerHandle);
-      clearInterval(entry.timerHandle);
-      entry.timerHandle = undefined;
+    // Remove the single entry (`agentId.value`) plus any `multi` sub-entries
+    // (`agentId.value#<i>`). Deleting during Map iteration is safe in JS.
+    const prefix = `${agentId.value}#`;
+    let removed = false;
+    for (const [key, entry] of this.#entries) {
+      if (key !== agentId.value && !key.startsWith(prefix)) continue;
+      if (entry.timerHandle) {
+        clearTimeout(entry.timerHandle);
+        clearInterval(entry.timerHandle);
+        entry.timerHandle = undefined;
+      }
+      this.#entries.delete(key);
+      removed = true;
     }
-    this.#entries.delete(agentId.value);
-    return true;
+    return removed;
   }
 
   public onWake(listener: WakeListener): void {
@@ -194,6 +227,15 @@ export class TimerScheduler implements Scheduler {
         );
         break;
       }
+      case "multi": {
+        // schedule() expands `multi` into non-multi sub-entries, so an armed
+        // entry should never carry kind "multi". Guard defensively rather
+        // than silently nesting.
+        console.warn(
+          `[scheduler] multi trigger reached #arm for agent ${entry.agentId.value} — should have been expanded by schedule()`,
+        );
+        break;
+      }
     }
   }
 
@@ -245,7 +287,10 @@ export class TimerScheduler implements Scheduler {
           kind: "scheduled",
           cronExpression: expression,
         });
-        if (this.#running && this.#entries.get(entry.agentId.value) === entry) {
+        // Re-arm only if this exact entry is still scheduled. Keyed by
+        // entry.key (not agentId.value) so multi sub-entries re-arm
+        // independently rather than clobbering each other.
+        if (this.#running && this.#entries.get(entry.key) === entry) {
           this.#armCron(entry);
         }
       })();

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -344,4 +344,102 @@ describe("TimerScheduler", () => {
 
     await scheduler.stop();
   });
+
+  // -------------------------------------------------------------------
+  // Multi (harness#420) — multiple wake schedules per agent
+  // -------------------------------------------------------------------
+
+  it("multi — arms every sub-trigger independently, all under the real agentId", async () => {
+    vi.useFakeTimers();
+    const scheduler = new TimerScheduler();
+    const agentId = makeAgentId("facilitator-agent");
+
+    const fired: ScheduledWakeEvent[] = [];
+    scheduler.onWake((event) => {
+      fired.push(event);
+    });
+
+    scheduler.schedule(agentId, {
+      kind: "multi",
+      triggers: [
+        { kind: "interval", intervalMs: 100 },
+        { kind: "interval", intervalMs: 250 },
+      ],
+    });
+    scheduler.start();
+
+    // Advance to 520ms (off any boundary): 100ms fires at 100/200/300/400/500
+    // = 5; 250ms fires at 250/500 = 2; total 7.
+    await vi.advanceTimersByTimeAsync(520);
+    expect(fired).toHaveLength(7);
+    // Every wake carries the real agentId, not the internal `agentId#i` key.
+    expect(fired.every((e) => e.agentId.value === "facilitator-agent")).toBe(true);
+
+    await scheduler.stop();
+  });
+
+  it("multi — unschedule clears every sub-entry", async () => {
+    vi.useFakeTimers();
+    const scheduler = new TimerScheduler();
+    const agentId = makeAgentId("facilitator-agent");
+
+    const fired: ScheduledWakeEvent[] = [];
+    scheduler.onWake((event) => {
+      fired.push(event);
+    });
+
+    scheduler.schedule(agentId, {
+      kind: "multi",
+      triggers: [
+        { kind: "interval", intervalMs: 100 },
+        { kind: "interval", intervalMs: 250 },
+      ],
+    });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(120); // only the 100ms sub-trigger has fired
+    expect(fired).toHaveLength(1);
+
+    expect(scheduler.unschedule(agentId)).toBe(true);
+
+    // Both sub-entries are cleared — nothing else fires.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fired).toHaveLength(1);
+
+    await scheduler.stop();
+  });
+
+  it("multi — each cron sub-trigger re-arms on its own key", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-09T12:00:00.000Z"));
+
+    const scheduler = new TimerScheduler();
+    const agentId = makeAgentId("facilitator-agent");
+
+    const fired: ScheduledWakeEvent[] = [];
+    scheduler.onWake((event) => {
+      fired.push(event);
+    });
+
+    // Two distinct crons: every minute, and every 2 minutes (at even minutes).
+    scheduler.schedule(agentId, {
+      kind: "multi",
+      triggers: [
+        { kind: "cron", expression: "* * * * *" },
+        { kind: "cron", expression: "*/2 * * * *" },
+      ],
+    });
+    scheduler.start();
+
+    // t+60s → 12:01: only the every-minute cron fires (1).
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fired).toHaveLength(1);
+
+    // t+120s → 12:02: every-minute (now 2) AND every-2-minute (1) both fire.
+    // Proves both crons re-armed independently via their own entry.key.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fired).toHaveLength(3);
+
+    await scheduler.stop();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #420. `wake_schedule` in `role.md` now accepts **an array of trigger objects** in addition to the single-object form, so an agent can wake on more than one schedule:

```yaml
wake_schedule:
  - cron: "40 22 * * 1"   # setup — before the circle's domain agents
    tz: America/Vancouver
    label: setup
  - cron: "0 3 * * 2"     # summary — after them
    tz: America/Vancouver
    label: summary
```

Previously a list was rejected by `roleFrontmatterSchema` (`expected object, received array`) and the agent silently dropped to the default-agent fallback — exactly what happened to EP's `facilitator-agent`.

## Changes

- **identity** (`packages/core/src/identity/index.ts`): `wake_schedule` accepts `object | array(min 1)`; entries take an optional `label` (logs/telemetry only).
- **scheduler** (`packages/core/src/scheduler/index.ts`): new `multi` `WakeTrigger`. `schedule()` fans it out into one sub-entry per sub-trigger keyed `agentId#i`, each with its own re-arm loop (the cron re-arm guard now keys on `entry.key`, not `agentId`, so sub-crons re-arm independently). `unschedule(agentId)` clears the single entry **plus** all `agentId#i` sub-entries.
- **boot** (`packages/cli/src/boot.ts`): `triggerFromFrontmatter` maps an array to a `multi` trigger (single-element arrays collapse to the lone trigger).
- **daemon** `formatTrigger` and **spirit** `overview` handle the array/`multi` shapes.

Backward compatible — single-object `wake_schedule` is untouched.

## Tests

- **scheduler**: independent firing of each sub-trigger (wakes carry the real `agentId`, not the `#i` key), `unschedule` clears all sub-entries, and two cron sub-triggers re-arm on their own keys.
- **identity**: array parse + labels, single-object form unchanged, empty array rejected, invalid cron in a list rejected.
- Full suite: 1330 passing.

Found while restarting EP on v0.9.0 (facilitator-agent had authored a two-cron list); EP is on a single-cron workaround until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)