### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-18
+
+**Trustworthy subscription-CLI agent actions, multi-schedule wakes, and daemon reliability.** The headline closes a validation blind spot in two steps: the claude subscription-CLI adapter now runs in `stream-json` mode so an agent's tool calls are actually visible (#430), and the validator consumes those confirmed calls as `verifiedActions` (#364B) — so an agent that posts a comment through its MCP bridge is no longer mistaken for an idle, narrative-only wake. Agents can wake on multiple cron schedules (#420); the daemon serializes the coincident same-agent wakes that multi-schedule made reachable (#435); Spirit recovers from stale resume sessions (#424); and `murmuration list` stops reporting phantom orphan daemons (#422). The toolchain moves to a Node 22 floor and pnpm 11 so npm OIDC Trusted Publishing works end to end.
+
 ### Added
 
 - **`verifiedActions` — confirmed in-subprocess tool calls as validation evidence** ([#364](https://github.com/murmurations-ai/murmurations-harness/issues/364) Part B). Subscription-CLI agents post comments via in-subprocess tool calls (e.g. `create_issue_comment` through the MCP bridge) that never reach `result.actions`, so the validator fell back to scraping forgeable URLs from the wake summary (#369/#379). Now the runner derives `verifiedActions` from the agent's **confirmed** (`ok === true`) tool calls — surfaced by the stream-json adapter (#430) — and the daemon folds them into the evidence `validateWake` sees (as synthetic successful receipts; the validator itself is unchanged). A subscription-CLI agent that comments via a tool call is no longer mistaken for an idle/narrative-only wake. v1 recognizes the issue-comment tool (`create_issue_comment` and common external-MCP aliases); commits already produce real receipts via the `wake_actions` path. New exports: `VerifiedAction`, `deriveVerifiedActions`, `verifiedActionsToReceipts`; new optional `AgentResult.verifiedActions`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurations-harness-monorepo",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Murmuration Harness — coordination and agent runtime layer for human-agent murmurations with pluggable governance. Monorepo root.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Command-line interface for the Murmuration Harness daemon — start, stop, status.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Core runtime for the Murmuration Harness — scheduler, signal aggregator, plugin registry, and executor interface.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/dashboard-tui/package.json
+++ b/packages/dashboard-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/dashboard-tui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Terminal dashboard for the Murmuration Harness — pipeline state, agent activity, governance rounds, cost tracking.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/github",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Typed GitHub REST client for the Murmuration Harness — rate-limited, cache-aware, secret-safe.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/llm",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Provider-agnostic LLM client for the Murmuration Harness — SecretValue auth, per-call cost hook, pluggable ProviderRegistry (ADR-0025).",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP tool loader for the Murmuration Harness — connects to MCP servers and converts tools to LLM-compatible format.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/secrets-dotenv/package.json
+++ b/packages/secrets-dotenv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/secrets-dotenv",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Default SecretsProvider for the Murmuration Harness — reads from a .env file at the murmuration root.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurations-ai/signals",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Default SignalAggregator for the Murmuration Harness — github + filesystem sources with interim trust taxonomy.",
   "license": "MIT",
   "author": "Murmuration Harness Contributors",


### PR DESCRIPTION
Stages **v0.10.0** for sign-off. Bumps root + the 8 published `packages/*` from `0.9.0 → 0.10.0` and cuts the `[0.10.0]` CHANGELOG section.

## What's in v0.10.0

The unreleased set since v0.9.0:

- **`verifiedActions`** — confirmed in-subprocess tool calls as validation evidence (#364B / #434)
- **claude adapter `stream-json`** so tool calls are visible (#430) — the foundation #434 builds on
- **Multiple cron wake schedules per agent** (#420)
- **Daemon serializes coincident same-agent wakes** that multi-schedule made reachable (#435)
- **Spirit recovers from a stale resume session** (#424)
- **`murmuration list` no longer reports phantom orphan daemons** (#422)
- **One-shot wake no longer orphans a co-rooted daemon** (#432)
- **Node 22 floor + pnpm 11.5.3** for OIDC Trusted Publishing

## Why minor (not patch)

The set contains new features (verifiedActions, multi-cron) and a consumer-facing Node 22 floor — either alone rules out a patch. Pre-1.0 minor bump per `RELEASE-POLICY.md`.

## Version-bump scope

Root + `packages/*` (cli, core, dashboard-tui, github, llm, mcp, secrets-dotenv, signals) → `0.10.0`. The example `@murmurations-ai/governance-s3` was **deliberately reverted** to `0.3.4` — it sits on its own version line (npm latest 0.3.4, never bumped across 0.4→0.9) and is not in the published set. Note: `pnpm version --recursive` under pnpm 11 reached into `examples/` even though the workspace is `packages/*` only — worth a follow-up so future releases don't re-bump it.

## Gate

`pnpm check` green locally: build · typecheck (0 errors) · lint (0 errors) · format · **1360 tests**. CI will confirm on this PR.

## ⚠️ Before merging + releasing (operator-only)

- [ ] **Confirm the 8 packages' npmjs Trusted Publisher bindings** (`release.yml` workflow) — the `ENEEDAUTH` gate that forced v0.9.0's manual passkey publish. This is the hard blocker.
- [ ] Source approves the release (`RELEASE-POLICY.md` §When to release).
- [ ] Merge this PR.
- [ ] Tag `main` and push: `git tag v0.10.0 && git push origin v0.10.0` — this triggers `release.yml` (publish + GH release). **Do not tag until the bindings are confirmed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
