### PR TITLE
fix(ci): pnpm 11.5.3 for OIDC publishing; require Node 22.13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        # Node 22.13+ only: pnpm 11 (required for OIDC trusted publishing in
+        # release.yml) drops Node < 22.13, and Node 20 is EOL (April 2026).
+        node-version: [22.x]
 
     steps:
       - name: Checkout repository
@@ -30,7 +32,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.33.0
+          version: 11.5.3
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        # Trusted Publishing requires pnpm >= 10.7. Pinned to a known-good
-        # release; bump when npm's OIDC contract changes.
+        # OIDC Trusted Publishing requires the NATIVE pnpm publish flow: pnpm
+        # 10.x delegated `pnpm publish` to the npm CLI and never performed the
+        # OIDC token exchange itself (10.33.0 fails with ENEEDAUTH). pnpm 11.0
+        # made publish native, 11.0.7 added OIDC precedence over a static
+        # token, and 11.1.3 fixed the setup-node empty-token E404. Pin 11.5.3
+        # (>= the 11.1.3 floor). Keep this in lockstep with package.json
+        # `packageManager` and ci.yml.
         uses: pnpm/action-setup@v4
         with:
-          version: 10.33.0
+          version: 11.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - **Multiple cron wake schedules per agent** ([#420](https://github.com/murmurations-ai/murmurations-harness/issues/420)). `wake_schedule` in `role.md` now accepts an array of trigger objects in addition to the single-object form, so an agent can wake on more than one schedule — e.g. a facilitator that runs a `setup` pass before its circle's domain agents and a `summary` pass after. Each entry takes an optional `label` (surfaced in logs). The scheduler gains a `multi` `WakeTrigger` that fans out into one independently-armed, independently-re-arming timer per sub-trigger; `unschedule` clears them all. Single-object `wake_schedule` is unchanged.
 
+### Changed
+
+- **Minimum Node.js raised to 22.** Node 20 reached end-of-life (April 2026) and pnpm 11 — required for OIDC trusted publishing (below) — drops Node < 22.13. The published packages now declare `engines.node >= 22.0.0`; the CI build/test matrix runs Node 22.x only; the dev/build toolchain (root `engines.node`) requires `>= 22.13.0` (pnpm 11's floor).
+
+### Internals
+
+- **CI: pnpm bumped 10.33.0 → 11.5.3** so `release.yml` can actually perform npm OIDC Trusted Publishing. pnpm 10.x delegated `pnpm publish` to the npm CLI and never ran the OIDC token exchange itself (the v0.9.0 publish failed with `ENEEDAUTH`); the native exchange landed in pnpm 11.0.7 and the setup-node empty-token fix in 11.1.3. Pinned in lockstep across `package.json` `packageManager`, `ci.yml`, and `release.yml`. `pnpm-workspace.yaml` now allows the `koffi` and `protobufjs` build scripts (pnpm 11 ignores dependency build scripts by default). `pnpm-lock.yaml` is unchanged (`lockfileVersion 9.0`). Operator step still required before the next tag: confirm the per-package Trusted Publisher bindings on npmjs.com.
+
 ## [0.9.0] - 2026-06-10
 
 **Operational hygiene, agent-lifecycle reconciliation, and contract-validation hardening.** A cycle of operator-visible diagnostics and correctness fixes for the silent failure modes that bite long-running murmurations: stale GitHub issues that bloat every watching agent's per-wake context, agent directories that wake on the default-agent template after their `role.md` was removed (and the `state.json` tombstones they leave behind), subscription-CLI agents whose declared file writes silently no-op'd in headless mode, and contract obligations that could be satisfied by a path the operator never declared. Behavioral validation remains warning-only — its promotion to hard-fail, and the `verifiedActions` evidence channel it depends on, are deferred to the next release ([#376](https://github.com/murmurations-ai/murmurations-harness/issues/376)).

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -8,7 +8,7 @@ This guide walks you from zero to a running meeting in under 10 minutes. No prio
 
 ## Prerequisites
 
-- **Node.js 20+** (`node --version`)
+- **Node.js 22+** (`node --version`)
 - **npm** (ships with Node)
 - **An LLM**, one of:
   - **A subscription CLI you're already paying for** (recommended for new operators) — Claude Code, OpenAI Codex, or Gemini CLI. `murmuration init` auto-detects them. Skip the API-key step entirely. $0 marginal cost.

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "node": ">=22.13.0",
+    "pnpm": ">=11.1.3"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.3",
   "scripts": {
     "build": "pnpm -r run build",
     "clean": "pnpm -r run clean",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "zod": "^4.3.6"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "cron-parser": "^4.9.0",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@murmurations-ai/core": "workspace:*",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -37,7 +37,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@langfuse/otel": "^5.1.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.1",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@murmurations-ai/core": "workspace:*",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@murmurations-ai/core": "workspace:*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
-  - 'packages/*'
+  - "packages/*"
+
+# pnpm 11 ignores dependency build scripts by default (supply-chain
+# hardening) and requires explicit per-package approval. These two were
+# built automatically under pnpm 10; allow them so the install runs their
+# scripts instead of failing with ERR_PNPM_IGNORED_BUILDS:
+#   - koffi      — native FFI used by @mariozechner/pi-tui (dashboard-tui)
+#   - protobufjs — postinstall via @grpc/proto-loader (OpenTelemetry, llm)
+allowBuilds:
+  koffi: true
+  protobufjs: true


### PR DESCRIPTION
## Why

The **v0.9.0 release publish failed** (`ENEEDAUTH`) on its first use of npm OIDC Trusted Publishing (migrated in #391; #419 fixed an earlier `E404`). Root cause: pnpm **10.x delegates `pnpm publish` to the npm CLI** and never performs the OIDC token exchange itself — so 10.33.0 can never publish via OIDC. The native exchange landed in pnpm **11.0.7**, and **11.1.3** fixed the setup-node empty-token `E404`.

## The catch → Node 22

**Every pnpm 11.x requires Node ≥ 22.13** (it uses `node:sqlite`). The CI matrix tested Node 20.x, so pnpm 11 broke that leg. Since **Node 20 is EOL** (April 2026), this raises the floor to Node 22:

- Pin **pnpm 11.5.3** in lockstep: `package.json` `packageManager`, `ci.yml`, `release.yml`.
- **CI matrix → Node 22.x only**; root `engines.node >= 22.13.0` (pnpm's floor); published packages `engines.node >= 22.0.0`; `GETTING-STARTED` → Node 22+.
- `pnpm-workspace.yaml` allows the `koffi` + `protobufjs` build scripts (pnpm 11 ignores dependency build scripts by default).
- `pnpm-lock.yaml` **unchanged** (`lockfileVersion 9.0`); full gate green under 11.5.3 (1330 tests).

Once OIDC works, **provenance is automatic**.

## ⚠️ Operator step before the next tag

This resolves the `ENEEDAUTH` (wrong-pnpm-version) mode. The *other* mode — `no trusted publisher configured` — is npmjs.com-only: per `@murmurations-ai/*` package, Settings → Trusted publishing → org `murmurations-ai`, repo `murmurations-harness`, workflow `release.yml`, **no environment**. npm doesn't validate at save time, so confirm each field. After merge, tag a release; any "no trusted publisher" error names exactly which binding to finish.

Refs #391, #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)