### PR TITLE
fix(cli): orphan-daemon scanner matches only real daemons (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - **Spirit no longer hard-fails on a stale resume session** ([#424](https://github.com/murmurations-ai/murmurations-harness/issues/424)). After a daemon restart (or on a fresh machine), the Spirit replayed a persisted subscription-CLI `sessionId` as `claude --resume <id>`; when that CLI session no longer existed it failed with `No conversation found with session ID` and surfaced a raw `internal` error. The Spirit client now detects that case (new `isResumeSessionMissing` helper in `@murmurations-ai/llm`), drops the stale id, and retries **once** without `--resume` — a fresh session that gets the full history — then persists the new id. Gated on having actually passed a session id (so unrelated failures never clear a valid session) and capped at one retry.
+- **`murmuration list` no longer reports phantom orphan daemons** ([#422](https://github.com/murmurations-ai/murmurations-harness/issues/422)). The orphan-daemon scanner matched any process whose command line merely contained `murmuration … start`, so it flagged the daemon's own `zsh` wrapper and `tee` (writing to `…/.murmuration/start-console.log`), plus unrelated commands — surfacing bogus "orphans" with unexpanded roots like `…/$CW`. It now matches only the actual daemon process (`murmuration start …` or `node …/murmuration start …`), and rejects captured roots containing control bytes or shell tokens. Parsing extracted to `parseDaemonProcesses` with unit tests.
 
 ### Internals
 

--- a/packages/cli/src/sessions.test.ts
+++ b/packages/cli/src/sessions.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+
+import { parseDaemonProcesses } from "./sessions.js";
 
 // sessions.ts reads from ~/.murmuration/sessions.json which we can't
 // override in the module. Instead, test the heartbeat logic directly
@@ -63,5 +65,57 @@ describe("sessions registry format", () => {
 
     expect(recentAge).toBeLessThan(120_000); // fresh (< 2 min)
     expect(staleAge).toBeGreaterThan(120_000); // stale (> 2 min)
+  });
+});
+
+describe("parseDaemonProcesses (harness#422)", () => {
+  const SELF = 99_999;
+
+  it("matches the real node daemon process", () => {
+    const ps = "9932 node /opt/homebrew/bin/murmuration start --root /Users/x/murm/chinook-wind";
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([
+      { pid: 9932, root: resolve("/Users/x/murm/chinook-wind") },
+    ]);
+  });
+
+  it("matches a directly-executed `murmuration start`", () => {
+    const ps = "4242 /opt/homebrew/bin/murmuration start --root /srv/murm/a --now";
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([{ pid: 4242, root: resolve("/srv/murm/a") }]);
+  });
+
+  it("does NOT match the zsh wrapper, the tee, or unrelated processes", () => {
+    // These are the exact false positives the old substring matcher produced:
+    // the daemon's own shell wrapper + the tee writing to start-console.log,
+    // and a coding-agent's command line that merely contains the words.
+    const ps = [
+      "59076 zsh -c murmuration start --root /Users/x/murm/cw 2>&1 | tee -a /Users/x/murm/cw/.murmuration/start-console.log",
+      "59079 tee -a /Users/x/murm/cw/.murmuration/start-console.log",
+      "9927 bash -c tmux new-session -d -s cw murmuration start --root $CW",
+      "1234 vim /Users/x/murm/cw/.murmuration/start-console.log",
+    ].join("\n");
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([]);
+  });
+
+  it("excludes the current process", () => {
+    const ps = `${String(SELF)} node /usr/local/bin/murmuration start --root /srv/murm/self`;
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([]);
+  });
+
+  it("rejects a root with control bytes or an unexpanded shell token", () => {
+    const ps = [
+      "111 node /bin/murmuration start --root /srv/$CW",
+      "112 node /bin/murmuration start --root /srv/[2Jevil",
+    ].join("\n");
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([]);
+  });
+
+  it("ignores a `ps` header line and blank lines", () => {
+    const ps = "  PID ARGS\n\n9932 node /bin/murmuration start --root /srv/murm/a\n";
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([{ pid: 9932, root: resolve("/srv/murm/a") }]);
+  });
+
+  it("matches a dev `node …/bin.js start` daemon", () => {
+    const ps = "777 node /repo/packages/cli/dist/bin.js start --root /srv/murm/dev";
+    expect(parseDaemonProcesses(ps, SELF)).toEqual([{ pid: 777, root: resolve("/srv/murm/dev") }]);
   });
 });

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve, join } from "node:path";
+import { basename, resolve, join } from "node:path";
 
 import { findRunningSessionByName, listRunningSessionNamesSync } from "./running-sessions.js";
 
@@ -142,18 +142,71 @@ export const listSessions = async (): Promise<void> => {
   }
 };
 
+/** Daemon bin name (npm global) and dev entrypoints (`node …/bin.js start`). */
+const isDaemonBin = (token: string): boolean => {
+  const b = basename(token);
+  return b === "murmuration" || /^bin\.(c?js|mjs|ts)$/.test(b);
+};
+
 /**
- * Scan the OS process table for `murmuration start --root <X>`
- * processes whose root isn't in `knownRoots`. Used to surface orphan
- * daemons in `murmuration list`. Best-effort — returns an empty list
- * if `ps` is unavailable or its output can't be parsed.
+ * Parse `ps` output (one `<pid> <args>` per line) into the murmuration
+ * daemon processes it contains. Exported for unit tests.
  *
- * Captured `--root` values are read from another process's command
- * line, which any local user can populate with arbitrary bytes —
- * including ANSI escape sequences that would inject controls into the
- * operator's terminal when the row is printed. We reject any captured
- * root that contains control characters and prefer `args=` (POSIX)
- * over `command=` (BSD-only) when both are available.
+ * The match is deliberately narrow (harness#422): a daemon is the process
+ * that actually *runs* the CLI — `murmuration start …` or `node …/murmuration
+ * start …` (or a dev `node …/bin.js start …`). It is NOT a shell wrapper
+ * (`zsh -c "murmuration start …"`), the `tee` writing to a path that contains
+ * `/.murmuration/start-console.log`, or any other process whose argv merely
+ * contains the words. The previous substring matcher (`murmuration … start`)
+ * flagged all of those, including coding-agent commands and the daemon's own
+ * `tee`/wrapper — surfacing phantom "orphans" with unexpanded roots like
+ * `…/$CW`.
+ *
+ * `--root` values come from another process's command line, which any local
+ * user can populate with arbitrary bytes. Roots containing control bytes
+ * (terminal-injection) or an unexpanded shell token (`$`/backtick) are
+ * rejected. `currentPid` is excluded so the scanner never reports itself.
+ */
+export const parseDaemonProcesses = (
+  psStdout: string,
+  currentPid: number,
+): readonly { readonly pid: number; readonly root: string }[] => {
+  const out: { pid: number; root: string }[] = [];
+  // The `=`-suffix `ps` form has no header; the fallback `-o pid,args` form
+  // has one. Any line whose first token isn't a digit is skipped, so the
+  // header is ignored either way.
+  for (const line of psStdout.split("\n")) {
+    const m = /^\s*(\d+)\s+(.+)$/.exec(line);
+    if (m === null) continue;
+    const pid = Number(m[1] ?? "");
+    if (Number.isNaN(pid) || pid === currentPid) continue;
+    const cmd = m[2] ?? "";
+    const tokens = cmd.split(/\s+/).filter((t) => t.length > 0);
+    const exe = tokens[0] ?? "";
+    const isDaemon =
+      // Direct: `murmuration start …`
+      (isDaemonBin(exe) && tokens[1] === "start") ||
+      // Via node: `node …/murmuration start …`
+      (/^node(\.exe)?$/.test(basename(exe)) &&
+        isDaemonBin(tokens[1] ?? "") &&
+        tokens[2] === "start");
+    if (!isDaemon) continue;
+    const captured = /--root\s+(\S+)/.exec(cmd)?.[1];
+    if (captured === undefined || captured.length === 0) continue;
+    // Reject control bytes (terminal-injection) and unexpanded shell tokens
+    // (a real path never contains `$` or a backtick).
+    if (CONTROL_CHAR_RE.test(captured) || /[$`]/.test(captured)) continue;
+    out.push({ pid, root: resolve(captured) });
+  }
+  return out;
+};
+
+/**
+ * Scan the OS process table for murmuration daemon processes whose root
+ * isn't in `knownRoots`. Used to surface orphan daemons in `murmuration
+ * list`. Best-effort — returns an empty list if `ps` is unavailable or its
+ * output can't be parsed. Parsing + the narrow daemon match live in
+ * {@link parseDaemonProcesses}.
  */
 const findOrphanDaemons = async (
   knownRoots: readonly string[],
@@ -161,8 +214,7 @@ const findOrphanDaemons = async (
   const { spawnSync } = await import("node:child_process");
   // POSIX-portable selector. Some non-GNU `ps` implementations reject the
   // `=`-suffix shorthand; we fall back to plain header output if needed.
-  const psArgs = ["-A", "-o", "pid=,args="];
-  let result = spawnSync("ps", psArgs, { encoding: "utf8" });
+  let result = spawnSync("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8" });
   if (result.status !== 0) {
     result = spawnSync("ps", ["-A", "-o", "pid,args"], { encoding: "utf8" });
   }
@@ -170,32 +222,8 @@ const findOrphanDaemons = async (
   const stdoutRaw = typeof result.stdout === "string" ? result.stdout : "";
   if (stdoutRaw.length === 0) return [];
 
-  const myPid = process.pid;
   const known = new Set(knownRoots.map((r) => resolve(r)));
-  const orphans: { pid: number; root: string }[] = [];
-  // First line of the fallback (`-o pid,args` without `=`) is the header.
-  // The `=`-suffix form has no header. Defensively treat any line whose
-  // first token isn't a digit as a header and skip it.
-  for (const line of stdoutRaw.split("\n")) {
-    const m = /^\s*(\d+)\s+(.+)$/.exec(line);
-    if (m === null) continue;
-    const pidStr = m[1] ?? "";
-    const cmd = m[2] ?? "";
-    const pid = Number(pidStr);
-    if (Number.isNaN(pid) || pid === myPid) continue;
-    if (!/\bmurmuration\b.*\bstart\b/.test(cmd)) continue;
-    const rootMatch = /--root\s+(\S+)/.exec(cmd);
-    if (rootMatch === null) continue;
-    const captured = rootMatch[1];
-    if (captured === undefined || captured.length === 0) continue;
-    // Reject anything with control bytes (ANSI escape, CR, LF, etc.) so a
-    // malicious process can't terminal-inject via its --root argv.
-    if (CONTROL_CHAR_RE.test(captured)) continue;
-    const root = resolve(captured);
-    if (known.has(root)) continue;
-    orphans.push({ pid, root });
-  }
-  return orphans;
+  return parseDaemonProcesses(stdoutRaw, process.pid).filter((d) => !known.has(d.root));
 };
 
 /** Update heartbeat for a running daemon. Called periodically by the daemon. */


### PR DESCRIPTION
## Summary

Closes #422. `murmuration list`'s orphan-daemon scanner matched **any** process whose command line contained `murmuration … start`, so it flagged:
- the daemon's own `zsh -c "murmuration start …"` wrapper,
- the `tee` writing to `…/.murmuration/start-console.log` (path contains `murmuration` + `start`),
- and unrelated commands (e.g. a coding agent's shell that mentions the command).

That surfaced phantom "orphans" — including rows with unexpanded roots like `/Users/…/murmurations-harness/$CW` — and advised the operator to `kill` PIDs that aren't daemons. (Seen live while restarting CW.)

## Fix

Match only the process that actually *runs* the CLI: `murmuration start …` or `node …/murmuration start …` (plus a dev `node …/bin.js start …`), keyed on the executable (argv0) + the `start` subcommand — not a substring. Also reject captured `--root` values containing control bytes (terminal-injection; pre-existing guard) or unexpanded shell tokens (`$` / backtick).

Parsing extracted to an exported `parseDaemonProcesses(psStdout, currentPid)`.

## Tests

`parseDaemonProcesses`: real node daemon + direct `murmuration start`; the zsh-wrapper / tee / unrelated false positives all rejected; self-exclusion; control-byte + `$`-token rejection; `ps` header/blank lines; dev `bin.js` form. Full suite: 1345 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)