### PR TITLE
fix(spirit): recover from a stale --resume session instead of hard-failing (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - **Minimum Node.js raised to 22.** Node 20 reached end-of-life (April 2026) and pnpm 11 — required for OIDC trusted publishing (below) — drops Node < 22.13. The published packages now declare `engines.node >= 22.0.0`; the CI build/test matrix runs Node 22.x only; the dev/build toolchain (root `engines.node`) requires `>= 22.13.0` (pnpm 11's floor).
 
+### Fixed
+
+- **Spirit no longer hard-fails on a stale resume session** ([#424](https://github.com/murmurations-ai/murmurations-harness/issues/424)). After a daemon restart (or on a fresh machine), the Spirit replayed a persisted subscription-CLI `sessionId` as `claude --resume <id>`; when that CLI session no longer existed it failed with `No conversation found with session ID` and surfaced a raw `internal` error. The Spirit client now detects that case (new `isResumeSessionMissing` helper in `@murmurations-ai/llm`), drops the stale id, and retries **once** without `--resume` — a fresh session that gets the full history — then persists the new id. Gated on having actually passed a session id (so unrelated failures never clear a valid session) and capped at one retry.
+
 ### Internals
 
 - **CI: pnpm bumped 10.33.0 → 11.5.3** so `release.yml` can actually perform npm OIDC Trusted Publishing. pnpm 10.x delegated `pnpm publish` to the npm CLI and never ran the OIDC token exchange itself (the v0.9.0 publish failed with `ENEEDAUTH`); the native exchange landed in pnpm 11.0.7 and the setup-node empty-token fix in 11.1.3. Pinned in lockstep across `package.json` `packageManager`, `ci.yml`, and `release.yml`. `pnpm-workspace.yaml` now allows the `koffi` and `protobufjs` build scripts (pnpm 11 ignores dependency build scripts by default). `pnpm-lock.yaml` is unchanged (`lockfileVersion 9.0`). Operator step still required before the next tag: confirm the per-package Trusted Publisher bindings on npmjs.com.

--- a/packages/cli/src/spirit/client.ts
+++ b/packages/cli/src/spirit/client.ts
@@ -23,6 +23,7 @@ import {
   createLLMClient,
   createSubscriptionCliClient,
   formatLLMError,
+  isResumeSessionMissing,
   ProviderRegistry,
   type LLMClient,
   type LLMClientConfig,
@@ -88,6 +89,13 @@ export interface SpiritTurnResult {
 export interface SpiritInitOptions {
   readonly rootDir: string;
   readonly send: Send;
+  /**
+   * Test seam: inject a pre-built {@link LLMClient} to bypass real
+   * provider/token/MCP construction. Production callers never set this; the
+   * provider is still read from harness.yaml so the resume/tool behavior
+   * matches what the injected client would see in production.
+   */
+  readonly llmClient?: LLMClient;
 }
 
 export class SpiritUnavailableError extends Error {
@@ -198,7 +206,13 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
   // written at attach time; called in close() on clean detach.
   let mcpConfigCleanup: (() => void) | undefined;
 
-  if (harness.llm.provider === "subscription-cli") {
+  if (opts.llmClient !== undefined) {
+    // Test seam: use the injected client; still honor the configured provider
+    // so subscription-cli resume behavior (sessionId → `--resume`) is exercised.
+    client = opts.llmClient;
+    model = harness.llm.model ?? DEFAULT_CLI_MODEL[harness.llm.cli ?? "claude"];
+    useApiTools = harness.llm.provider !== "subscription-cli";
+  } else if (harness.llm.provider === "subscription-cli") {
     const cli: SubscriptionCli = harness.llm.cli ?? "claude";
     model = harness.llm.model ?? DEFAULT_CLI_MODEL[cli];
 
@@ -285,24 +299,41 @@ export const initSpiritSession = async (opts: SpiritInitOptions): Promise<Spirit
     await store.append({ role: "user", content: message, ts: userTs });
 
     const maxSteps = harness.spirit.maxSteps;
-    // When sessionId is present, the subscription-CLI adapter uses
-    // `--resume <id>` and only the latest user message is the
-    // material new context (the rest lives in the CLI's session
-    // cache). Send the trailing user message only, in that case;
-    // first turn sends full history. Direct API path ignores
-    // sessionId and gets the full history regardless.
-    const lastMessage = history[history.length - 1];
-    const messages: readonly LLMMessage[] =
-      sessionId !== undefined && lastMessage ? [lastMessage] : history;
-    const result = await client.complete({
-      model,
-      messages,
-      systemPromptOverride: systemPrompt,
-      maxOutputTokens: 4096,
-      temperature: 0.2,
-      ...(sessionId !== undefined ? { sessionId } : {}),
-      ...(tools ? { tools, maxSteps } : {}),
-    });
+    // One completion attempt against the CURRENT sessionId. When sessionId
+    // is present, the subscription-CLI adapter uses `--resume <id>` and only
+    // the latest user message is the material new context (the rest lives in
+    // the CLI's session cache); first turn / fresh session sends the full
+    // history. The direct API path ignores sessionId and gets full history.
+    const runComplete = (): ReturnType<typeof client.complete> => {
+      const lastMessage = history[history.length - 1];
+      const messages: readonly LLMMessage[] =
+        sessionId !== undefined && lastMessage ? [lastMessage] : history;
+      return client.complete({
+        model,
+        messages,
+        systemPromptOverride: systemPrompt,
+        maxOutputTokens: 4096,
+        temperature: 0.2,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+        ...(tools ? { tools, maxSteps } : {}),
+      });
+    };
+
+    let result = await runComplete();
+
+    // harness#424: a persisted CLI session can vanish (daemon restart, claude
+    // session GC, different machine), so `--resume <id>` fails hard with "No
+    // conversation found with session ID". Recover instead of surfacing a raw
+    // internal error: drop the stale id and retry ONCE without `--resume` —
+    // now a fresh session that gets the full history (sessionId is cleared, so
+    // runComplete() sends `history`, not just the trailing message). Gated on
+    // having actually passed a sessionId so an unrelated failure can't clear a
+    // valid session; capped at one retry so a genuinely broken CLI can't loop.
+    if (!result.ok && sessionId !== undefined && isResumeSessionMissing(result.error)) {
+      sessionId = undefined;
+      await store.setSessionId(undefined);
+      result = await runComplete();
+    }
 
     if (!result.ok) {
       history.pop();

--- a/packages/cli/src/spirit/spirit-resume.test.ts
+++ b/packages/cli/src/spirit/spirit-resume.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Spirit resume-session recovery (harness#424).
+ *
+ * When the claude CLI session that a persisted `sessionId` points at no
+ * longer exists (daemon restart, session GC, different machine), `--resume`
+ * fails hard. The Spirit must drop the stale id and retry once with a fresh
+ * session instead of surfacing a raw internal error. These tests inject a
+ * mock LLM client (via the `llmClient` test seam) so the full `turn()` flow
+ * runs without spawning a real subprocess.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  LLMInternalError,
+  type LLMClient,
+  type LLMClientError,
+  type LLMRequest,
+  type LLMResponse,
+  type Result,
+} from "@murmurations-ai/llm";
+
+import { initSpiritSession } from "./client.js";
+
+const HARNESS_YAML = `governance:
+  model: sociocracy-3.0
+  plugin: "@murmurations-ai/governance-s3"
+llm:
+  provider: subscription-cli
+  cli: claude
+  model: claude-sonnet-4-6
+`;
+
+const noopSend = (): Promise<{ id: string; error: string }> =>
+  Promise.resolve({ id: "0", error: "no daemon" });
+
+const okResponse = (sessionId: string): Result<LLMResponse, LLMClientError> => ({
+  ok: true,
+  value: {
+    content: "hi back",
+    stopReason: "stop",
+    inputTokens: 10,
+    outputTokens: 5,
+    modelUsed: "claude-sonnet-4-6",
+    providerUsed: "claude-cli",
+    sessionId,
+    toolCalls: [],
+  },
+});
+
+const resumeMissing = (): Result<LLMResponse, LLMClientError> => ({
+  ok: false,
+  error: new LLMInternalError("claude-cli", "No conversation found with session ID: stale-id", {
+    requestUrl: "subprocess://claude",
+  }),
+});
+
+const authFailure = (): Result<LLMResponse, LLMClientError> => ({
+  ok: false,
+  error: new LLMInternalError("claude-cli", "invalid api key", { requestUrl: "x" }),
+});
+
+/** Mock LLM client that returns scripted results and records each request. */
+const mockClient = (
+  results: readonly (() => Result<LLMResponse, LLMClientError>)[],
+): { client: LLMClient; calls: LLMRequest[] } => {
+  const calls: LLMRequest[] = [];
+  const client: LLMClient = {
+    capabilities: () => ({
+      supportsStreaming: false,
+      supportsToolUse: false,
+      supportsJsonMode: false,
+      maxContextTokens: 200_000,
+    }),
+    complete: (request) => {
+      const idx = Math.min(calls.length, results.length - 1);
+      calls.push(request);
+      const fn = results[idx];
+      return Promise.resolve(fn ? fn() : okResponse("fallback"));
+    },
+  };
+  return { client, calls };
+};
+
+const readPersistedSessionId = async (root: string): Promise<string | null> => {
+  const raw = await readFile(join(root, ".murmuration", "spirit", "session.json"), "utf8");
+  return (JSON.parse(raw) as { sessionId?: string | null }).sessionId ?? null;
+};
+
+describe("Spirit resume-session recovery (harness#424)", () => {
+  let root = "";
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "spirit-resume-"));
+    await mkdir(join(root, "murmuration"), { recursive: true });
+    await writeFile(join(root, "murmuration", "harness.yaml"), HARNESS_YAML, "utf8");
+    await writeFile(join(root, "murmuration", "soul.md"), "# Test murmuration\n", "utf8");
+    // Seed a stale CLI session id, as a prior attach would have left.
+    const spiritDir = join(root, ".murmuration", "spirit");
+    await mkdir(spiritDir, { recursive: true });
+    await writeFile(
+      join(spiritDir, "session.json"),
+      JSON.stringify({ sessionId: "stale-id" }),
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it("drops a stale session and retries once without --resume, then persists the fresh id", async () => {
+    const { client, calls } = mockClient([resumeMissing, () => okResponse("fresh-id")]);
+    const session = await initSpiritSession({ rootDir: root, send: noopSend, llmClient: client });
+
+    await expect(session.turn("hi")).resolves.toBeDefined();
+
+    // Exactly one retry — no loop.
+    expect(calls).toHaveLength(2);
+    // First attempt resumed the stale id; the retry omitted it (fresh session).
+    expect(calls[0]?.sessionId).toBe("stale-id");
+    expect(calls[1]?.sessionId).toBeUndefined();
+    // The retry still carried the user's message.
+    expect(calls[1]?.messages.some((m) => m.content === "hi")).toBe(true);
+    // The fresh id surfaced by the retry is persisted for the next turn.
+    expect(await readPersistedSessionId(root)).toBe("fresh-id");
+  });
+
+  it("does NOT retry or clear the session on a non-resume error", async () => {
+    const { client, calls } = mockClient([authFailure]);
+    const session = await initSpiritSession({ rootDir: root, send: noopSend, llmClient: client });
+
+    await expect(session.turn("hi")).rejects.toThrow();
+
+    expect(calls).toHaveLength(1); // no retry
+    // The stale id is left untouched — only the resume-missing case clears it.
+    expect(await readPersistedSessionId(root)).toBe("stale-id");
+  });
+
+  it("gives up after one retry if the fresh session also fails", async () => {
+    const { client, calls } = mockClient([resumeMissing, authFailure]);
+    const session = await initSpiritSession({ rootDir: root, send: noopSend, llmClient: client });
+
+    await expect(session.turn("hi")).rejects.toThrow();
+
+    expect(calls).toHaveLength(2); // one retry, then surface the error
+    expect(calls[1]?.sessionId).toBeUndefined(); // retry was the fresh-session attempt
+    // Session was cleared on the resume-missing detection and not re-set.
+    expect(await readPersistedSessionId(root)).toBeNull();
+  });
+});

--- a/packages/llm/src/errors.test.ts
+++ b/packages/llm/src/errors.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 
 import {
   formatLLMError,
+  isResumeSessionMissing,
   LLMForbiddenError,
+  LLMInternalError,
   LLMRateLimitError,
   LLMUnauthorizedError,
 } from "./errors.js";
@@ -48,5 +50,47 @@ describe("formatLLMError", () => {
     const err = new LLMForbiddenError("openai", "nope", { requestUrl: "x" });
     const out = formatLLMError(err);
     expect(out).toMatch(/^LLM call failed\n/);
+  });
+});
+
+describe("isResumeSessionMissing (harness#424)", () => {
+  const internal = (message: string, cause?: unknown): LLMInternalError =>
+    new LLMInternalError("claude-cli", message, {
+      requestUrl: "subprocess://claude",
+      ...(cause !== undefined ? { cause } : {}),
+    });
+
+  it("matches the claude resume-missing stderr on the error message", () => {
+    expect(
+      isResumeSessionMissing(
+        internal("No conversation found with session ID: 44f95226-4fee-4bbe-bea0-dfada5e9d77c"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive and ignores the trailing id", () => {
+    expect(isResumeSessionMissing(internal("no conversation found with session id: abc"))).toBe(
+      true,
+    );
+  });
+
+  it("matches when the text is on the cause, not the top-level message", () => {
+    const err = internal("in-process runner threw", {
+      message: "No conversation found with session ID: deadbeef",
+      kind: "spawn-error",
+    });
+    expect(isResumeSessionMissing(err)).toBe(true);
+  });
+
+  it("does NOT match unrelated failures (auth, rate limit, generic exit 1)", () => {
+    expect(isResumeSessionMissing(internal("invalid API key"))).toBe(false);
+    expect(isResumeSessionMissing(internal("claude exited with code 1"))).toBe(false);
+    expect(
+      isResumeSessionMissing(new LLMUnauthorizedError("anthropic", "bad key", { requestUrl: "x" })),
+    ).toBe(false);
+  });
+
+  it("does not throw on a non-object cause", () => {
+    expect(isResumeSessionMissing(internal("boom", "a string cause"))).toBe(false);
   });
 });

--- a/packages/llm/src/errors.ts
+++ b/packages/llm/src/errors.ts
@@ -305,6 +305,33 @@ const providerForbiddenHints = (provider: string): readonly string[] => {
 };
 
 /**
+ * Pattern the claude CLI prints to stderr when `--resume <id>` targets a
+ * session that no longer exists in its local store (daemon restart, session
+ * GC, or a different machine). The trailing UUID varies, so match the stable
+ * prefix case-insensitively.
+ */
+const RESUME_SESSION_MISSING_RE = /no conversation found with session id/i;
+
+/**
+ * True when an LLM error indicates a subscription-CLI resume target is gone
+ * (harness#424). A caller that passed a `sessionId` (and therefore a
+ * `--resume` flag) can use this to drop the stale id and retry with a fresh
+ * session. Checks both the error message and its `cause` (the typed
+ * `SubprocessError` carries the scrubbed stderr). Callers SHOULD gate the
+ * retry on having actually passed a sessionId, so an unrelated non-zero exit
+ * that happens to contain this text can't clear a still-valid session.
+ */
+export const isResumeSessionMissing = (error: LLMClientError): boolean => {
+  if (RESUME_SESSION_MISSING_RE.test(error.message)) return true;
+  const cause: unknown = error.cause;
+  const causeMessage =
+    typeof cause === "object" && cause !== null
+      ? (cause as { message?: unknown }).message
+      : undefined;
+  return typeof causeMessage === "string" && RESUME_SESSION_MISSING_RE.test(causeMessage);
+};
+
+/**
  * Best-effort scrub of the raw token from a cause's message. Primary
  * defense is that the token never enters any error path we construct;
  * this is belt-and-suspenders for fetch implementations that somehow

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -64,7 +64,7 @@ export {
   LLMValidationError,
 } from "./errors.js";
 export type { LLMClientErrorCode, RateLimitScope } from "./errors.js";
-export { formatLLMError } from "./errors.js";
+export { formatLLMError, isResumeSessionMissing } from "./errors.js";
 
 // Subscription-CLI provider family (ADR-0034)
 export {


### PR DESCRIPTION
## Summary

Closes #424. A live Spirit attach to a restarted murmuration hard-failed on the first turn:

```
chinook-wind> hi
… --resume 44f95226-… → stderr: No conversation found with session ID: 44f95226-…
(Spirit error: LLM call failed for spirit … code: internal)
```

The Spirit persists the subscription-CLI `sessionId` and replays it as `claude --resume <id>`. When that CLI session no longer exists (daemon restart, session GC, different machine), `--resume` fails hard and the Spirit surfaced a raw `internal` error with no fallback.

## Fix

When a turn fails **and** a `sessionId` was passed **and** the error is the resume-missing case, the client drops the stale id (`store.setSessionId(undefined)`) and retries **once** without `--resume` — a fresh session that receives the **full history** (the trailing-message-only optimization only applies while resuming) — then persists the new id.

- **`@murmurations-ai/llm`**: new exported `isResumeSessionMissing(error)` — matches the stable `No conversation found with session ID` prefix on the error message or its `cause`. Gated detection so callers only act when they passed a session.
- **Spirit client**: one-retry recovery in `turn()`, **gated** on having passed a sessionId (an unrelated failure can't clear a valid session) and **capped** at one retry (no loop).
- **Test seam**: `initSpiritSession` gains an optional `llmClient` (production never sets it) so the full `turn()` flow is testable without a subprocess.

## Tests

- `isResumeSessionMissing`: message match, cause match, case-insensitivity, negative (auth / generic exit-1 / non-object cause).
- Spirit integration: clear-and-retry-then-persist; **no** retry/clear on a non-resume error; give-up after exactly one retry. Full suite: 1338 passing.

## Notes

- The same latent failure exists for **daemon agent wakes** via the persistent-context executor — noted as a follow-up on #424.
- Immediate operational workaround was already applied to the affected murmuration (cleared the stale `sessionId` from `session.json`, history preserved), so the Spirit there works now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)