### PR TITLE
docs(plans): scope v0.8.2 — verifiedActions + validateBehavior hard-fail

### DIFF
--- a/docs/plans/v0.8.2-verifiedactions-and-hard-fail.md
+++ b/docs/plans/v0.8.2-verifiedactions-and-hard-fail.md
@@ -1,0 +1,149 @@
+# v0.8.2 — verifiedActions + validateBehavior hard-fail
+
+**Status:** Design (2026-06-17) · **Target:** v0.8.2 (post-v0.10.0) · **Owner:** Source
+
+## Why
+
+`validateBehavior` ships **warning-only** (v0.8.0, ADR-0048): the validator flags
+wakes whose narrative claims an action it can't find structured evidence for, but
+does not mark them non-productive. The plan was to promote it to **hard-fail**
+after a 14-day zero-false-positive soak (#376). That promotion is still pending,
+and a direct attempt to run the soak fails its own gate for a structural reason:
+
+- The validator's evidence sources are (1) harness-executed `WakeActionReceipt`s
+  and (2) URLs scraped from the wake-summary prose (#369 issue URLs, #377 blob
+  URLs).
+- **Subscription-CLI agents act inside the subprocess** (via the MCP github
+  bridge, #291, or `gh`), so they produce **no harness receipt** — the validator
+  falls back to prose-scraped URLs.
+- A hallucinating or compromised agent can **fabricate a plausible URL** in its
+  summary; the validator accepts it (#379). Under hard-fail, the incentive to do
+  so increases.
+- Empirically, the partial EP soak (2026-05-19→21) showed a **~44% behavior-warning
+  rate**, dominated by this receipt gap — so a soak run _before_ this is fixed can
+  never reach the zero-false-positive bar.
+
+`verifiedActions` (#364 Part B) is the named resolution: a trustworthy, structured
+record of operations the executor can actually vouch for, which `validateWake`
+prefers over prose-scraped URLs. It is the **keystone** — both the security gate
+(#379) and a meaningful soak depend on it.
+
+## Two workstreams
+
+This release is **not** a single PR. It has a harness track (code, here) and an
+EP-operational track (governance/ops, in `xeeban/emergent-praxis`), with a hard
+dependency between them.
+
+```
+[harness] build verifiedActions ──▶ release ──▶ [EP] add contract: to 9 agents
+                                                      │
+                                                      ▼
+                                          [EP] fresh 14-day warning-only soak
+                                                      │ (zero false positives?)
+                                                      ▼
+                                          [harness] flip validateBehavior → hard-fail (PR 6b)
+```
+
+The EP soak is the long pole (weeks) and is partly outside this repo.
+
+## Goals
+
+- Add `verifiedActions` as a structured evidence channel on `AgentResult`,
+  populated by subscription-CLI executors.
+- `validateWake` / `isOutputSatisfied` consume `verifiedActions` as **primary**
+  evidence, ahead of prose-scraped issue/blob URLs.
+- Cut the behavior-warning false-positive rate enough that a real soak can pass.
+- Close the #379 fabricated-URL gate.
+- After a clean soak: promote `validateBehavior` (and the composite read+network
+  permission check) from warning to hard-fail.
+
+## Non-goals
+
+- No change to the direct-API providers' behavior (they already produce
+  first-class receipts/tool results; this targets the subscription-CLI gap).
+- Not wiring agent wake-to-wake session resume (J2) — unrelated; see #426.
+- Not removing the legacy artifact-counting heuristic (#363) — that's its own
+  v0.9.0/v0.10.0 milestone.
+
+## Design fork: how `verifiedActions` is sourced
+
+The crux. Three options, all grounded in current code; **(a) is recommended.**
+
+### (a) Capture the claude CLI's `tool_use` / `tool_result` stream events — RECOMMENDED
+
+The claude adapter (`packages/llm/src/providers/subprocess/adapters/claude.ts:225`)
+already accumulates `tool_use` blocks into `toolCalls`, but hardcodes
+`result: null` (line 245) — it sees _which_ tools were called but discards the
+outcome.
+
+- Extend the adapter to capture each `tool_result` (incl. `is_error`).
+- Thread a `verifiedActions: readonly VerifiedAction[]` field onto `LLMResponse`
+  → `AgentResult` (a `VerifiedAction` = `{ kind, target, source: "tool-call" }`,
+  derived from `mcp__github__*` / `Bash(gh …)` calls that returned non-error).
+- `validateWake` prefers `verifiedActions` over the URL-scrape fallback; an
+  obligation is satisfied by a matching verified tool call, not by prose alone.
+
+**Why recommended:** EP agents act through the MCP github bridge (#291), so their
+real actions _are_ `tool_use` calls this captures cleanly. Lowest risk, keeps the
+validator **pure** (no network I/O), and delivers value immediately — it cuts the
+false-positive rate independent of the eventual flip.
+
+**Cost:** ~80–100 LOC across adapter → executor → `validateWake`. claude-only;
+codex/gemini fall back to today's behavior (acceptable — they're warning-only).
+
+**Caveat:** proves "tool called and returned non-error," not a remote re-fetch.
+For MCP github tools a non-error result _is_ confirmation the operation landed;
+for `Bash(gh …)` the exit code in `tool_result` is the signal.
+
+### (b) Remote-verify the evidence URLs during validation
+
+When the only evidence is a blob/issue URL, do a GitHub API existence check.
+
+- **Pro:** provider-agnostic, 100% certain (the artifact really exists).
+- **Con:** adds **network I/O to a currently-pure validation path**, with
+  cold-start cost-gate implications (v0.8.0 measured 0 GitHub calls during
+  cold-start). Would need explicit interaction design with the cost gate +
+  caching/timeout handling.
+
+### (c) Both
+
+Prefer (a)'s verified tool calls; fall back to (b) for subprocess `gh` commits
+that leave no captured tool call. Most thorough, most surface area. Defer (b)
+unless (a) proves insufficient in the soak.
+
+## Implementation sketch (option a)
+
+1. `LLMResponse.verifiedActions?: readonly VerifiedAction[]` + the `VerifiedAction`
+   type in `@murmurations-ai/llm`.
+2. claude adapter: capture `tool_result` (`is_error`, content) alongside each
+   `tool_use`; map confirmed `mcp__github__*` / `gh` operations to
+   `VerifiedAction`s; attach to the response.
+3. Executor/runner: thread `verifiedActions` onto `AgentResult`.
+4. `validateWake` / `isOutputSatisfied`: consult `verifiedActions` first; keep
+   URL-scrape as a lower-precedence fallback (or gate it off under hard-fail).
+5. Tests: adapter capture (tool_use + result, error vs success); validateWake
+   prefers verified evidence; a fabricated URL with no verified action does **not**
+   satisfy under the (future) hard-fail path.
+
+## EP-side prerequisites (tracked in xeeban/emergent-praxis)
+
+- Add `contract:` blocks to the 9 agents without one (only `intelligence-agent`
+  has one today). These are governance authoring tasks, one per agent.
+- Restart the daemon on the verifiedActions release.
+- Run a fresh 14-day warning-only soak; record the behavior-warning instances and
+  adjudicate false-positive vs true-positive on #376.
+
+## The flip (PR 6b) — gated
+
+Only after the soak shows zero false positives **and** all production role.md carry
+`contract:` blocks (ADR-0048 §Decision 2):
+
+- Promote `validateBehavior` + the composite read+network permission check from
+  warning to hard-fail.
+- Resolve #379 (URL fabrication) — satisfied by verifiedActions being primary.
+- Update CHANGELOG + the v0.8.0 "Known limitations" follow-ups.
+
+## Open question for review
+
+Pick the sourcing approach: **(a)** (recommended), **(b)**, or **(c)**. Everything
+downstream (impl sketch, tests, soak) assumes (a) unless changed here.


### PR DESCRIPTION
Scoping doc for the deferred hard-fail train (the v0.8.2 keystone), per the decision to **plan before building**.

Captures:
- **Two workstreams** — harness `verifiedActions` (#364B) + the EP-side soak prerequisites (contract blocks on 9 agents, fresh 14-day soak) + the gated flip — and the hard dependency between them.
- **The design fork** for sourcing `verifiedActions`, grounded in the current adapter + `validateWake` code:
  - **(a)** capture the claude CLI `tool_use`/`tool_result` events — **recommended** (lowest risk, keeps validation pure, fits EP's MCP-bridge path),
  - **(b)** remote-verify evidence URLs (certain but adds network I/O to validation),
  - **(c)** both.
- Implementation sketch (option a), EP prerequisites, and the gated PR-6b flip.

**Open question** at the bottom for review: confirm (a)/(b)/(c) before any implementation. No code change.

Refs #364, #376, #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)